### PR TITLE
Add local map operation

### DIFF
--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -78,8 +78,8 @@ class BeamOperations(PipelineOperations):
 class LocalPipelineOperations(PipelineOperations):
   """Local Pipeline adapter."""
   
-  def map(self, col, fn, stage_name: str):
-    pass
+  def map(self, col, fn, stage_name: str = None):
+    return map(fn, col)
 
   def map_tuple(self, col, fn, stage_name: str):
     pass

--- a/tests/pipeline_operations_test.py
+++ b/tests/pipeline_operations_test.py
@@ -1,12 +1,25 @@
 import unittest
 
-import pipeline_dp
+from pipeline_dp.pipeline_operations import LocalPipelineOperations
+
 
 class PipelineOperationsTest(unittest.TestCase):
   pass
 
 class LocalPipelineOperationsTest(unittest.TestCase):
-  pass
+  @classmethod
+  def setUpClass(cls):
+    cls.ops = LocalPipelineOperations()
+
+  def test_local_map(self):
+    some_map = self.ops.map([1,2,3], lambda x: x)
+    # some_map is its own consumable iterator
+    self.assertIs(some_map, iter(some_map))
+
+    self.assertEqual(list(self.ops.map([1,2,3], str)),
+                     ["1", "2", "3"])
+    self.assertEqual(list(self.ops.map(range(5), lambda x: x ** 2)),
+                     [0, 1, 4, 9, 16])
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
## Description
Adds a method for local map operation. See comment about a file change below.

## Affected Dependencies
Nope.

## How has this been tested?
Tests added :test_tube: 
The empty `__init__.py` file has been added because without it pytest (and probably other testing frameworks?) cannot find `pipeline_dp` for importing (Python 3.8.5). I can imagine PyCharm users do not see the issue, but it will be needed for CI.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
