### PR TITLE
Add explain plan to dp_engine and test

### DIFF
--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -46,19 +46,6 @@ class DPEngine:
     if params is None:
       return None
     self._report_generators.append(ReportGenerator(params))
-    self._add_report_stage(f"Clip values to {params.low, params.high}")
-    self._add_report_stage(
-      f"Per-partition contribution: randomly selected not "
-      f"more than {params.max_partitions_contributed} contributions")
-    self._add_report_stage(
-      f"Cross partition contribution bounding: randomly selected not"
-      f"more than {params.max_contributions_per_partition} partitions per"
-      " user")
-    if params.public_partitions is None:
-      self._add_report_stage("Partitions selection: using thresholding")
-    else:
-      self._add_report_stage(
-        "Partitions selection: using provided public partition")
     # TODO: implement aggregate().
     # It returns input for now, just to ensure that the an example works.
     return col

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -29,8 +29,6 @@ class DPEngineTest(unittest.TestCase):
     engine.aggregate(None, params1, None)
     engine.aggregate(None, params2, None)
     self.assertEqual(len(engine._report_generators), 2)  # pylint: disable=protected-access
-    self.assertIn("['p', 'c', 'm']", engine._report_generators[0].report())  # pylint: disable=protected-access
-    self.assertIn("['v', 's', 'm']", engine._report_generators[1].report())  # pylint: disable=protected-access
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -1,10 +1,36 @@
+"""DPEngine Test"""
+
 import unittest
 
-import pipeline_dp
+from pipeline_dp.aggregate_params import AggregateParams, Metrics
+from pipeline_dp.dp_engine import DPEngine
 
 class DPEngineTest(unittest.TestCase):
-  pass
+  def test_aggregate_none(self):
+    self.assertIsNone(DPEngine(None, None).aggregate(None, None, None))
 
+  def test_aggregate_report(self):
+    params1 = AggregateParams(
+      max_partitions_contributed=3,
+      max_contributions_per_partition=2,
+      low=1,
+      high=5,
+      metrics=[Metrics.PRIVACY_ID_COUNT, Metrics.COUNT, Metrics.MEAN],
+    )
+    params2 = AggregateParams(
+      max_partitions_contributed=1,
+      max_contributions_per_partition=3,
+      low=2,
+      high=10,
+      metrics=[Metrics.VAR, Metrics.SUM, Metrics.MEAN],
+      public_partitions = list(range(1,40)),
+    )
+    engine = DPEngine(None, None)
+    engine.aggregate(None, params1, None)
+    engine.aggregate(None, params2, None)
+    self.assertEqual(len(engine._report_generators), 2)  # pylint: disable=protected-access
+    self.assertIn("['p', 'c', 'm']", engine._report_generators[0].report())  # pylint: disable=protected-access
+    self.assertIn("['v', 's', 'm']", engine._report_generators[1].report())  # pylint: disable=protected-access
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
## Description

- This PR changes `DPEngine` to use the `ReportGenerator` which constructs the explain plan for issue #10.

## Affected Dependencies
Part of #10 

## How has this been tested?
- `dp_engine_test` adds two reports and checks that they are valid
- Tested with `conda` environment under `Python 3.8`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests