### PR TITLE
Contribution Bounding - per partition and cross partition bounding - continued from #26 pull request

### DIFF
--- a/pipeline_dp/__init__.py
+++ b/pipeline_dp/__init__.py
@@ -3,5 +3,6 @@ from pipeline_dp.aggregate_params import AggregateParams
 from pipeline_dp.aggregate_params import Metrics
 from pipeline_dp.dp_engine import DataExtractors
 from pipeline_dp.dp_engine import DPEngine
+from pipeline_dp.pipeline_operations import LocalPipelineOperations
 from pipeline_dp.pipeline_operations import BeamOperations
 from pipeline_dp.pipeline_operations import SparkRDDOperations

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -88,18 +88,11 @@ class DPEngine:
     col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
                                          "Sample per privacy_id")
     # (privacy_id, [(partition_key, aggregator)])
+
+    def unnest_cross_partition_bound_sampled_per_key(pid_pk_v):
+      pid, pk_values = pid_pk_v
+      return (((pid, pk), v) for (pk, v) in pk_values)
+
     return self._ops.flat_map(col,
-                              self._unnest_cross_partition_bound_sampled_per_key,
+                              unnest_cross_partition_bound_sampled_per_key,
                               "Unnest")
-
-  def _unnest_cross_partition_bound_sampled_per_key(self, pid):
-    """
-    Unnests the cross partition sampled result per key.
-    Args:
-      pid: tuple of the form (privacy_id, [(partition_key, values)])
-
-    Returns: tuple of the form ((privacy_id, partition_key), values)
-
-    """
-    for pk_v in pid[1]:
-      yield (pid[0], pk_v[0]), pk_v[1]

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -68,15 +68,19 @@ class DPEngine:
     col = self._ops.sample_fixed_per_key(col,
                                          max_contributions_per_partition,
                                          "Sample per (privacy_id, partition_key)")
+    # ((privacy_id, partition_key), [value])
     col = self._ops.map(col, lambda pid_pk: (pid_pk[0], aggregator_fn(
       pid_pk[1])), "Apply aggregate_fn after per partition bounding")
+    # ((privacy_id, partition_key), aggregator)
 
     # Cross partition bounding
     col = self._ops.map_tuple(col, lambda pid_pk, v: (pid_pk[0],
                                                       (pid_pk[1], v)),
-                              "To (privacy_id, (partition_key, vector))")
+                              "To (privacy_id, (partition_key, aggregator))")
     col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
                                          "Sample per privacy_id")
+    # (privacy_id, [partition_key, aggregator])
     return self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]), pk_v[1])
                                                 for pk_v in pid[1]],
                               "Unnest")
+

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -44,8 +44,10 @@ class DPEngine:
         # It returns input for now, just to ensure that the an example works.
         return col
 
-    def _bound_cross_partition_contributions(self, col, max_partitions_contributed: int,
-                                             max_contributions_per_partition: int, aggregator_fn):
+    def _bound_cross_partition_contributions(self, col,
+                                             max_partitions_contributed: int,
+                                             max_contributions_per_partition: int,
+                                             aggregator_fn):
         """
         Binds the contribution by privacy_id within and across partitions
         Args:
@@ -61,7 +63,8 @@ class DPEngine:
         col = self._ops.map_tuple(col, lambda privacy_id, partition_key, v:
         ((privacy_id, partition_key), v),
                                   "To (privacy_id, partition_key), value))")
-        col = self._ops.sample_fixed_per_key(col, max_contributions_per_partition,
+        col = self._ops.sample_fixed_per_key(col,
+                                             max_contributions_per_partition,
                                              "Sample per (privacy_id, partition_key)")
 
         # Cross partition bounding
@@ -72,4 +75,5 @@ class DPEngine:
                                              "Sample per privacy_id")
         return self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]),
                                                      aggregator_fn(pk_v[1]))
-                                                    for pk_v in pid[1]], "Unnest")
+                                                    for pk_v in pid[1]],
+                                  "Unnest")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -7,66 +7,69 @@ from pipeline_dp.aggregate_params import AggregateParams
 from pipeline_dp.budget_accounting import BudgetAccountant
 from pipeline_dp.pipeline_operations import PipelineOperations
 
+
 @dataclass
 class DataExtractors:
-  """Data extractors
+    """Data extractors
 
-  A set of functions that, given an input, return the privacy id, partition key,
-  and value.
-  """
+    A set of functions that, given an input, return the privacy id, partition key,
+    and value.
+    """
 
-  privacy_id_extractor: Callable = None
-  partition_extractor: Callable = None
-  value_extractor: Callable = None
+    privacy_id_extractor: Callable = None
+    partition_extractor: Callable = None
+    value_extractor: Callable = None
 
 
 class DPEngine:
-  """Performs DP aggregations."""
+    """Performs DP aggregations."""
 
-  def __init__(self, budget_accountant: BudgetAccountant,
-               ops: PipelineOperations):
-    self._budget_accountant = budget_accountant
-    self._ops = ops
+    def __init__(self, budget_accountant: BudgetAccountant,
+                 ops: PipelineOperations):
+        self._budget_accountant = budget_accountant
+        self._ops = ops
 
-  def aggregate(self, col, params: AggregateParams,
-                data_extractors: DataExtractors):
-    """Computes DP aggregation metrics
+    def aggregate(self, col, params: AggregateParams,
+                  data_extractors: DataExtractors):
+        """Computes DP aggregation metrics
 
-    Args:
-      col: collection with elements of the same type.
-      params: specifies which metrics to compute and computation parameters.
-      data_extractors: functions that extract needed pieces of information from
-        elements of 'col'
-    """
+        Args:
+          col: collection with elements of the same type.
+          params: specifies which metrics to compute and computation parameters.
+          data_extractors: functions that extract needed pieces of information from
+            elements of 'col'
+        """
 
-    # TODO: implement aggregate().
-    # It returns input for now, just to ensure that the an example works.
-    return col
+        # TODO: implement aggregate().
+        # It returns input for now, just to ensure that the an example works.
+        return col
 
-  def _bound_cross_partition_contributions(self, col, max_partitions_contributed: int, max_contributions_per_partition: int, aggregator_fn):
-    """
-    Binds the contribution by privacy_id within and across partitions
-    Args:
-      col:collection, with types of each element: (privacy_id, partition_key, value)
-      max_partitions_contributed
-      max_contributions_per_partition
-      aggregator_fn: function that takes a list of values and returns an aggregator object which handles all aggregation logic.
+    def _bound_cross_partition_contributions(self, col, max_partitions_contributed: int,
+                                             max_contributions_per_partition: int, aggregator_fn):
+        """
+        Binds the contribution by privacy_id within and across partitions
+        Args:
+          col:collection, with types of each element: (privacy_id, partition_key, value)
+          max_partitions_contributed
+          max_contributions_per_partition
+          aggregator_fn: function that takes a list of values and returns an aggregator object
+                        which handles all aggregation logic.
 
-    output:((privacy_id, parition_key), aggregator)
-    """
-    #  per partition-contribution bounding with bounding of each contribution
-    col = self._ops.map_tuple(col, lambda privacy_id, partition_key, v:
-                                        ((privacy_id, partition_key), v),
-                              "To (privacy_id, partition_key), value))")
-    col = self._ops.sample_fixed_per_key(col, max_contributions_per_partition,
-                                      "Sample per (privacy_id, partition_key)")
+        output:((privacy_id, parition_key), aggregator)
+        """
+        #  per partition-contribution bounding with bounding of each contribution
+        col = self._ops.map_tuple(col, lambda privacy_id, partition_key, v:
+        ((privacy_id, partition_key), v),
+                                  "To (privacy_id, partition_key), value))")
+        col = self._ops.sample_fixed_per_key(col, max_contributions_per_partition,
+                                             "Sample per (privacy_id, partition_key)")
 
-    # Cross partition bounding
-    col = self._ops.map_tuple(col, lambda pid_pk, v: (pid_pk[0],
-                                                      (pid_pk[1], v)),
-                              "To (privacy_id, (partition_key, vector))")
-    col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
-                                      "Sample per privacy_id")
-    return self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]),
-                                                  aggregator_fn(pk_v[1]))
-                                                 for pk_v in pid[1]], "Unnest")
+        # Cross partition bounding
+        col = self._ops.map_tuple(col, lambda pid_pk, v: (pid_pk[0],
+                                                          (pid_pk[1], v)),
+                                  "To (privacy_id, (partition_key, vector))")
+        col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
+                                             "Sample per privacy_id")
+        return self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]),
+                                                     aggregator_fn(pk_v[1]))
+                                                    for pk_v in pid[1]], "Unnest")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -90,6 +90,8 @@ class DPEngine:
     # (privacy_id, [(partition_key, aggregator)])
 
     def unnest_cross_partition_bound_sampled_per_key(pid_pk_v):
+      # unnest from (privacy_id, [(partition_key, values)])
+      # to ((privacy_id, partition_key), values)
       pid, pk_values = pid_pk_v
       return (((pid, pk), v) for (pk, v) in pk_values)
 

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -49,17 +49,21 @@ class DPEngine:
                                              max_contributions_per_partition: int,
                                              aggregator_fn):
         """
-        Binds the contribution by privacy_id within and across partitions
+        Bounds the contribution by privacy_id in and cross partitions
         Args:
-          col:collection, with types of each element: (privacy_id, partition_key, value)
-          max_partitions_contributed
-          max_contributions_per_partition
-          aggregator_fn: function that takes a list of values and returns an aggregator object
-                        which handles all aggregation logic.
+          col: collection, with types of each element: (privacy_id,
+            partition_key, value)
+          max_partitions_contributed: maximum number of partitions that one
+            privacy id can contribute to
+          max_contributions_per_partition: maximum number of records that one
+            privacy id can contribute to one partition
+          aggregator_fn: function that takes a list of values and returns an
+            aggregator object which handles all aggregation logic.
 
-        output:((privacy_id, parition_key), aggregator)
+        return: collection with elements ((privacy_id, partition_key),
+              aggregator)
         """
-        #  per partition-contribution bounding with bounding of each contribution
+        # per partition-contribution bounding with bounding of each contribution
         col = self._ops.map_tuple(col, lambda privacy_id, partition_key, v:
         ((privacy_id, partition_key), v),
                                   "To (privacy_id, partition_key), value))")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -90,8 +90,6 @@ class DPEngine:
     # (privacy_id, [(partition_key, aggregator)])
 
     def unnest_cross_partition_bound_sampled_per_key(pid_pk_v):
-      # unnest from (privacy_id, [(partition_key, values)])
-      # to ((privacy_id, partition_key), values)
       pid, pk_values = pid_pk_v
       return (((pid, pk), v) for (pk, v) in pk_values)
 

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -64,4 +64,6 @@ class DPEngine:
                               "To (privacy_id, (partition_key, vector))")
     col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
                                       "Sample per privacy_id")
-    return self._ops.flat_map(col, lambda pid: [((pid[0],pk_v[0]), aggregator_fn(pk_v[1])) for pk_v in pid[1]], "Unnest")
+    return self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]),
+                                                  aggregator_fn(pk_v[1])) 
+                                                 for pk_v in pid[1]], "Unnest")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -45,8 +45,11 @@ class DPEngine:
 
   def _bound_cross_partition_contributions(self, col, max_partitions_contributed: int, max_contributions_per_partition: int, aggregator_fn):
     """
+    Binds the contribution by privacy_id within and across partitions
     Args:
       col:collection, with types of each element: (privacy_id, partition_key, value)
+      max_partitions_contributed
+      max_contributions_per_partition
       aggregator_fn: function that takes a list of values and returns an aggregator object which handles all aggregation logic.
 
     output:((privacy_id, parition_key), aggregator)
@@ -65,5 +68,5 @@ class DPEngine:
     col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
                                       "Sample per privacy_id")
     return self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]),
