### PR TITLE
Add more local pipeline operations

### DIFF
--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -149,14 +149,14 @@ class SparkRDDOperations(PipelineOperations):
 class LocalPipelineOperations(PipelineOperations):
     """Local Pipeline adapter."""
 
-    def map(self, col, fn, stage_name: str = None):
+    def map(self, col, fn, stage_name: typing.Optional[str] = None):
         return map(fn, col)
 
     def map_tuple(self, col, fn, stage_name: typing.Optional[str] = None):
         return (fn(k, v) for k, v in col)
 
-    def map_values(self, col, fn, stage_name: str):
-        pass
+    def map_values(self, col, fn, stage_name: typing.Optional[str] = None):
+        return ((k, fn(v)) for k, v in col)
 
     def group_by_key(self, col, stage_name: typing.Optional[str] = None):
         def group_by_key_generator():
@@ -167,17 +167,17 @@ class LocalPipelineOperations(PipelineOperations):
                 yield item
         return group_by_key_generator()
 
-    def filter(self, col, fn, stage_name: str):
-        pass
+    def filter(self, col, fn, stage_name: typing.Optional[str] = None):
+        return filter(fn, col)
 
     def keys(self, col, stage_name: str):
         pass
 
-    def values(self, col, stage_name: str):
-        pass
+    def values(self, col, stage_name: typing.Optional[str] = None):
+        return (v for k, v in col)
 
     def sample_fixed_per_key(self, col, n: int, stage_name: str):
         pass
 
-    def count_per_element(self, col, stage_name: str):
-        pass
+    def count_per_element(self, col, stage_name: typing.Optional[str] = None):
+        yield from collections.Counter(col).items()

--- a/tests/pipeline_operations_test.py
+++ b/tests/pipeline_operations_test.py
@@ -46,9 +46,12 @@ class LocalPipelineOperationsTest(unittest.TestCase):
         cls.ops = LocalPipelineOperations()
 
     def test_local_map(self):
-        some_map = self.ops.map([1, 2, 3], lambda x: x)
-        # some_map is its own consumable iterator
-        self.assertIs(some_map, iter(some_map))
+        self.assertEqual(list(self.ops.map([], lambda x: x / 0)),
+                         [])
+
+        some_mapped_list = self.ops.map([1, 2, 3], lambda x: x)
+        # some_mapped_list is its own consumable iterator
+        self.assertIs(some_mapped_list, iter(some_mapped_list))
 
         self.assertEqual(list(self.ops.map([1, 2, 3], str)),
                          ["1", "2", "3"])
@@ -64,6 +67,17 @@ class LocalPipelineOperationsTest(unittest.TestCase):
         self.assertEqual(list(self.ops.map_tuple(tuple_list, lambda k, v: (
             str(k), str(v)))), [("1", "2"), ("2", "3"), ("3", "4")])
 
+    def test_local_map_values(self):
+        self.assertEqual(list(self.ops.map_values([], lambda x: x / 0)),
+                         [])
+
+        tuple_list = [(1, 2), (2, 3), (3, 4)]
+
+        self.assertEqual(list(self.ops.map_values(tuple_list, str)),
+                         [(1, "2"), (2, "3"), (3, "4")])
+        self.assertEqual(list(self.ops.map_values(tuple_list, lambda x: x**2)),
+                         [(1, 4), (2, 9), (3, 16)])
+
     def test_local_group_by_key(self):
         some_dict = [("cheese", "brie"), ("bread", "sourdough"),
                      ("cheese", "swiss")]
@@ -71,6 +85,37 @@ class LocalPipelineOperationsTest(unittest.TestCase):
         self.assertEqual(list(self.ops.group_by_key(some_dict)), [
                          ("cheese", ["brie", "swiss"]),
                          ("bread", ["sourdough"])])
+
+    def test_local_filter(self):
+        self.assertEqual(list(self.ops.filter([], lambda x: True)),
+                         [])
+        self.assertEqual(list(self.ops.filter([], lambda x: False)),
+                         [])
+
+        example_list = [1, 2, 2, 3, 3, 4, 2]
+
+        self.assertEqual(list(self.ops.filter(example_list, lambda x: x % 2)),
+                         [1, 3, 3])
+        self.assertEqual(list(self.ops.filter(example_list, lambda x: x < 3)),
+                         [1, 2, 2, 2])
+
+    def test_local_values(self):
+        self.assertEqual(list(self.ops.values([])),
+                         [])
+
+        example_list = [(1, 2), (2, 3), (3, 4), (4, 8)]
+
+        self.assertEqual(list(self.ops.values(example_list)),
+                         [2, 3, 4, 8])
+
+    def test_local_count_per_element(self):
+        example_list = [1, 2, 3, 4, 5, 6, 1, 4, 0, 1]
+        result = self.ops.count_per_element(example_list)
+        # result is its own consumable iterator
+        self.assertIs(result, iter(result))
+
+        self.assertEqual(dict(result),
+                         {1: 3, 2: 1, 3: 1, 4: 2, 5: 1, 6: 1, 0: 1})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Adds every other remaining method to `LocalPipelineOperations` (we split work with Zachery).

## Affected Dependencies
None.

## How has this been tested?
Unit tests added :broom:

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