-                                                  aggregator_fn(pk_v[1])) 
+                                                  aggregator_fn(pk_v[1]))
                                                  for pk_v in pid[1]], "Unnest")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -86,7 +86,7 @@ class DPEngine:
                               "To (privacy_id, (partition_key, aggregator))")
     col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
                                          "Sample per privacy_id")
-    # (privacy_id, [partition_key, aggregator])
+    # (privacy_id, [(partition_key, aggregator)])
     return self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]), pk_v[1])
                                                 for pk_v in pid[1]],
                               "Unnest")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -68,6 +68,8 @@ class DPEngine:
     col = self._ops.sample_fixed_per_key(col,
                                          max_contributions_per_partition,
                                          "Sample per (privacy_id, partition_key)")
+    col = self._ops.map(col, lambda pid_pk: (pid_pk[0], aggregator_fn(
+      pid_pk[1])), "Apply aggregate_fn after per partition bounding")
 
     # Cross partition bounding
     col = self._ops.map_tuple(col, lambda pid_pk, v: (pid_pk[0],
@@ -75,8 +77,6 @@ class DPEngine:
                               "To (privacy_id, (partition_key, vector))")
     col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
                                          "Sample per privacy_id")
-    col = self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]), pk_v[1])
-                                               for pk_v in pid[1]],
-                             "Unnest")
-    return self._ops.map(col, lambda pid_pk: (pid_pk[0], aggregator_fn(
-      pid_pk[1])), "Apply aggregate_fn")
+    return self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]), pk_v[1])
+                                                for pk_v in pid[1]],
+                              "Unnest")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -10,74 +10,73 @@ from pipeline_dp.pipeline_operations import PipelineOperations
 
 @dataclass
 class DataExtractors:
-    """Data extractors
+  """Data extractors
+  A set of functions that, given an input, return the privacy id, partition key,
+  and value.
+  """
 
-    A set of functions that, given an input, return the privacy id, partition key,
-    and value.
-    """
-
-    privacy_id_extractor: Callable = None
-    partition_extractor: Callable = None
-    value_extractor: Callable = None
+  privacy_id_extractor: Callable = None
+  partition_extractor: Callable = None
+  value_extractor: Callable = None
 
 
 class DPEngine:
-    """Performs DP aggregations."""
+  """Performs DP aggregations."""
 
-    def __init__(self, budget_accountant: BudgetAccountant,
-                 ops: PipelineOperations):
-        self._budget_accountant = budget_accountant
-        self._ops = ops
+  def __init__(self, budget_accountant: BudgetAccountant,
+               ops: PipelineOperations):
+    self._budget_accountant = budget_accountant
+    self._ops = ops
 
-    def aggregate(self, col, params: AggregateParams,
-                  data_extractors: DataExtractors):
-        """Computes DP aggregation metrics
+  def aggregate(self, col, params: AggregateParams,
+                data_extractors: DataExtractors):
+    """Computes DP aggregation metrics
 
-        Args:
-          col: collection with elements of the same type.
-          params: specifies which metrics to compute and computation parameters.
-          data_extractors: functions that extract needed pieces of information from
-            elements of 'col'
-        """
+    Args:
+      col: collection with elements of the same type.
+      params: specifies which metrics to compute and computation parameters.
+      data_extractors: functions that extract needed pieces of information from
+        elements of 'col'
+    """
 
-        # TODO: implement aggregate().
-        # It returns input for now, just to ensure that the an example works.
-        return col
+    # TODO: implement aggregate().
+    # It returns input for now, just to ensure that the an example works.
+    return col
 
-    def _bound_cross_partition_contributions(self, col,
-                                             max_partitions_contributed: int,
-                                             max_contributions_per_partition: int,
-                                             aggregator_fn):
-        """
-        Bounds the contribution by privacy_id in and cross partitions
-        Args:
-          col: collection, with types of each element: (privacy_id,
-            partition_key, value)
-          max_partitions_contributed: maximum number of partitions that one
-            privacy id can contribute to
-          max_contributions_per_partition: maximum number of records that one
-            privacy id can contribute to one partition
-          aggregator_fn: function that takes a list of values and returns an
-            aggregator object which handles all aggregation logic.
+  def _bound_cross_partition_contributions(self, col,
+                                           max_partitions_contributed: int,
+                                           max_contributions_per_partition: int,
+                                           aggregator_fn):
+    """
+    Bounds the contribution by privacy_id in and cross partitions
+    Args:
+      col: collection, with types of each element: (privacy_id,
+        partition_key, value)
+      max_partitions_contributed: maximum number of partitions that one
+        privacy id can contribute to
+      max_contributions_per_partition: maximum number of records that one
+        privacy id can contribute to one partition
+      aggregator_fn: function that takes a list of values and returns an
+        aggregator object which handles all aggregation logic.
 
-        return: collection with elements ((privacy_id, partition_key),
-              aggregator)
-        """
-        # per partition-contribution bounding with bounding of each contribution
-        col = self._ops.map_tuple(col, lambda pid, pk, v: ((pid, pk), v),
-                                  "To (privacy_id, partition_key), value))")
-        col = self._ops.sample_fixed_per_key(col,
-                                             max_contributions_per_partition,
-                                             "Sample per (privacy_id, partition_key)")
+    return: collection with elements ((privacy_id, partition_key),
+          aggregator)
+    """
+    # per partition-contribution bounding with bounding of each contribution
+    col = self._ops.map_tuple(col, lambda pid, pk, v: ((pid, pk), v),
+                              "To (privacy_id, partition_key), value))")
+    col = self._ops.sample_fixed_per_key(col,
+                                         max_contributions_per_partition,
+                                         "Sample per (privacy_id, partition_key)")
 
-        # Cross partition bounding
-        col = self._ops.map_tuple(col, lambda pid_pk, v: (pid_pk[0],
-                                                          (pid_pk[1], v)),
-                                  "To (privacy_id, (partition_key, vector))")
-        col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
-                                             "Sample per privacy_id")
-        col = self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]), pk_v[1])
-                                                   for pk_v in pid[1]],
-                                 "Unnest")
-        return self._ops.map(col, lambda pid_pk: (pid_pk[0], aggregator_fn(
-            pid_pk[1])), "Apply aggregate_fn")
+    # Cross partition bounding
+    col = self._ops.map_tuple(col, lambda pid_pk, v: (pid_pk[0],
+                                                      (pid_pk[1], v)),
+                              "To (privacy_id, (partition_key, vector))")
+    col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
+                                         "Sample per privacy_id")
+    col = self._ops.flat_map(col, lambda pid: [((pid[0], pk_v[0]), pk_v[1])
+                                               for pk_v in pid[1]],
+                             "Unnest")
+    return self._ops.map(col, lambda pid_pk: (pid_pk[0], aggregator_fn(
+      pid_pk[1])), "Apply aggregate_fn")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -42,3 +42,26 @@ class DPEngine:
     # TODO: implement aggregate().
     # It returns input for now, just to ensure that the an example works.
     return col
+
+  def _bound_cross_partition_contributions(self, col, max_partitions_contributed: int, max_contributions_per_partition: int, aggregator_fn):
+    """
+    Args:
+      col:collection, with types of each element: (privacy_id, partition_key, value)
+      aggregator_fn: function that takes a list of values and returns an aggregator object which handles all aggregation logic.
+
+    output:((privacy_id, parition_key), aggregator)
+    """
+    #  per partition-contribution bounding with bounding of each contribution
+    col = self._ops.map_tuple(col, lambda privacy_id, partition_key, v:
+                                        ((privacy_id, partition_key), v),
+                              "To (privacy_id, partition_key), value))")
+    col = self._ops.sample_fixed_per_key(col, max_contributions_per_partition,
+                                      "Sample per (privacy_id, partition_key)")
+
+    # Cross partition bounding
+    col = self._ops.map_tuple(col, lambda pid_pk, v: (pid_pk[0],
+                                                      (pid_pk[1], v)),
+                              "To (privacy_id, (partition_key, vector))")
+    col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
+                                      "Sample per privacy_id")
+    return self._ops.flat_map(col, lambda pid: [((pid[0],pk_v[0]), aggregator_fn(pk_v[1])) for pk_v in pid[1]], "Unnest")

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -183,8 +183,8 @@ class LocalPipelineOperations(PipelineOperations):
     def sample_fixed_per_key(self, col, n: int, stage_name: str):
         # TODO: replace to group_by_key
         d = collections.defaultdict(lambda: [])
-        for key, v in col:
-            d[key].append(v)
+        for key, value in col:
+            d[key].append(value)
 
         result = []
         for key, values in d.items():
@@ -192,7 +192,7 @@ class LocalPipelineOperations(PipelineOperations):
                 result.append((key, values))
                 continue
             sampled_indices = np.random.choice(range(len(values)), n,
-                                           replace=False)
+                                               replace=False)
             sampled_values = [values[i] for i in sampled_indices]
             result.append((key, sampled_values))
         return result

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -63,7 +63,7 @@ class BeamOperations(PipelineOperations):
         return col | stage_name >> beam.FlatMap(fn)
 
     def map_tuple(self, col, fn, stage_name: str):
-        return col | stage_name >> beam.MapTuple(fn)
+        return col | stage_name >> beam.Map(lambda x: fn(*x))
 
     def map_values(self, col, fn, stage_name: str):
         return col | stage_name >> beam.MapTuple(lambda k, v: (k, fn(v)))

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -207,3 +207,4 @@ class LocalPipelineOperations(PipelineOperations):
 
     def count_per_element(self, col, stage_name: str):
         pass
+    

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -105,6 +105,9 @@ class SparkRDDOperations(PipelineOperations):
     def map(self, rdd, fn, stage_name: str = None):
         return rdd.map(fn)
 
+    def flat_map(self, rdd, fn, stage_name: str = None):
+        return rdd.flatMap(fn)
+
     def map_tuple(self, rdd, fn, stage_name: str = None):
         return rdd.map(fn)
 
@@ -161,7 +164,7 @@ class LocalPipelineOperations(PipelineOperations):
     def map(self, col, fn, stage_name: typing.Optional[str] = None):
         return map(fn, col)
 
-    def flat_map(self, col, fn, stage_name: str):
+    def flat_map(self, col, fn, stage_name: str = None):
         return (x for el in col for x in fn(el))
 
     def map_tuple(self, col, fn, stage_name: str = None):

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -188,20 +188,17 @@ class LocalPipelineOperations(PipelineOperations):
     def values(self, col, stage_name: typing.Optional[str] = None):
         return (v for k, v in col)
 
-    def sample_fixed_per_key(self, col, n: int, stage_name: str):
-        # TODO: replace to group_by_key
+    def sample_fixed_per_key(self, col, n: int,
+                             stage_name: typing.Optional[str] = None):
         def sample_fixed_per_key_generator():
-            d = collections.defaultdict(list)
-            for key, value in col:
-                d[key].append(value)
-            for item in d.items():
+            for item in self.group_by_key(col):
                 key = item[0]
                 values = item[1]
-                if len(item[1]) > n:
-                    sampled_indices = np.random.choice(range(len(item[1])), n,
+                if len(values) > n:
+                    sampled_indices = np.random.choice(range(len(values)), n,
                                                        replace=False)
                     values = [values[i] for i in sampled_indices]
-                yield item[0], values
+                yield key, values
 
         return sample_fixed_per_key_generator()
 

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -10,193 +10,192 @@ import apache_beam.transforms.combiners as combiners
 
 
 class PipelineOperations(abc.ABC):
-  """Interface for pipeline frameworks adapters."""
+    """Interface for pipeline frameworks adapters."""
 
-  @abc.abstractmethod
-  def map(self, col, fn, stage_name: str):
-    pass
+    @abc.abstractmethod
+    def map(self, col, fn, stage_name: str):
+        pass
 
-  @abc.abstractmethod
-  def flat_map(self, col, fn, stage_name: str):
-    pass
+    @abc.abstractmethod
+    def flat_map(self, col, fn, stage_name: str):
+        pass
 
-  @abc.abstractmethod
-  def map_tuple(self, col, fn, stage_name: str):
-    pass
+    @abc.abstractmethod
+    def map_tuple(self, col, fn, stage_name: str):
+        pass
 
-  @abc.abstractmethod
-  def map_values(self, col, fn, stage_name: str):
-    pass
+    @abc.abstractmethod
+    def map_values(self, col, fn, stage_name: str):
+        pass
 
-  @abc.abstractmethod
-  def group_by_key(self, col, stage_name: str):
-    pass
+    @abc.abstractmethod
+    def group_by_key(self, col, stage_name: str):
+        pass
 
-  @abc.abstractmethod
-  def filter(self, col, fn, stage_name: str):
-    pass
+    @abc.abstractmethod
+    def filter(self, col, fn, stage_name: str):
+        pass
 
-  @abc.abstractmethod
-  def keys(self, col, stage_name: str):
-    pass
+    @abc.abstractmethod
+    def keys(self, col, stage_name: str):
+        pass
 
-  @abc.abstractmethod
-  def values(self, col, stage_name: str):
-    pass
+    @abc.abstractmethod
+    def values(self, col, stage_name: str):
+        pass
 
-  @abc.abstractmethod
-  def sample_fixed_per_key(self, col, n: int, stage_name: str):
-    pass
+    @abc.abstractmethod
+    def sample_fixed_per_key(self, col, n: int, stage_name: str):
+        pass
 
-  @abc.abstractmethod
-  def count_per_element(self, col, stage_name: str):
-    pass
+    @abc.abstractmethod
+    def count_per_element(self, col, stage_name: str):
+        pass
 
 
 class BeamOperations(PipelineOperations):
-  """Apache Beam adapter."""
+    """Apache Beam adapter."""
 
-  def map(self, col, fn, stage_name: str):
-    return col | stage_name >> beam.Map(fn)
+    def map(self, col, fn, stage_name: str):
+        return col | stage_name >> beam.Map(fn)
 
-  def flat_map(self, col, fn, stage_name: str):
-    return col | stage_name >> beam.FlatMap(fn)
+    def flat_map(self, col, fn, stage_name: str):
+        return col | stage_name >> beam.FlatMap(fn)
 
-  def map_tuple(self, col, fn, stage_name: str):
-    return col | stage_name >> beam.Map(lambda x: fn(*x))
+    def map_tuple(self, col, fn, stage_name: str):
+        return col | stage_name >> beam.Map(lambda x: fn(*x))
 
-  def map_values(self, col, fn, stage_name: str):
-    return col | stage_name >> beam.MapTuple(lambda k, v: (k, fn(v)))
+    def map_values(self, col, fn, stage_name: str):
+        return col | stage_name >> beam.MapTuple(lambda k, v: (k, fn(v)))
 
-  def group_by_key(self, col, stage_name: str):
-    """Group the values for each key in the PCollection into a single sequence.
+    def group_by_key(self, col, stage_name: str):
+        """Group the values for each key in the PCollection into a single sequence.
 
-    Args:
-      col: input collection
-      stage_name: name of the stage
+        Args:
+          col: input collection
+          stage_name: name of the stage
 
-    Returns:
-      An PCollection of tuples in which the type of the second item is list.
+        Returns:
+          An PCollection of tuples in which the type of the second item is list.
 
-    """
-    return col | stage_name >> beam.GroupByKey()
+        """
+        return col | stage_name >> beam.GroupByKey()
 
-  def filter(self, col, fn, stage_name: str):
-    return col | stage_name >> beam.Filter(fn)
+    def filter(self, col, fn, stage_name: str):
+        return col | stage_name >> beam.Filter(fn)
 
-  def keys(self, col, stage_name: str):
-    return col | stage_name >> beam.Keys()
+    def keys(self, col, stage_name: str):
+        return col | stage_name >> beam.Keys()
 
-  def values(self, col, stage_name: str):
-    return col | stage_name >> beam.Values()
+    def values(self, col, stage_name: str):
+        return col | stage_name >> beam.Values()
 
-  def sample_fixed_per_key(self, col, n: int, stage_name: str):
-    return col | stage_name >> combiners.Sample.FixedSizePerKey(n)
+    def sample_fixed_per_key(self, col, n: int, stage_name: str):
+        return col | stage_name >> combiners.Sample.FixedSizePerKey(n)
 
-  def count_per_element(self, col, stage_name: str):
-    return col | stage_name >> combiners.Count.PerElement()
+    def count_per_element(self, col, stage_name: str):
+        return col | stage_name >> combiners.Count.PerElement()
 
 
 class SparkRDDOperations(PipelineOperations):
-  """Apache Spark RDD adapter."""
+    """Apache Spark RDD adapter."""
 
-  def map(self, rdd, fn, stage_name: str = None):
-    return rdd.map(fn)
+    def map(self, rdd, fn, stage_name: str = None):
+        return rdd.map(fn)
 
-  def map_tuple(self, rdd, fn, stage_name: str = None):
-    return rdd.map(fn)
+    def map_tuple(self, rdd, fn, stage_name: str = None):
+        return rdd.map(fn)
 
-  def map_values(self, rdd, fn, stage_name: str = None):
-    return rdd.mapValues(fn)
+    def map_values(self, rdd, fn, stage_name: str = None):
+        return rdd.mapValues(fn)
 
-  def group_by_key(self, rdd, stage_name: str = None):
-    """Group the values for each key in the RDD into a single sequence.
+    def group_by_key(self, rdd, stage_name: str = None):
+        """Group the values for each key in the RDD into a single sequence.
 
-    Args:
-      rdd: input RDD
-      stage_name: not used
+        Args:
+          rdd: input RDD
+          stage_name: not used
 
-    Returns:
-      An RDD of tuples in which the type of the second item
-      is the pyspark.resultiterable.ResultIterable.
+        Returns:
+          An RDD of tuples in which the type of the second item
+          is the pyspark.resultiterable.ResultIterable.
 
-    """
-    return rdd.groupByKey()
+        """
+        return rdd.groupByKey()
 
-  def filter(self, rdd, fn, stage_name: str = None):
-    return rdd.filter(fn)
+    def filter(self, rdd, fn, stage_name: str = None):
+        return rdd.filter(fn)
 
-  def keys(self, rdd, stage_name: str = None):
-    return rdd.keys()
+    def keys(self, rdd, stage_name: str = None):
+        return rdd.keys()
 
-  def values(self, rdd, stage_name: str = None):
-    return rdd.values()
+    def values(self, rdd, stage_name: str = None):
+        return rdd.values()
 
-  def sample_fixed_per_key(self, rdd, n: int, stage_name: str = None):
-    """Get fixed-size random samples for each unique key in an RDD of key-values.
-    Sampling is not guaranteed to be uniform across partitions.
+    def sample_fixed_per_key(self, rdd, n: int, stage_name: str = None):
+        """Get fixed-size random samples for each unique key in an RDD of key-values.
+        Sampling is not guaranteed to be uniform across partitions.
 
-    Args:
-      rdd: input RDD
-      n: number of values to sample for each key
-      stage_name: not used
+        Args:
+          rdd: input RDD
+          n: number of values to sample for each key
+          stage_name: not used
 
-    Returns:
-      An RDD of tuples.
+        Returns:
+          An RDD of tuples.
 
-    """
-    return rdd.mapValues(lambda x: [x]) \
-      .reduceByKey(
-      lambda x, y: random.sample(x + y, min(len(x) + len(y), n)))
+        """
+        return rdd.mapValues(lambda x: [x])\
+            .reduceByKey(lambda x, y: random.sample(x+y, min(len(x)+len(y), n)))
 
-  def count_per_element(self, rdd, stage_name: str = None):
-    return rdd.map(lambda x: (x, 1)) \
-      .reduceByKey(lambda x, y: (x + y))
+    def count_per_element(self, rdd, stage_name: str = None):
+        return rdd.map(lambda x: (x, 1))\
+            .reduceByKey(lambda x, y: (x + y))
 
 
 class LocalPipelineOperations(PipelineOperations):
-  """Local Pipeline adapter."""
+    """Local Pipeline adapter."""
 
-  def map(self, col, fn, stage_name: str = None):
-    return map(fn, col)
+    def map(self, col, fn, stage_name: str = None):
+        return map(fn, col)
 
-  def flat_map(self, col, fn, stage_name: str):
-    return (x for el in col for x in fn(el))
+    def flat_map(self, col, fn, stage_name: str):
+        return (x for el in col for x in fn(el))
 
-  def map_tuple(self, col, fn, stage_name: str = None):
-    return map(lambda x: fn(*x), col)
+    def map_tuple(self, col, fn, stage_name: str = None):
+        return map(lambda x: fn(*x), col)
 
-  def map_values(self, col, fn, stage_name: str):
-    pass
+    def map_values(self, col, fn, stage_name: str):
+        pass
 
-  def group_by_key(self, col, stage_name: str):
-    pass
+    def group_by_key(self, col, stage_name: str):
+        pass
 
-  def filter(self, col, fn, stage_name: str):
-    pass
+    def filter(self, col, fn, stage_name: str):
+        pass
 
-  def keys(self, col, stage_name: str):
-    pass
+    def keys(self, col, stage_name: str):
+        pass
 
-  def values(self, col, stage_name: str):
-    pass
+    def values(self, col, stage_name: str):
+        pass
 
-  def sample_fixed_per_key(self, col, n: int, stage_name: str):
-    # TODO: replace to group_by_key
-    d = collections.defaultdict(lambda: [])
-    for key, v in col:
-      d[key].append(v)
+    def sample_fixed_per_key(self, col, n: int, stage_name: str):
+        # TODO: replace to group_by_key
+        d = collections.defaultdict(lambda: [])
+        for key, v in col:
+            d[key].append(v)
 
-    result = []
-    for key, values in d.items():
-      if len(values) <= n:
-        result.append((key, values))
-        continue
-      sampled_indices = np.random.choice(range(len(values)), n,
-                                         replace=False)
-      sampled_values = [values[i] for i in sampled_indices]
-      result.append((key, sampled_values))
-    return result
+        result = []
+        for key, values in d.items():
+            if len(values) <= n:
+                result.append((key, values))
+                continue
+            sampled_indices = np.random.choice(range(len(values)), n,
+                                           replace=False)
+            sampled_values = [values[i] for i in sampled_indices]
+            result.append((key, sampled_values))
+        return result
 
-  def count_per_element(self, col, stage_name: str):
-    pass
+    def count_per_element(self, col, stage_name: str):
+        pass

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -190,21 +190,20 @@ class LocalPipelineOperations(PipelineOperations):
 
     def sample_fixed_per_key(self, col, n: int, stage_name: str):
         # TODO: replace to group_by_key
-        d = collections.defaultdict(lambda: [])
-        for key, value in col:
-            d[key].append(value)
+        def sample_fixed_per_key_generator():
+            d = collections.defaultdict(list)
+            for key, value in col:
+                d[key].append(value)
+            for item in d.items():
+                key = item[0]
+                values = item[1]
+                if len(item[1]) > n:
+                    sampled_indices = np.random.choice(range(len(item[1])), n,
+                                                       replace=False)
+                    values = [values[i] for i in sampled_indices]
+                yield item[0], values
 
-        result = []
-        for key, values in d.items():
-            if len(values) <= n:
-                result.append((key, values))
-                continue
-            sampled_indices = np.random.choice(range(len(values)), n,
-                                               replace=False)
-            sampled_values = [values[i] for i in sampled_indices]
-            result.append((key, sampled_values))
-        return result
+        return sample_fixed_per_key_generator()
 
     def count_per_element(self, col, stage_name: str):
         pass
-    

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -145,11 +145,11 @@ class SparkRDDOperations(PipelineOperations):
           An RDD of tuples.
 
         """
-        return rdd.mapValues(lambda x: [x])\
-            .reduceByKey(lambda x, y: random.sample(x+y, min(len(x)+len(y), n)))
+        return rdd.mapValues(lambda x: [x]) \
+            .reduceByKey(lambda x, y: random.sample(x + y, min(len(x) + len(y), n)))
 
     def count_per_element(self, rdd, stage_name: str = None):
-        return rdd.map(lambda x: (x, 1))\
+        return rdd.map(lambda x: (x, 1)) \
             .reduceByKey(lambda x, y: (x + y))
 
 
@@ -163,7 +163,7 @@ class LocalPipelineOperations(PipelineOperations):
         return [x for el in col for x in fn(el)]
 
     def map_tuple(self, col, fn, stage_name: str = None):
-        return list(map(lambda x : fn(*x), col))
+        return list(map(lambda x: fn(*x), col))
 
     def map_values(self, col, fn, stage_name: str):
         pass
@@ -183,19 +183,19 @@ class LocalPipelineOperations(PipelineOperations):
     def sample_fixed_per_key(self, col, n: int, stage_name: str):
         d = defaultdict(lambda: [])
         for k, v in col:
-          d[k].append(v)
+            d[k].append(v)
 
         result = []
         for k, values in d.items():
-          if len(values) <= n:
-            result.append((k, values))
-            continue
-          # random.choice doesn't work with list of tuples, so it's needed to make
-          # choice over indices.
-          sampled_indices = np.random.choice(range(len(values)), n, replace=False)
-          sampled_values = [values[i] for i in sampled_indices]
-          # sampled_values = list(np.random.choice(values, n, replace=False))
-          result.append((k, sampled_values))
+            if len(values) <= n:
+                result.append((k, values))
+                continue
+            # random.choice doesn't work with list of tuples, so it's needed to make
+            # choice over indices.
+            sampled_indices = np.random.choice(range(len(values)), n, replace=False)
+            sampled_values = [values[i] for i in sampled_indices]
+            # sampled_values = list(np.random.choice(values, n, replace=False))
+            result.append((k, sampled_values))
         return result
 
     def count_per_element(self, col, stage_name: str):

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -146,7 +146,8 @@ class SparkRDDOperations(PipelineOperations):
 
         """
         return rdd.mapValues(lambda x: [x]) \
-            .reduceByKey(lambda x, y: random.sample(x + y, min(len(x) + len(y), n)))
+            .reduceByKey(
+            lambda x, y: random.sample(x + y, min(len(x) + len(y), n)))
 
     def count_per_element(self, rdd, stage_name: str = None):
         return rdd.map(lambda x: (x, 1)) \
@@ -192,7 +193,8 @@ class LocalPipelineOperations(PipelineOperations):
                 continue
             # random.choice doesn't work with list of tuples, so it's needed to make
             # choice over indices.
-            sampled_indices = np.random.choice(range(len(values)), n, replace=False)
+            sampled_indices = np.random.choice(range(len(values)), n,
+                                               replace=False)
             sampled_values = [values[i] for i in sampled_indices]
             # sampled_values = list(np.random.choice(values, n, replace=False))
             result.append((k, sampled_values))

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -10,193 +10,193 @@ import apache_beam.transforms.combiners as combiners
 
 
 class PipelineOperations(abc.ABC):
-    """Interface for pipeline frameworks adapters."""
+  """Interface for pipeline frameworks adapters."""
 
-    @abc.abstractmethod
-    def map(self, col, fn, stage_name: str):
-        pass
+  @abc.abstractmethod
+  def map(self, col, fn, stage_name: str):
+    pass
 
-    @abc.abstractmethod
-    def flat_map(self, col, fn, stage_name: str):
-        pass
+  @abc.abstractmethod
+  def flat_map(self, col, fn, stage_name: str):
+    pass
 
-    @abc.abstractmethod
-    def map_tuple(self, col, fn, stage_name: str):
-        pass
+  @abc.abstractmethod
+  def map_tuple(self, col, fn, stage_name: str):
+    pass
 
-    @abc.abstractmethod
-    def map_values(self, col, fn, stage_name: str):
-        pass
+  @abc.abstractmethod
+  def map_values(self, col, fn, stage_name: str):
+    pass
 
-    @abc.abstractmethod
-    def group_by_key(self, col, stage_name: str):
-        pass
+  @abc.abstractmethod
+  def group_by_key(self, col, stage_name: str):
+    pass
 
-    @abc.abstractmethod
-    def filter(self, col, fn, stage_name: str):
-        pass
+  @abc.abstractmethod
+  def filter(self, col, fn, stage_name: str):
+    pass
 
-    @abc.abstractmethod
-    def keys(self, col, stage_name: str):
-        pass
+  @abc.abstractmethod
+  def keys(self, col, stage_name: str):
+    pass
 
-    @abc.abstractmethod
-    def values(self, col, stage_name: str):
-        pass
+  @abc.abstractmethod
+  def values(self, col, stage_name: str):
+    pass
 
-    @abc.abstractmethod
-    def sample_fixed_per_key(self, col, n: int, stage_name: str):
-        pass
+  @abc.abstractmethod
+  def sample_fixed_per_key(self, col, n: int, stage_name: str):
+    pass
 
-    @abc.abstractmethod
-    def count_per_element(self, col, stage_name: str):
-        pass
+  @abc.abstractmethod
+  def count_per_element(self, col, stage_name: str):
+    pass
 
 
 class BeamOperations(PipelineOperations):
-    """Apache Beam adapter."""
+  """Apache Beam adapter."""
 
-    def map(self, col, fn, stage_name: str):
-        return col | stage_name >> beam.Map(fn)
+  def map(self, col, fn, stage_name: str):
+    return col | stage_name >> beam.Map(fn)
 
-    def flat_map(self, col, fn, stage_name: str):
-        return col | stage_name >> beam.FlatMap(fn)
+  def flat_map(self, col, fn, stage_name: str):
+    return col | stage_name >> beam.FlatMap(fn)
 
-    def map_tuple(self, col, fn, stage_name: str):
-        return col | stage_name >> beam.Map(lambda x: fn(*x))
+  def map_tuple(self, col, fn, stage_name: str):
+    return col | stage_name >> beam.Map(lambda x: fn(*x))
 
-    def map_values(self, col, fn, stage_name: str):
-        return col | stage_name >> beam.MapTuple(lambda k, v: (k, fn(v)))
+  def map_values(self, col, fn, stage_name: str):
+    return col | stage_name >> beam.MapTuple(lambda k, v: (k, fn(v)))
 
-    def group_by_key(self, col, stage_name: str):
-        """Group the values for each key in the PCollection into a single sequence.
+  def group_by_key(self, col, stage_name: str):
+    """Group the values for each key in the PCollection into a single sequence.
 
-        Args:
-          col: input collection
-          stage_name: name of the stage
+    Args:
+      col: input collection
+      stage_name: name of the stage
 
-        Returns:
-          An PCollection of tuples in which the type of the second item is list.
+    Returns:
+      An PCollection of tuples in which the type of the second item is list.
 
-        """
-        return col | stage_name >> beam.GroupByKey()
+    """
+    return col | stage_name >> beam.GroupByKey()
 
-    def filter(self, col, fn, stage_name: str):
-        return col | stage_name >> beam.Filter(fn)
+  def filter(self, col, fn, stage_name: str):
+    return col | stage_name >> beam.Filter(fn)
 
-    def keys(self, col, stage_name: str):
-        return col | stage_name >> beam.Keys()
+  def keys(self, col, stage_name: str):
+    return col | stage_name >> beam.Keys()
 
-    def values(self, col, stage_name: str):
-        return col | stage_name >> beam.Values()
+  def values(self, col, stage_name: str):
+    return col | stage_name >> beam.Values()
 
-    def sample_fixed_per_key(self, col, n: int, stage_name: str):
-        return col | stage_name >> combiners.Sample.FixedSizePerKey(n)
+  def sample_fixed_per_key(self, col, n: int, stage_name: str):
+    return col | stage_name >> combiners.Sample.FixedSizePerKey(n)
 
-    def count_per_element(self, col, stage_name: str):
-        return col | stage_name >> combiners.Count.PerElement()
+  def count_per_element(self, col, stage_name: str):
+    return col | stage_name >> combiners.Count.PerElement()
 
 
 class SparkRDDOperations(PipelineOperations):
-    """Apache Spark RDD adapter."""
+  """Apache Spark RDD adapter."""
 
-    def map(self, rdd, fn, stage_name: str = None):
-        return rdd.map(fn)
+  def map(self, rdd, fn, stage_name: str = None):
+    return rdd.map(fn)
 
-    def map_tuple(self, rdd, fn, stage_name: str = None):
-        return rdd.map(fn)
+  def map_tuple(self, rdd, fn, stage_name: str = None):
+    return rdd.map(fn)
 
-    def map_values(self, rdd, fn, stage_name: str = None):
-        return rdd.mapValues(fn)
+  def map_values(self, rdd, fn, stage_name: str = None):
+    return rdd.mapValues(fn)
 
-    def group_by_key(self, rdd, stage_name: str = None):
-        """Group the values for each key in the RDD into a single sequence.
+  def group_by_key(self, rdd, stage_name: str = None):
+    """Group the values for each key in the RDD into a single sequence.
 
-        Args:
-          rdd: input RDD
-          stage_name: not used
+    Args:
+      rdd: input RDD
+      stage_name: not used
 
-        Returns:
-          An RDD of tuples in which the type of the second item
-          is the pyspark.resultiterable.ResultIterable.
+    Returns:
+      An RDD of tuples in which the type of the second item
+      is the pyspark.resultiterable.ResultIterable.
 
-        """
-        return rdd.groupByKey()
+    """
+    return rdd.groupByKey()
 
-    def filter(self, rdd, fn, stage_name: str = None):
-        return rdd.filter(fn)
+  def filter(self, rdd, fn, stage_name: str = None):
+    return rdd.filter(fn)
 
-    def keys(self, rdd, stage_name: str = None):
-        return rdd.keys()
+  def keys(self, rdd, stage_name: str = None):
+    return rdd.keys()
 
-    def values(self, rdd, stage_name: str = None):
-        return rdd.values()
+  def values(self, rdd, stage_name: str = None):
+    return rdd.values()
 
-    def sample_fixed_per_key(self, rdd, n: int, stage_name: str = None):
-        """Get fixed-size random samples for each unique key in an RDD of key-values.
-        Sampling is not guaranteed to be uniform across partitions.
+  def sample_fixed_per_key(self, rdd, n: int, stage_name: str = None):
+    """Get fixed-size random samples for each unique key in an RDD of key-values.
+    Sampling is not guaranteed to be uniform across partitions.
 
-        Args:
-          rdd: input RDD
-          n: number of values to sample for each key
-          stage_name: not used
+    Args:
+      rdd: input RDD
+      n: number of values to sample for each key
+      stage_name: not used
 
-        Returns:
-          An RDD of tuples.
+    Returns:
+      An RDD of tuples.
 
-        """
-        return rdd.mapValues(lambda x: [x]) \
-            .reduceByKey(
-            lambda x, y: random.sample(x + y, min(len(x) + len(y), n)))
+    """
+    return rdd.mapValues(lambda x: [x]) \
+      .reduceByKey(
+      lambda x, y: random.sample(x + y, min(len(x) + len(y), n)))
 
-    def count_per_element(self, rdd, stage_name: str = None):
-        return rdd.map(lambda x: (x, 1)) \
-            .reduceByKey(lambda x, y: (x + y))
+  def count_per_element(self, rdd, stage_name: str = None):
+    return rdd.map(lambda x: (x, 1)) \
+      .reduceByKey(lambda x, y: (x + y))
 
 
 class LocalPipelineOperations(PipelineOperations):
-    """Local Pipeline adapter."""
+  """Local Pipeline adapter."""
 
-    def map(self, col, fn, stage_name: str = None):
-        return map(fn, col)
+  def map(self, col, fn, stage_name: str = None):
+    return map(fn, col)
 
-    def flat_map(self, col, fn, stage_name: str):
-        return (x for el in col for x in fn(el))
+  def flat_map(self, col, fn, stage_name: str):
+    return (x for el in col for x in fn(el))
 
-    def map_tuple(self, col, fn, stage_name: str = None):
-        return map(lambda x: fn(*x), col)
+  def map_tuple(self, col, fn, stage_name: str = None):
+    return map(lambda x: fn(*x), col)
 
-    def map_values(self, col, fn, stage_name: str):
-        pass
+  def map_values(self, col, fn, stage_name: str):
+    pass
 
-    def group_by_key(self, col, stage_name: str):
-        pass
+  def group_by_key(self, col, stage_name: str):
+    pass
 
-    def filter(self, col, fn, stage_name: str):
-        pass
+  def filter(self, col, fn, stage_name: str):
+    pass
 
-    def keys(self, col, stage_name: str):
-        pass
+  def keys(self, col, stage_name: str):
+    pass
 
-    def values(self, col, stage_name: str):
-        pass
+  def values(self, col, stage_name: str):
+    pass
 
-    def sample_fixed_per_key(self, col, n: int, stage_name: str):
-        # TODO: replace to group_by_key
-        d = collections.defaultdict(lambda: [])
-        for key, v in col:
-            d[key].append(v)
+  def sample_fixed_per_key(self, col, n: int, stage_name: str):
+    # TODO: replace to group_by_key
+    d = collections.defaultdict(lambda: [])
+    for key, v in col:
+      d[key].append(v)
 
-        result = []
-        for key, values in d.items():
-            if len(values) <= n:
-                result.append((key, values))
-                continue
-            sampled_indices = np.random.choice(range(len(values)), n,
-                                               replace=False)
-            sampled_values = [values[i] for i in sampled_indices]
-            result.append((key, sampled_values))
-        return result
+    result = []
+    for key, values in d.items():
+      if len(values) <= n:
+        result.append((key, values))
+        continue
+      sampled_indices = np.random.choice(range(len(values)), n,
+                                         replace=False)
+      sampled_values = [values[i] for i in sampled_indices]
+      result.append((key, sampled_values))
+    return result
 
-    def count_per_element(self, col, stage_name: str):
-        pass
+  def count_per_element(self, col, stage_name: str):
+    pass

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -18,7 +18,7 @@ class PipelineOperations(abc.ABC):
 
     @abc.abstractmethod
     def flat_map(self, col, fn, stage_name: str):
-        return col | stage_name >> beam.FlatMap(fn)
+        pass
 
     @abc.abstractmethod
     def map_tuple(self, col, fn, stage_name: str):

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -6,105 +6,105 @@ import pipeline_dp
 
 
 class dp_engineTest(unittest.TestCase):
-    aggregator_fn = lambda input_values: (len(input_values),
-                                          np.sum(input_values),
-                                          np.sum(np.square(input_values)))
+  aggregator_fn = lambda input_values: (len(input_values),
+                                        np.sum(input_values),
+                                        np.sum(np.square(input_values)))
 
-    def test_contribution_bounding_empty_col(self):
-        input_col = []
-        max_partitions_contributed = 2
-        max_contributions_per_partition = 2
+  def test_contribution_bounding_empty_col(self):
+    input_col = []
+    max_partitions_contributed = 2
+    max_contributions_per_partition = 2
 
-        dp_engine = pipeline_dp.DPEngine(
-            pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp.LocalPipelineOperations())
-        bound_op = list(dp_engine._bound_cross_partition_contributions(
-            input_col,
-            max_partitions_contributed=max_partitions_contributed,
-            max_contributions_per_partition=max_contributions_per_partition,
-            aggregator_fn=dp_engineTest.aggregator_fn))
+    dp_engine = pipeline_dp.DPEngine(
+      pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+      pipeline_dp.LocalPipelineOperations())
+    bound_op = list(dp_engine._bound_cross_partition_contributions(
+      input_col,
+      max_partitions_contributed=max_partitions_contributed,
+      max_contributions_per_partition=max_contributions_per_partition,
+      aggregator_fn=dp_engineTest.aggregator_fn))
 
-        self.assertFalse(bound_op)
+    self.assertFalse(bound_op)
 
-    def test_contribution_bounding_bound_input_nothing_dropped(self):
-        input_col = [("pid1", 'pk1', 1),
-                     ("pid1", 'pk1', 2),
-                     ("pid1", 'pk2', 3),
-                     ("pid1", 'pk2', 4)]
-        max_partitions_contributed = 2
-        max_contributions_per_partition = 2
+  def test_contribution_bounding_bound_input_nothing_dropped(self):
+    input_col = [("pid1", 'pk1', 1),
+                 ("pid1", 'pk1', 2),
+                 ("pid1", 'pk2', 3),
+                 ("pid1", 'pk2', 4)]
+    max_partitions_contributed = 2
+    max_contributions_per_partition = 2
 
-        dp_engine = pipeline_dp.DPEngine(
-            pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp.LocalPipelineOperations())
-        bound_op = list(dp_engine._bound_cross_partition_contributions(
-            input_col,
-            max_partitions_contributed=max_partitions_contributed,
-            max_contributions_per_partition=max_contributions_per_partition,
-            aggregator_fn=dp_engineTest.aggregator_fn))
+    dp_engine = pipeline_dp.DPEngine(
+      pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+      pipeline_dp.LocalPipelineOperations())
+    bound_op = list(dp_engine._bound_cross_partition_contributions(
+      input_col,
+      max_partitions_contributed=max_partitions_contributed,
+      max_contributions_per_partition=max_contributions_per_partition,
+      aggregator_fn=dp_engineTest.aggregator_fn))
 
-        expected_op = [(('pid1', 'pk2'), (2, 7, 25)),
-                       (('pid1', 'pk1'), (2, 3, 5))]
-        self.assertEqual(set(expected_op), set(bound_op))
+    expected_op = [(('pid1', 'pk2'), (2, 7, 25)),
+                   (('pid1', 'pk1'), (2, 3, 5))]
+    self.assertEqual(set(expected_op), set(bound_op))
 
-    def test_contribution_bounding_per_partition_bounding_applied(self):
-        input_col = [("pid1", 'pk1', 1),
-                     ("pid1", 'pk1', 2),
-                     ("pid1", 'pk2', 3),
-                     ("pid1", 'pk2', 4),
-                     ("pid1", 'pk2', 5),
-                     ("pid2", 'pk2', 6)]
-        max_partitions_contributed = 5
-        max_contributions_per_partition = 2
+  def test_contribution_bounding_per_partition_bounding_applied(self):
+    input_col = [("pid1", 'pk1', 1),
+                 ("pid1", 'pk1', 2),
+                 ("pid1", 'pk2', 3),
+                 ("pid1", 'pk2', 4),
+                 ("pid1", 'pk2', 5),
+                 ("pid2", 'pk2', 6)]
+    max_partitions_contributed = 5
+    max_contributions_per_partition = 2
 
-        dp_engine = pipeline_dp.DPEngine(
-            pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp.LocalPipelineOperations())
-        bound_op = list(dp_engine._bound_cross_partition_contributions(
-            input_col,
-            max_partitions_contributed=max_partitions_contributed,
-            max_contributions_per_partition=max_contributions_per_partition,
-            aggregator_fn=dp_engineTest.aggregator_fn))
+    dp_engine = pipeline_dp.DPEngine(
+      pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+      pipeline_dp.LocalPipelineOperations())
+    bound_op = list(dp_engine._bound_cross_partition_contributions(
+      input_col,
+      max_partitions_contributed=max_partitions_contributed,
+      max_contributions_per_partition=max_contributions_per_partition,
+      aggregator_fn=dp_engineTest.aggregator_fn))
 
-        self.assertEqual(len(bound_op), 3)
-        self.assertTrue(all(map(
-            lambda op_val: op_val[1][0] <= max_contributions_per_partition,
-            bound_op)))
+    self.assertEqual(len(bound_op), 3)
+    self.assertTrue(all(map(
+      lambda op_val: op_val[1][0] <= max_contributions_per_partition,
+      bound_op)))
 
-    def test_contribution_bounding_cross_partition_bounding_applied(self):
-        input_col = [("pid1", 'pk1', 1),
-                     ("pid1", 'pk1', 2),
-                     ("pid1", 'pk2', 3),
-                     ("pid1", 'pk2', 4),
-                     ("pid1", 'pk2', 5),
-                     ("pid1", 'pk3', 6),
-                     ("pid1", 'pk4', 7),
-                     ("pid2", 'pk4', 8)]
-        max_partitions_contributed = 3
-        max_contributions_per_partition = 5
+  def test_contribution_bounding_cross_partition_bounding_applied(self):
+    input_col = [("pid1", 'pk1', 1),
+                 ("pid1", 'pk1', 2),
+                 ("pid1", 'pk2', 3),
+                 ("pid1", 'pk2', 4),
+                 ("pid1", 'pk2', 5),
+                 ("pid1", 'pk3', 6),
+                 ("pid1", 'pk4', 7),
+                 ("pid2", 'pk4', 8)]
+    max_partitions_contributed = 3
+    max_contributions_per_partition = 5
 
-        dp_engine = pipeline_dp.DPEngine(
-            pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp.LocalPipelineOperations())
-        bound_op = list(dp_engine._bound_cross_partition_contributions(
-            input_col,
-            max_partitions_contributed=max_partitions_contributed,
-            max_contributions_per_partition=max_contributions_per_partition,
-            aggregator_fn=dp_engineTest.aggregator_fn))
+    dp_engine = pipeline_dp.DPEngine(
+      pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+      pipeline_dp.LocalPipelineOperations())
+    bound_op = list(dp_engine._bound_cross_partition_contributions(
+      input_col,
+      max_partitions_contributed=max_partitions_contributed,
+      max_contributions_per_partition=max_contributions_per_partition,
+      aggregator_fn=dp_engineTest.aggregator_fn))
 
-        self.assertEqual(len(bound_op), 4)
-        self.assertTrue(all(map(
-            lambda op_val: op_val[1][0] <= max_contributions_per_partition,
-            bound_op)))
-        dict_of_pid_to_pk = collections.defaultdict(lambda: [])
-        for key, _ in bound_op:
-            dict_of_pid_to_pk[key[0]].append(key[1])
-        self.assertEqual(len(dict_of_pid_to_pk), 2)
-        self.assertTrue(
-            all(map(lambda key: len(
-                dict_of_pid_to_pk[key]) <= max_partitions_contributed,
-                    dict_of_pid_to_pk)))
+    self.assertEqual(len(bound_op), 4)
+    self.assertTrue(all(map(
+      lambda op_val: op_val[1][0] <= max_contributions_per_partition,
+      bound_op)))
+    dict_of_pid_to_pk = collections.defaultdict(lambda: [])
+    for key, _ in bound_op:
+      dict_of_pid_to_pk[key[0]].append(key[1])
+    self.assertEqual(len(dict_of_pid_to_pk), 2)
+    self.assertTrue(
+      all(map(lambda key: len(
+        dict_of_pid_to_pk[key]) <= max_partitions_contributed,
+              dict_of_pid_to_pk)))
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -17,7 +17,7 @@ class dp_engineTest(unittest.TestCase):
 
         dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp.LocalPipelineOperations())
+            pipeline_dp..BeamOperations())
         bound_op = list(dp_engine._bound_cross_partition_contributions(
             input_col,
             max_partitions_contributed=max_partitions_contributed,
@@ -36,7 +36,7 @@ class dp_engineTest(unittest.TestCase):
 
         dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp.LocalPipelineOperations())
+            pipeline_dp..BeamOperations())
         bound_op = list(dp_engine._bound_cross_partition_contributions(
             input_col,
             max_partitions_contributed=max_partitions_contributed,
@@ -59,7 +59,7 @@ class dp_engineTest(unittest.TestCase):
 
         dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp.LocalPipelineOperations())
+            pipeline_dp..BeamOperations())
         bound_op = list(dp_engine._bound_cross_partition_contributions(
             input_col,
             max_partitions_contributed=max_partitions_contributed,
@@ -85,7 +85,7 @@ class dp_engineTest(unittest.TestCase):
 
         dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp.LocalPipelineOperations())
+            pipeline_dp..BeamOperations())
         bound_op = list(dp_engine._bound_cross_partition_contributions(
             input_col,
             max_partitions_contributed=max_partitions_contributed,

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -1,102 +1,102 @@
-from collections import defaultdict
+import collections
 import numpy as np
 import unittest
 
 import pipeline_dp
 
 
-class DPEngineTest(unittest.TestCase):
-    aggregator_fn = lambda inp_values: (len(inp_values),
-                                        np.sum(inp_values),
-                                        np.sum(np.square(inp_values)))
+class dp_engineTest(unittest.TestCase):
+    aggregator_fn = lambda input_values: (len(input_values),
+                                          np.sum(input_values),
+                                          np.sum(np.square(input_values)))
 
-    def testContributionBounding_emptyCol(self):
-        inp_col = []
+    def test_contribution_bounding_empty_col(self):
+        input_col = []
         max_partitions_contributed = 2
         max_contributions_per_partition = 2
 
-        dpEngine = pipeline_dp.DPEngine(
+        dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
             pipeline_dp.LocalPipelineOperations())
-        bound_op = dpEngine._bound_cross_partition_contributions(
-            inp_col,
+        bound_op = list(dp_engine._bound_cross_partition_contributions(
+            input_col,
             max_partitions_contributed=max_partitions_contributed,
             max_contributions_per_partition=max_contributions_per_partition,
-            aggregator_fn=DPEngineTest.aggregator_fn)
+            aggregator_fn=dp_engineTest.aggregator_fn))
 
         self.assertFalse(bound_op)
 
-    def testContributionBounding_boundInput_nothingDropped(self):
-        inp_col = [("pid1", 'pk1', 1),
-                   ("pid1", 'pk1', 2),
-                   ("pid1", 'pk2', 3),
-                   ("pid1", 'pk2', 4)]
+    def test_contribution_bounding_bound_input_nothing_dropped(self):
+        input_col = [("pid1", 'pk1', 1),
+                     ("pid1", 'pk1', 2),
+                     ("pid1", 'pk2', 3),
+                     ("pid1", 'pk2', 4)]
         max_partitions_contributed = 2
         max_contributions_per_partition = 2
 
-        dpEngine = pipeline_dp.DPEngine(
+        dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
             pipeline_dp.LocalPipelineOperations())
-        bound_op = dpEngine._bound_cross_partition_contributions(
-            inp_col,
+        bound_op = list(dp_engine._bound_cross_partition_contributions(
+            input_col,
             max_partitions_contributed=max_partitions_contributed,
             max_contributions_per_partition=max_contributions_per_partition,
-            aggregator_fn=DPEngineTest.aggregator_fn)
+            aggregator_fn=dp_engineTest.aggregator_fn))
 
         expected_op = [(('pid1', 'pk2'), (2, 7, 25)),
                        (('pid1', 'pk1'), (2, 3, 5))]
         self.assertEqual(set(expected_op), set(bound_op))
 
-    def testContributionBounding_perPartitionBoundingApplied(self):
-        inp_col = [("pid1", 'pk1', 1),
-                   ("pid1", 'pk1', 2),
-                   ("pid1", 'pk2', 3),
-                   ("pid1", 'pk2', 4),
-                   ("pid1", 'pk2', 5),
-                   ("pid2", 'pk2', 6)]
+    def test_contribution_bounding_per_partition_bounding_applied(self):
+        input_col = [("pid1", 'pk1', 1),
+                     ("pid1", 'pk1', 2),
+                     ("pid1", 'pk2', 3),
+                     ("pid1", 'pk2', 4),
+                     ("pid1", 'pk2', 5),
+                     ("pid2", 'pk2', 6)]
         max_partitions_contributed = 5
         max_contributions_per_partition = 2
 
-        dpEngine = pipeline_dp.DPEngine(
+        dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
             pipeline_dp.LocalPipelineOperations())
-        bound_op = dpEngine._bound_cross_partition_contributions(
-            inp_col,
+        bound_op = list(dp_engine._bound_cross_partition_contributions(
+            input_col,
             max_partitions_contributed=max_partitions_contributed,
             max_contributions_per_partition=max_contributions_per_partition,
-            aggregator_fn=DPEngineTest.aggregator_fn)
+            aggregator_fn=dp_engineTest.aggregator_fn))
 
         self.assertEqual(len(bound_op), 3)
         self.assertTrue(all(map(
             lambda op_val: op_val[1][0] <= max_contributions_per_partition,
             bound_op)))
 
-    def testContributionBounding_crossPartitionBoundingApplied(self):
-        inp_col = [("pid1", 'pk1', 1),
-                   ("pid1", 'pk1', 2),
-                   ("pid1", 'pk2', 3),
-                   ("pid1", 'pk2', 4),
-                   ("pid1", 'pk2', 5),
-                   ("pid1", 'pk3', 6),
-                   ("pid1", 'pk4', 7),
-                   ("pid2", 'pk4', 8)]
+    def test_contribution_bounding_cross_partition_bounding_applied(self):
+        input_col = [("pid1", 'pk1', 1),
+                     ("pid1", 'pk1', 2),
+                     ("pid1", 'pk2', 3),
+                     ("pid1", 'pk2', 4),
+                     ("pid1", 'pk2', 5),
+                     ("pid1", 'pk3', 6),
+                     ("pid1", 'pk4', 7),
+                     ("pid2", 'pk4', 8)]
         max_partitions_contributed = 3
         max_contributions_per_partition = 5
 
-        dpEngine = pipeline_dp.DPEngine(
+        dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
             pipeline_dp.LocalPipelineOperations())
-        bound_op = dpEngine._bound_cross_partition_contributions(
-            inp_col,
+        bound_op = list(dp_engine._bound_cross_partition_contributions(
+            input_col,
             max_partitions_contributed=max_partitions_contributed,
             max_contributions_per_partition=max_contributions_per_partition,
-            aggregator_fn=DPEngineTest.aggregator_fn)
+            aggregator_fn=dp_engineTest.aggregator_fn))
 
         self.assertEqual(len(bound_op), 4)
         self.assertTrue(all(map(
             lambda op_val: op_val[1][0] <= max_contributions_per_partition,
             bound_op)))
-        dict_of_pid_to_pk = defaultdict(lambda: [])
+        dict_of_pid_to_pk = collections.defaultdict(lambda: [])
         for key, _ in bound_op:
             dict_of_pid_to_pk[key[0]].append(key[1])
         self.assertEqual(len(dict_of_pid_to_pk), 2)

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -21,7 +21,7 @@ class dp_engineTest(unittest.TestCase):
     dp_engine = pipeline_dp.DPEngine(
       pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
       pipeline_dp.LocalPipelineOperations())
-    bound_result = list(dp_engine._bound_cross_partition_contributions(
+    bound_result = list(dp_engine._bound_contributions(
       input_col,
       max_partitions_contributed=max_partitions_contributed,
       max_contributions_per_partition=max_contributions_per_partition,
@@ -40,7 +40,7 @@ class dp_engineTest(unittest.TestCase):
     dp_engine = pipeline_dp.DPEngine(
       pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
       pipeline_dp.LocalPipelineOperations())
-    bound_result = list(dp_engine._bound_cross_partition_contributions(
+    bound_result = list(dp_engine._bound_contributions(
       input_col,
       max_partitions_contributed=max_partitions_contributed,
       max_contributions_per_partition=max_contributions_per_partition,
@@ -63,7 +63,7 @@ class dp_engineTest(unittest.TestCase):
     dp_engine = pipeline_dp.DPEngine(
       pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
       pipeline_dp.LocalPipelineOperations())
-    bound_result = list(dp_engine._bound_cross_partition_contributions(
+    bound_result = list(dp_engine._bound_contributions(
       input_col,
       max_partitions_contributed=max_partitions_contributed,
       max_contributions_per_partition=max_contributions_per_partition,
@@ -90,7 +90,7 @@ class dp_engineTest(unittest.TestCase):
     dp_engine = pipeline_dp.DPEngine(
       pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
       pipeline_dp.LocalPipelineOperations())
-    bound_result = list(dp_engine._bound_cross_partition_contributions(
+    bound_result = list(dp_engine._bound_contributions(
       input_col,
       max_partitions_contributed=max_partitions_contributed,
       max_contributions_per_partition=max_contributions_per_partition,

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -18,13 +18,13 @@ class dp_engineTest(unittest.TestCase):
     dp_engine = pipeline_dp.DPEngine(
       pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
       pipeline_dp.LocalPipelineOperations())
-    bound_op = list(dp_engine._bound_cross_partition_contributions(
+    bound_result = list(dp_engine._bound_cross_partition_contributions(
       input_col,
       max_partitions_contributed=max_partitions_contributed,
       max_contributions_per_partition=max_contributions_per_partition,
       aggregator_fn=dp_engineTest.aggregator_fn))
 
-    self.assertFalse(bound_op)
+    self.assertFalse(bound_result)
 
   def test_contribution_bounding_bound_input_nothing_dropped(self):
     input_col = [("pid1", 'pk1', 1),
@@ -37,15 +37,15 @@ class dp_engineTest(unittest.TestCase):
     dp_engine = pipeline_dp.DPEngine(
       pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
       pipeline_dp.LocalPipelineOperations())
-    bound_op = list(dp_engine._bound_cross_partition_contributions(
+    bound_result = list(dp_engine._bound_cross_partition_contributions(
       input_col,
       max_partitions_contributed=max_partitions_contributed,
       max_contributions_per_partition=max_contributions_per_partition,
       aggregator_fn=dp_engineTest.aggregator_fn))
 
-    expected_op = [(('pid1', 'pk2'), (2, 7, 25)),
-                   (('pid1', 'pk1'), (2, 3, 5))]
-    self.assertEqual(set(expected_op), set(bound_op))
+    expected_result = [(('pid1', 'pk2'), (2, 7, 25)),
+                       (('pid1', 'pk1'), (2, 3, 5))]
+    self.assertEqual(set(expected_result), set(bound_result))
 
   def test_contribution_bounding_per_partition_bounding_applied(self):
     input_col = [("pid1", 'pk1', 1),
@@ -60,16 +60,17 @@ class dp_engineTest(unittest.TestCase):
     dp_engine = pipeline_dp.DPEngine(
       pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
       pipeline_dp.LocalPipelineOperations())
-    bound_op = list(dp_engine._bound_cross_partition_contributions(
+    bound_result = list(dp_engine._bound_cross_partition_contributions(
       input_col,
       max_partitions_contributed=max_partitions_contributed,
       max_contributions_per_partition=max_contributions_per_partition,
       aggregator_fn=dp_engineTest.aggregator_fn))
 
-    self.assertEqual(len(bound_op), 3)
+    self.assertEqual(len(bound_result), 3)
+    # Check contributions per partitions
     self.assertTrue(all(map(
       lambda op_val: op_val[1][0] <= max_contributions_per_partition,
-      bound_op)))
+      bound_result)))
 
   def test_contribution_bounding_cross_partition_bounding_applied(self):
     input_col = [("pid1", 'pk1', 1),
@@ -86,18 +87,20 @@ class dp_engineTest(unittest.TestCase):
     dp_engine = pipeline_dp.DPEngine(
       pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
       pipeline_dp.LocalPipelineOperations())
-    bound_op = list(dp_engine._bound_cross_partition_contributions(
+    bound_result = list(dp_engine._bound_cross_partition_contributions(
       input_col,
       max_partitions_contributed=max_partitions_contributed,
       max_contributions_per_partition=max_contributions_per_partition,
       aggregator_fn=dp_engineTest.aggregator_fn))
 
-    self.assertEqual(len(bound_op), 4)
+    self.assertEqual(len(bound_result), 4)
+    # Check contributions per partitions
     self.assertTrue(all(map(
       lambda op_val: op_val[1][0] <= max_contributions_per_partition,
-      bound_op)))
+      bound_result)))
+    # Check cross partition contributions
     dict_of_pid_to_pk = collections.defaultdict(lambda: [])
-    for key, _ in bound_op:
+    for key, _ in bound_result:
       dict_of_pid_to_pk[key[0]].append(key[1])
     self.assertEqual(len(dict_of_pid_to_pk), 2)
     self.assertTrue(

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -10,6 +10,21 @@ class DPEngineTest(unittest.TestCase):
                                            np.sum(inp_values),
                                            np.sum(np.square(inp_values)))
 
+  def testContributionBounding_emptyCol(self):
+    inp_col = []
+    max_partitions_contributed = 2
+    max_contributions_per_partition = 2
+
+    dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+    pipeline_dp.LocalPipelineOperations())
+    bound_op = dpEngine._bound_cross_partition_contributions(
+                          inp_col,
+                          max_partitions_contributed=max_partitions_contributed,
+                          max_contributions_per_partition=max_contributions_per_partition,
+                          aggregator_fn=DPEngineTest.aggregator_fn)
+
+    self.assertFalse(bound_op)
+
   def testContributionBounding_boundInput_nothingDropped(self):
       inp_col = [("pid1", 'pk1' , 1),
                  ("pid1", 'pk1' , 2),

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -129,12 +129,13 @@ class dp_engineTest(unittest.TestCase):
       low=2,
       high=10,
       metrics=[pipeline_dp.Metrics.VAR, pipeline_dp.Metrics.SUM, pipeline_dp.Metrics.MEAN],
-      public_partitions = list(range(1,40)),
+      public_partitions = list(range(1, 40)),
     )
     engine = pipeline_dp.DPEngine(None, None)
     engine.aggregate(None, params1, None)
     engine.aggregate(None, params2, None)
     self.assertEqual(len(engine._report_generators), 2)  # pylint: disable=protected-access
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -15,8 +15,9 @@ class DPEngineTest(unittest.TestCase):
         max_partitions_contributed = 2
         max_contributions_per_partition = 2
 
-        dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-                                        pipeline_dp.LocalPipelineOperations())
+        dpEngine = pipeline_dp.DPEngine(
+            pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+            pipeline_dp.LocalPipelineOperations())
         bound_op = dpEngine._bound_cross_partition_contributions(
             inp_col,
             max_partitions_contributed=max_partitions_contributed,
@@ -33,15 +34,17 @@ class DPEngineTest(unittest.TestCase):
         max_partitions_contributed = 2
         max_contributions_per_partition = 2
 
-        dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-                                        pipeline_dp.LocalPipelineOperations())
+        dpEngine = pipeline_dp.DPEngine(
+            pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+            pipeline_dp.LocalPipelineOperations())
         bound_op = dpEngine._bound_cross_partition_contributions(
             inp_col,
             max_partitions_contributed=max_partitions_contributed,
             max_contributions_per_partition=max_contributions_per_partition,
             aggregator_fn=DPEngineTest.aggregator_fn)
 
-        expected_op = [(('pid1', 'pk2'), (2, 7, 25)), (('pid1', 'pk1'), (2, 3, 5))]
+        expected_op = [(('pid1', 'pk2'), (2, 7, 25)),
+                       (('pid1', 'pk1'), (2, 3, 5))]
         self.assertEqual(set(expected_op), set(bound_op))
 
     def testContributionBounding_perPartitionBoundingApplied(self):
@@ -54,8 +57,9 @@ class DPEngineTest(unittest.TestCase):
         max_partitions_contributed = 5
         max_contributions_per_partition = 2
 
-        dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-                                        pipeline_dp.LocalPipelineOperations())
+        dpEngine = pipeline_dp.DPEngine(
+            pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+            pipeline_dp.LocalPipelineOperations())
         bound_op = dpEngine._bound_cross_partition_contributions(
             inp_col,
             max_partitions_contributed=max_partitions_contributed,
@@ -63,7 +67,9 @@ class DPEngineTest(unittest.TestCase):
             aggregator_fn=DPEngineTest.aggregator_fn)
 
         self.assertEqual(len(bound_op), 3)
-        self.assertTrue(all(map(lambda op_val: op_val[1][0] <= max_contributions_per_partition, bound_op)))
+        self.assertTrue(all(map(
+            lambda op_val: op_val[1][0] <= max_contributions_per_partition,
+            bound_op)))
 
     def testContributionBounding_crossPartitionBoundingApplied(self):
         inp_col = [("pid1", 'pk1', 1),
@@ -77,8 +83,9 @@ class DPEngineTest(unittest.TestCase):
         max_partitions_contributed = 3
         max_contributions_per_partition = 5
 
-        dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-                                        pipeline_dp.LocalPipelineOperations())
+        dpEngine = pipeline_dp.DPEngine(
+            pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+            pipeline_dp.LocalPipelineOperations())
         bound_op = dpEngine._bound_cross_partition_contributions(
             inp_col,
             max_partitions_contributed=max_partitions_contributed,
@@ -86,13 +93,17 @@ class DPEngineTest(unittest.TestCase):
             aggregator_fn=DPEngineTest.aggregator_fn)
 
         self.assertEqual(len(bound_op), 4)
-        self.assertTrue(all(map(lambda op_val: op_val[1][0] <= max_contributions_per_partition, bound_op)))
+        self.assertTrue(all(map(
+            lambda op_val: op_val[1][0] <= max_contributions_per_partition,
+            bound_op)))
         dict_of_pid_to_pk = defaultdict(lambda: [])
         for key, _ in bound_op:
             dict_of_pid_to_pk[key[0]].append(key[1])
         self.assertEqual(len(dict_of_pid_to_pk), 2)
         self.assertTrue(
-            all(map(lambda key: len(dict_of_pid_to_pk[key]) <= max_partitions_contributed, dict_of_pid_to_pk)))
+            all(map(lambda key: len(
+                dict_of_pid_to_pk[key]) <= max_partitions_contributed,
+                    dict_of_pid_to_pk)))
 
 
 if __name__ == '__main__':

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -17,7 +17,7 @@ class dp_engineTest(unittest.TestCase):
 
         dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp..BeamOperations())
+            pipeline_dp.LocalPipelineOperations())
         bound_op = list(dp_engine._bound_cross_partition_contributions(
             input_col,
             max_partitions_contributed=max_partitions_contributed,
@@ -36,7 +36,7 @@ class dp_engineTest(unittest.TestCase):
 
         dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp..BeamOperations())
+            pipeline_dp.LocalPipelineOperations())
         bound_op = list(dp_engine._bound_cross_partition_contributions(
             input_col,
             max_partitions_contributed=max_partitions_contributed,
@@ -59,7 +59,7 @@ class dp_engineTest(unittest.TestCase):
 
         dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp..BeamOperations())
+            pipeline_dp.LocalPipelineOperations())
         bound_op = list(dp_engine._bound_cross_partition_contributions(
             input_col,
             max_partitions_contributed=max_partitions_contributed,
@@ -85,7 +85,7 @@ class dp_engineTest(unittest.TestCase):
 
         dp_engine = pipeline_dp.DPEngine(
             pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-            pipeline_dp..BeamOperations())
+            pipeline_dp.LocalPipelineOperations())
         bound_op = list(dp_engine._bound_cross_partition_contributions(
             input_col,
             max_partitions_contributed=max_partitions_contributed,

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -1,10 +1,82 @@
+from collections import defaultdict
+import numpy as np
 import unittest
 
 import pipeline_dp
 
 class DPEngineTest(unittest.TestCase):
-  pass
 
+  aggregator_fn = lambda inp_values : (len(inp_values),
+                                           np.sum(inp_values),
+                                           np.sum(np.square(inp_values)))
+
+  def testContributionBounding_boundInput_nothingDropped(self):
+      inp_col = [("pid1", 'pk1' , 1),
+                 ("pid1", 'pk1' , 2),
+                 ("pid1", 'pk2' , 3),
+                 ("pid1", 'pk2' , 4)]
+      max_partitions_contributed = 2
+      max_contributions_per_partition = 2
+
+      dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+      pipeline_dp.LocalPipelineOperations())
+      bound_op = dpEngine._bound_cross_partition_contributions(
+                            inp_col,
+                            max_partitions_contributed=max_partitions_contributed,
+                            max_contributions_per_partition=max_contributions_per_partition,
+                            aggregator_fn=DPEngineTest.aggregator_fn)
+
+      expected_op = [(('pid1', 'pk2'), (2, 7, 25)), (('pid1', 'pk1'), (2, 3, 5))]
+      self.assertEqual(set(expected_op), set(bound_op))
+
+  def testContributionBounding_perPartitionBoundingApplied(self):
+    inp_col = [("pid1", 'pk1' , 1),
+               ("pid1", 'pk1' , 2),
+               ("pid1", 'pk2' , 3),
+               ("pid1", 'pk2' , 4),
+               ("pid1", 'pk2' , 5),
+               ("pid2", 'pk2' , 6)]
+    max_partitions_contributed = 5
+    max_contributions_per_partition = 2
+
+    dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+    pipeline_dp.LocalPipelineOperations())
+    bound_op = dpEngine._bound_cross_partition_contributions(
+                          inp_col,
+                          max_partitions_contributed=max_partitions_contributed,
+                          max_contributions_per_partition=max_contributions_per_partition,
+                          aggregator_fn=DPEngineTest.aggregator_fn)
+
+    self.assertEqual(len(bound_op), 3)
+    self.assertTrue(all(map(lambda op_val : op_val[1][0] <= max_contributions_per_partition, bound_op)))
+
+  def testContributionBounding_crossPartitionBoundingApplied(self):
+    inp_col = [("pid1", 'pk1' , 1),
+               ("pid1", 'pk1' , 2),
+               ("pid1", 'pk2' , 3),
+               ("pid1", 'pk2' , 4),
+               ("pid1", 'pk2' , 5),
+               ("pid1", 'pk3' , 6),
+               ("pid1", 'pk4' , 7),
+               ("pid2", 'pk4' , 8)]
+    max_partitions_contributed = 3
+    max_contributions_per_partition = 5
+
+    dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+    pipeline_dp.LocalPipelineOperations())
+    bound_op = dpEngine._bound_cross_partition_contributions(
+                          inp_col,
+                          max_partitions_contributed=max_partitions_contributed,
+                          max_contributions_per_partition=max_contributions_per_partition,
+                          aggregator_fn=DPEngineTest.aggregator_fn)
+
+    self.assertEqual(len(bound_op), 4)
+    self.assertTrue(all(map(lambda op_val : op_val[1][0] <= max_contributions_per_partition, bound_op)))
+    dict_of_pid_to_pk = defaultdict(lambda:[])
+    for key, _ in bound_op:
+      dict_of_pid_to_pk[key[0]].append(key[1])
+    self.assertEqual(len(dict_of_pid_to_pk), 2)
+    self.assertTrue(all(map(lambda key : len(dict_of_pid_to_pk[key]) <= max_partitions_contributed, dict_of_pid_to_pk)))
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -4,94 +4,96 @@ import unittest
 
 import pipeline_dp
 
+
 class DPEngineTest(unittest.TestCase):
+    aggregator_fn = lambda inp_values: (len(inp_values),
+                                        np.sum(inp_values),
+                                        np.sum(np.square(inp_values)))
 
-  aggregator_fn = lambda inp_values : (len(inp_values),
-                                           np.sum(inp_values),
-                                           np.sum(np.square(inp_values)))
+    def testContributionBounding_emptyCol(self):
+        inp_col = []
+        max_partitions_contributed = 2
+        max_contributions_per_partition = 2
 
-  def testContributionBounding_emptyCol(self):
-    inp_col = []
-    max_partitions_contributed = 2
-    max_contributions_per_partition = 2
+        dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+                                        pipeline_dp.LocalPipelineOperations())
+        bound_op = dpEngine._bound_cross_partition_contributions(
+            inp_col,
+            max_partitions_contributed=max_partitions_contributed,
+            max_contributions_per_partition=max_contributions_per_partition,
+            aggregator_fn=DPEngineTest.aggregator_fn)
 
-    dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-    pipeline_dp.LocalPipelineOperations())
-    bound_op = dpEngine._bound_cross_partition_contributions(
-                          inp_col,
-                          max_partitions_contributed=max_partitions_contributed,
-                          max_contributions_per_partition=max_contributions_per_partition,
-                          aggregator_fn=DPEngineTest.aggregator_fn)
+        self.assertFalse(bound_op)
 
-    self.assertFalse(bound_op)
+    def testContributionBounding_boundInput_nothingDropped(self):
+        inp_col = [("pid1", 'pk1', 1),
+                   ("pid1", 'pk1', 2),
+                   ("pid1", 'pk2', 3),
+                   ("pid1", 'pk2', 4)]
+        max_partitions_contributed = 2
+        max_contributions_per_partition = 2
 
-  def testContributionBounding_boundInput_nothingDropped(self):
-      inp_col = [("pid1", 'pk1' , 1),
-                 ("pid1", 'pk1' , 2),
-                 ("pid1", 'pk2' , 3),
-                 ("pid1", 'pk2' , 4)]
-      max_partitions_contributed = 2
-      max_contributions_per_partition = 2
+        dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+                                        pipeline_dp.LocalPipelineOperations())
+        bound_op = dpEngine._bound_cross_partition_contributions(
+            inp_col,
+            max_partitions_contributed=max_partitions_contributed,
+            max_contributions_per_partition=max_contributions_per_partition,
+            aggregator_fn=DPEngineTest.aggregator_fn)
 
-      dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-      pipeline_dp.LocalPipelineOperations())
-      bound_op = dpEngine._bound_cross_partition_contributions(
-                            inp_col,
-                            max_partitions_contributed=max_partitions_contributed,
-                            max_contributions_per_partition=max_contributions_per_partition,
-                            aggregator_fn=DPEngineTest.aggregator_fn)
+        expected_op = [(('pid1', 'pk2'), (2, 7, 25)), (('pid1', 'pk1'), (2, 3, 5))]
+        self.assertEqual(set(expected_op), set(bound_op))
 
-      expected_op = [(('pid1', 'pk2'), (2, 7, 25)), (('pid1', 'pk1'), (2, 3, 5))]
-      self.assertEqual(set(expected_op), set(bound_op))
+    def testContributionBounding_perPartitionBoundingApplied(self):
+        inp_col = [("pid1", 'pk1', 1),
+                   ("pid1", 'pk1', 2),
+                   ("pid1", 'pk2', 3),
+                   ("pid1", 'pk2', 4),
+                   ("pid1", 'pk2', 5),
+                   ("pid2", 'pk2', 6)]
+        max_partitions_contributed = 5
+        max_contributions_per_partition = 2
 
-  def testContributionBounding_perPartitionBoundingApplied(self):
-    inp_col = [("pid1", 'pk1' , 1),
-               ("pid1", 'pk1' , 2),
-               ("pid1", 'pk2' , 3),
-               ("pid1", 'pk2' , 4),
-               ("pid1", 'pk2' , 5),
-               ("pid2", 'pk2' , 6)]
-    max_partitions_contributed = 5
-    max_contributions_per_partition = 2
+        dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+                                        pipeline_dp.LocalPipelineOperations())
+        bound_op = dpEngine._bound_cross_partition_contributions(
+            inp_col,
+            max_partitions_contributed=max_partitions_contributed,
+            max_contributions_per_partition=max_contributions_per_partition,
+            aggregator_fn=DPEngineTest.aggregator_fn)
 
-    dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-    pipeline_dp.LocalPipelineOperations())
-    bound_op = dpEngine._bound_cross_partition_contributions(
-                          inp_col,
-                          max_partitions_contributed=max_partitions_contributed,
-                          max_contributions_per_partition=max_contributions_per_partition,
-                          aggregator_fn=DPEngineTest.aggregator_fn)
+        self.assertEqual(len(bound_op), 3)
+        self.assertTrue(all(map(lambda op_val: op_val[1][0] <= max_contributions_per_partition, bound_op)))
 
-    self.assertEqual(len(bound_op), 3)
-    self.assertTrue(all(map(lambda op_val : op_val[1][0] <= max_contributions_per_partition, bound_op)))
+    def testContributionBounding_crossPartitionBoundingApplied(self):
+        inp_col = [("pid1", 'pk1', 1),
+                   ("pid1", 'pk1', 2),
+                   ("pid1", 'pk2', 3),
+                   ("pid1", 'pk2', 4),
+                   ("pid1", 'pk2', 5),
+                   ("pid1", 'pk3', 6),
+                   ("pid1", 'pk4', 7),
+                   ("pid2", 'pk4', 8)]
+        max_partitions_contributed = 3
+        max_contributions_per_partition = 5
 
-  def testContributionBounding_crossPartitionBoundingApplied(self):
-    inp_col = [("pid1", 'pk1' , 1),
-               ("pid1", 'pk1' , 2),
-               ("pid1", 'pk2' , 3),
-               ("pid1", 'pk2' , 4),
-               ("pid1", 'pk2' , 5),
-               ("pid1", 'pk3' , 6),
-               ("pid1", 'pk4' , 7),
-               ("pid2", 'pk4' , 8)]
-    max_partitions_contributed = 3
-    max_contributions_per_partition = 5
+        dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
+                                        pipeline_dp.LocalPipelineOperations())
+        bound_op = dpEngine._bound_cross_partition_contributions(
+            inp_col,
+            max_partitions_contributed=max_partitions_contributed,
+            max_contributions_per_partition=max_contributions_per_partition,
+            aggregator_fn=DPEngineTest.aggregator_fn)
 
-    dpEngine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-10),
-    pipeline_dp.LocalPipelineOperations())
-    bound_op = dpEngine._bound_cross_partition_contributions(
-                          inp_col,
-                          max_partitions_contributed=max_partitions_contributed,
-                          max_contributions_per_partition=max_contributions_per_partition,
-                          aggregator_fn=DPEngineTest.aggregator_fn)
+        self.assertEqual(len(bound_op), 4)
+        self.assertTrue(all(map(lambda op_val: op_val[1][0] <= max_contributions_per_partition, bound_op)))
+        dict_of_pid_to_pk = defaultdict(lambda: [])
+        for key, _ in bound_op:
+            dict_of_pid_to_pk[key[0]].append(key[1])
+        self.assertEqual(len(dict_of_pid_to_pk), 2)
+        self.assertTrue(
+            all(map(lambda key: len(dict_of_pid_to_pk[key]) <= max_partitions_contributed, dict_of_pid_to_pk)))
 
-    self.assertEqual(len(bound_op), 4)
-    self.assertTrue(all(map(lambda op_val : op_val[1][0] <= max_contributions_per_partition, bound_op)))
-    dict_of_pid_to_pk = defaultdict(lambda:[])
-    for key, _ in bound_op:
-      dict_of_pid_to_pk[key[0]].append(key[1])
-    self.assertEqual(len(dict_of_pid_to_pk), 2)
-    self.assertTrue(all(map(lambda key : len(dict_of_pid_to_pk[key]) <= max_partitions_contributed, dict_of_pid_to_pk)))
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()

--- a/tests/pipeline_operations_test.py
+++ b/tests/pipeline_operations_test.py
@@ -39,6 +39,26 @@ class SparkRDDOperationsTest(unittest.TestCase):
         def tearDownClass(cls):
             cls.sc.stop()
 
+    def test_flat_map(self):
+      spark_operations = SparkRDDOperations()
+      data = [[1, 2, 3, 4], [5, 6, 7, 8]]
+      dist_data = SparkRDDOperationsTest.sc.parallelize(data)
+      self.assertEqual(spark_operations.flat_map(dist_data, lambda x:
+      x).collect(),
+                       [1, 2, 3, 4, 5, 6, 7, 8])
+
+      data = [("a", [1, 2, 3, 4]), ("b", [5, 6, 7, 8])]
+      dist_data = SparkRDDOperationsTest.sc.parallelize(data)
+      self.assertEqual(spark_operations.flat_map(dist_data, lambda x: x[
+        1]).collect(),
+                       [1, 2, 3, 4, 5, 6, 7, 8])
+      self.assertEqual(
+        spark_operations.flat_map(dist_data, lambda x: [(x[0], y) for
+                                                        y in x[
+                                                          1]]).collect(),
+        [("a", 1), ("a", 2), ("a", 3), ("a", 4),
+         ("b", 5), ("b", 6), ("b", 7), ("b", 8)])
+
 
 class LocalPipelineOperationsTest(unittest.TestCase):
     @classmethod
@@ -132,6 +152,52 @@ class LocalPipelineOperationsTest(unittest.TestCase):
         assert_laziness(self.ops.filter, bool)
         assert_laziness(self.ops.values)
         assert_laziness(self.ops.count_per_element)
+
+    def test_local_sample_fixed_per_key_requires_no_discarding(self):
+      input_col = [("pid1", ('pk1', 1)),
+                   ("pid1", ('pk2', 1)),
+                   ("pid1", ('pk3', 1)),
+                   ("pid2", ('pk4', 1))]
+      n = 3
+
+      sample_fixed_per_key_result = list(self.ops.sample_fixed_per_key(
+        input_col, n))
+
+      expected_result = [("pid1", [('pk1', 1), ('pk2', 1), ('pk3', 1)]),
+                         ("pid2", [('pk4', 1)])]
+      self.assertEqual(sample_fixed_per_key_result, expected_result)
+
+    def test_local_sample_fixed_per_key_with_sampling(self):
+      input_col = [(("pid1", "pk1"), 1),
+                   (("pid1", "pk1"), 1),
+                   (("pid1", "pk1"), 1),
+                   (("pid1", "pk1"), 1),
+                   (("pid1", "pk1"), 1),
+                   (("pid1", "pk2"), 1),
+                   (("pid1", "pk2"), 1)]
+      n = 3
+
+      sample_fixed_per_key_result = list(self.ops.sample_fixed_per_key(
+        input_col, n))
+
+      self.assertTrue(
+        all(map(lambda pid_pk_v: len(pid_pk_v[1]) <= n,
+                sample_fixed_per_key_result)))
+
+    def test_local_flat_map(self):
+      input_col = [[1, 2, 3, 4], [5, 6, 7, 8]]
+      self.assertEqual(list(self.ops.flat_map(input_col, lambda x: x)),
+                       [1, 2, 3, 4, 5, 6, 7, 8])
+
+      input_col = [("a", [1, 2, 3, 4]), ("b", [5, 6, 7, 8])]
+      self.assertEqual(list(self.ops.flat_map(input_col, lambda x: x[1])),
+                       [1, 2, 3, 4, 5, 6, 7, 8])
+      self.assertEqual(list(self.ops.flat_map(input_col,
+                                              lambda x: [(x[0], y) for
+                                                         y in x[1]]
+                                              )),
+                       [("a", 1), ("a", 2), ("a", 3), ("a", 4),
+                        ("b", 5), ("b", 6), ("b", 7), ("b", 8)])
 
 
 if __name__ == '__main__':

--- a/tests/pipeline_operations_test.py
+++ b/tests/pipeline_operations_test.py
@@ -152,6 +152,8 @@ class LocalPipelineOperationsTest(unittest.TestCase):
         assert_laziness(self.ops.filter, bool)
         assert_laziness(self.ops.values)
         assert_laziness(self.ops.count_per_element)
+        assert_laziness(self.ops.flat_map, str)
+        assert_laziness(self.ops.sample_fixed_per_key, int)
 
     def test_local_sample_fixed_per_key_requires_no_discarding(self):
       input_col = [("pid1", ('pk1', 1)),


### PR DESCRIPTION
## Description
Implementing Per partition - bounding of each contribution and cross partition. Added flat map in pipeline_operations.py to accommodate this functionality. Continuation of https://github.com/OpenMined/PipelineDP/pull/26

## How has this been tested?
- Unit tests for bounding

## Checklist
- [x ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
