### PR TITLE
PLD budget accountant

### DIFF
--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -1,7 +1,10 @@
 """Privacy budget accounting for DP pipelines."""
 
 import logging
+import math
 from dataclasses import dataclass
+from pipeline_dp.aggregate_params import NoiseKind
+from dp_accounting import privacy_loss_distribution as pldlib
 
 
 @dataclass
@@ -59,10 +62,8 @@ class BudgetAccountant:
         Args:
             epsilon, delta: Parameters of (epsilon, delta)-differential privacy.
         """
-        if epsilon <= 0:
-            raise ValueError(f"Epsilon must be positive, not {epsilon}.")
-        if delta < 0:
-            raise ValueError(f"Delta must be non-negative, not {delta}.")
+
+        _validate_epsilon_delta(epsilon, delta)
 
         self._eps = epsilon
         self._delta = delta
@@ -74,8 +75,8 @@ class BudgetAccountant:
 
         Args:
             weight: The weight used to compute epsilon and delta for the budget.
-            use_eps: A boolean that is False when the operation doesn't need epsilon.
-            use_delta: A boolean that is False when the operation doesn't need delta.
+            use_eps: False when the operation doesn't need epsilon.
+            use_delta: False when the operation doesn't need delta.
 
         Returns:
             A "lazy" budget object that doesn't contain epsilon/delta until the
@@ -87,7 +88,7 @@ class BudgetAccountant:
         return budget
 
     def compute_budgets(self):
-        """All previously requested Budget objects are updated with corresponding budget values."""
+        """Updates all previously requested Budget objects with corresponding budget values."""
         if not self._requested_budgets:
             logging.warning("No budgets were requested.")
             return
@@ -100,7 +101,205 @@ class BudgetAccountant:
         for requested_budget in self._requested_budgets:
             eps = delta = 0
             if total_weight_eps:
-                eps = requested_budget.use_eps * self._eps * requested_budget.weight / total_weight_eps
+                numerator = requested_budget.use_eps * self._eps * requested_budget.weight
+                eps = numerator / total_weight_eps
             if total_weight_delta:
-                delta = requested_budget.use_delta * self._delta * requested_budget.weight / total_weight_delta
+                numerator = requested_budget.use_delta * self._delta * requested_budget.weight
+                delta = numerator / total_weight_delta
             requested_budget.budget.set_eps_delta(eps, delta)
+
+
+@dataclass
+class MechanismSpec:
+    """Specifies the parameters for a mechanism.
+
+    NoiseKind defines the kind of noise distribution.
+    noise is the minimized noise standard deviation.
+    """
+    noise_kind: NoiseKind
+    _noise_standard_deviation: float = None
+
+    @property
+    def noise_standard_deviation(self):
+        """Noise value for the mechanism.
+
+        Raises:
+            AssertionError: The noise value is not calculated yet.
+        """
+        if self._noise_standard_deviation is None:
+            raise AssertionError(
+                "Noise standard deviation is not calculated yet.")
+        return self._noise_standard_deviation
+
+
+@dataclass
+class MechanismSpecInternal:
+    """Stores sensitivity and weight not exposed in MechanismSpec."""
+    sensitivity: float
+    weight: float
+    mechanism_spec: MechanismSpec
+
+
+class PLDBudgetAccountant:
+    """Manages the privacy budget for privacy loss distributions.
+
+    It manages the privacy budget for the pipeline using the
+    Privacy Loss Distribution (PLD) implementation from Google's
+    dp_accounting library.
+    """
+
+    def __init__(self,
+                 total_epsilon: float,
+                 total_delta: float,
+                 pld_discretization: float = 1e-4):
+        """Constructs a PLDBudgetAccountant.
+
+        Args:
+            total_epsilon: epsilon for the entire pipeline.
+            total_delta: delta for the entire pipeline.
+            pld_discretization: `value_discretization_interval` in PLD library.
+                Smaller interval results in better accuracy, but increases running time.
+
+        Raises:
+            ValueError: Arguments are missing or out of range.
+        """
+
+        _validate_epsilon_delta(total_epsilon, total_delta)
+
+        self._total_epsilon = total_epsilon
+        self._total_delta = total_delta
+        self._mechanisms = []
+        self.minimum_noise_std = None
+        self._pld_discretization = pld_discretization
+
+    def request_budget(self,
+                       noise_kind: NoiseKind,
+                       sensitivity: float = 1,
+                       weight: float = 1) -> MechanismSpec:
+        """Request a budget.
+
+        Constructs a mechanism spec based on the parameters.
+        Adds the mechanism to the pipeline for future calculation.
+
+        Args:
+            noise_kind: The kind of noise distribution for the mechanism.
+            sensitivity: The sensitivity for the mechanism.
+            weight: The weight for the mechanism.
+
+        Returns:
+            A "lazy" mechanism spec object that doesn't contain the noise
+            standard deviation until compute_budgets is called.
+        """
+        if noise_kind == NoiseKind.GAUSSIAN and self._total_delta == 0:
+            raise AssertionError("Gaussian delta value must be greater than 0")
+        mechanism_spec = MechanismSpec(noise_kind=noise_kind)
+        mechanism_spec_internal = MechanismSpecInternal(
+            mechanism_spec=mechanism_spec,
+            sensitivity=sensitivity,
+            weight=weight)
+        self._mechanisms.append(mechanism_spec_internal)
+        return mechanism_spec
+
+    def compute_budgets(self):
+        """Computes the budget for the pipeline.
+
+        Composes the mechanisms and adjusts the amount of
+        noise based on given epsilon. Sets the noise for the
+        entire pipeline.
+        """
+        if not self._mechanisms:
+            return
+        if self._total_delta == 0:
+            standard_noise = len(self._mechanisms) / self._total_epsilon
+            self.minimum_noise_std = 0
+            for mechanism in self._mechanisms:
+                mechanism_noise_std = mechanism.sensitivity * standard_noise / mechanism.weight
+                mechanism.mechanism_spec._noise_standard_deviation = mechanism_noise_std
+                self.minimum_noise_std = self.minimum_noise_std + mechanism_noise_std
+        else:
+            minimum_noise_std = self._find_minimum_noise_std()
+            self.minimum_noise_std = minimum_noise_std
+            for mechanism in self._mechanisms:
+                mechanism_noise_std = mechanism.sensitivity * minimum_noise_std / mechanism.weight
+                mechanism.mechanism_spec._noise_standard_deviation = mechanism_noise_std
+
+    def _find_minimum_noise_std(self) -> float:
+        """Finds the minimum noise which satisfies the total budget.
+
+        Use binary search to find a minimum noise value that gives a
+        new epsilon close to the given epsilon (within a threshold).
+        By increasing the noise we can decrease the epsilon.
+
+        Returns:
+            The noise value adjusted for the given epsilon.
+        """
+        threshold = 1e-4
+        maximum_noise_std = self._calculate_max_noise_std()
+        low, high = 0, maximum_noise_std
+        while low + threshold < high:
+            mid = (high - low) / 2 + low
+            pld = self._compose_distributions(mid)
+            pld_epsilon = pld.get_epsilon_for_delta(self._total_delta)
+            if pld_epsilon <= self._total_epsilon:
+                high = mid
+            elif pld_epsilon > self._total_epsilon:
+                low = mid
+
+        return high
+
+    def _calculate_max_noise_std(self) -> float:
+        """Calculates an upper bound for the noise to satisfy the budget."""
+        max_noise_std = 1
+        pld_epsilon = self._total_epsilon + 1
+        while pld_epsilon > self._total_epsilon:
+            max_noise_std *= 2
+            pld = self._compose_distributions(max_noise_std)
+            pld_epsilon = pld.get_epsilon_for_delta(self._total_delta)
+        return max_noise_std
+
+    def _compose_distributions(
+            self,
+            noise_standard_deviation: float) -> pldlib.PrivacyLossDistribution:
+        """Uses the Privacy Loss Distribution library to compose distributions.
+
+        Args:
+            noise_standard_deviation: The noise of the distributions to construct.
+
+        Returns:
+            A PrivacyLossDistribution object for the pipeline.
+        """
+        composed, pld = None, None
+
+        for mechanism_spec_internal in self._mechanisms:
+            if mechanism_spec_internal.mechanism_spec.noise_kind == NoiseKind.LAPLACE:
+                # The Laplace distribution parameter = std/sqrt(2).
+                pld = pldlib.PrivacyLossDistribution.from_laplace_mechanism(
+                    mechanism_spec_internal.sensitivity *
+                    noise_standard_deviation / math.sqrt(2) /
+                    mechanism_spec_internal.weight,
+                    value_discretization_interval=self._pld_discretization)
+            elif mechanism_spec_internal.mechanism_spec.noise_kind == NoiseKind.GAUSSIAN:
+                pld = pldlib.PrivacyLossDistribution.from_gaussian_mechanism(
+                    mechanism_spec_internal.sensitivity *
+                    noise_standard_deviation / mechanism_spec_internal.weight,
+                    value_discretization_interval=self._pld_discretization)
+
+            composed = pld if composed is None else composed.compose(pld)
+
+        return composed
+
+
+def _validate_epsilon_delta(epsilon: float, delta: float):
+    """Helper function to validate the epsilon and delta parameters.
+
+    Args:
+        epsilon: The epsilon value to validate.
+        delta: The delta value to validate.
+
+    Raises:
+        A ValueError if either epsilon or delta are out of range.
+    """
+    if epsilon <= 0:
+        raise ValueError(f"Epsilon must be positive, not {epsilon}.")
+    if delta < 0:
+        raise ValueError(f"Delta must be non-negative, not {delta}.")

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,3 +5,4 @@ pyspark
 pytest
 pylint
 yapf
+git+https://github.com/google/differential-privacy.git@327972c1ae710e8cd0a4754fffdd78c3500272ee#subdirectory=python

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -1,8 +1,13 @@
+"""Budget Accounting Test"""
+
 import unittest
-
+from dataclasses import dataclass
 import pipeline_dp
+from pipeline_dp.aggregate_params import NoiseKind
+from pipeline_dp.budget_accounting import MechanismSpec, PLDBudgetAccountant
 
 
+# pylint: disable=protected-access
 class BudgetAccountantTest(unittest.TestCase):
 
     def test_validation(self):
@@ -46,6 +51,177 @@ class BudgetAccountantTest(unittest.TestCase):
 
         self.assertEqual(budget2.eps, 0.75)
         self.assertEqual(budget2.delta, 1e-6)
+
+
+class PLDBudgetAccountantTest(unittest.TestCase):
+
+    def test_noise_not_calculated(self):
+        with self.assertRaises(AssertionError):
+            mechanism = MechanismSpec(NoiseKind.LAPLACE)
+            print(mechanism.noise_standard_deviation())
+
+    def test_invalid_epsilon(self):
+        with self.assertRaises(ValueError):
+            PLDBudgetAccountant(total_epsilon=0, total_delta=1e-5)
+
+    def test_invalid_delta(self):
+        with self.assertRaises(ValueError):
+            PLDBudgetAccountant(total_epsilon=1, total_delta=-1e-5)
+
+    def test_invalid_gaussian_delta(self):
+        accountant = PLDBudgetAccountant(total_epsilon=1, total_delta=0)
+        with self.assertRaises(AssertionError):
+            accountant.request_budget(NoiseKind.GAUSSIAN)
+
+    def test_compute_budgets_none_noise(self):
+        accountant = PLDBudgetAccountant(total_epsilon=3, total_delta=1e-5)
+        accountant.compute_budgets()
+        self.assertEqual(None, accountant.minimum_noise_std)
+
+    def test_compute_budgets(self):
+
+        @dataclass
+        class ComputeBudgetMechanisms:
+            count: int
+            expected_noise_std: float
+            noise_kind: NoiseKind
+            weight: float
+            sensitivity: float
+
+        @dataclass
+        class ComputeBudgetTestCase:
+            name: str
+            epsilon: float
+            delta: float
+            expected_pipeline_noise_std: float
+            mechanisms: []
+
+        testcases = [
+
+            ComputeBudgetTestCase(name="standard_laplace",
+                                  epsilon=4,
+                                  delta=0,
+                                  mechanisms=[
+                                      ComputeBudgetMechanisms(
+                                          2, 0.5, NoiseKind.LAPLACE, 1, 1)
+                                  ],
+                                  expected_pipeline_noise_std=1),
+            ComputeBudgetTestCase(name="standard_laplace_weights",
+                                  epsilon=4,
+                                  delta=0,
+                                  mechanisms=[
+                                      ComputeBudgetMechanisms(
+                                          2, 0.25, NoiseKind.LAPLACE, 2, 1)
+                                  ],
+                                  expected_pipeline_noise_std=0.5),
+            ComputeBudgetTestCase(name="standard_laplace_sensitivities",
+                                  epsilon=3,
+                                  delta=0,
+                                  mechanisms=[
+                                      ComputeBudgetMechanisms(
+                                          2, 2, NoiseKind.LAPLACE, 1, 3)
+                                  ],
+                                  expected_pipeline_noise_std=4),
+            ComputeBudgetTestCase(name="laplace_mechanisms",
+                                  epsilon=0.19348133991361996,
+                                  delta=1e-3,
+                                  mechanisms=[
+                                      ComputeBudgetMechanisms(
+                                          10, 50, NoiseKind.LAPLACE, 1, 1)
+                                  ],
+                                  expected_pipeline_noise_std=50),
+            ComputeBudgetTestCase(name="gaussian_mechanisms",
+                                  epsilon=0.16421041618759222,
+                                  delta=1e-3,
+                                  mechanisms=[
+                                      ComputeBudgetMechanisms(
+                                          10, 50, NoiseKind.GAUSSIAN, 1, 1)
+                                  ],
+                                  expected_pipeline_noise_std=50),
+            ComputeBudgetTestCase(
+                name="multiple_noise_kinds",
+                epsilon=0.17915869168056622,
+                delta=1e-3,
+                mechanisms=[
+                    ComputeBudgetMechanisms(5, 50, NoiseKind.LAPLACE, 1, 1),
+                    ComputeBudgetMechanisms(5, 50, NoiseKind.GAUSSIAN, 1, 1)
+                ],
+                expected_pipeline_noise_std=50),
+            ComputeBudgetTestCase(
+                name="multiple_weights",
+                epsilon=1.924852037917208,
+                delta=1e-5,
+                mechanisms=[
+                    ComputeBudgetMechanisms(4, 10, NoiseKind.LAPLACE, 2, 1),
+                    ComputeBudgetMechanisms(4, 5, NoiseKind.GAUSSIAN, 4, 1)
+                ],
+                expected_pipeline_noise_std=20),
+            ComputeBudgetTestCase(
+                name="multiple_sensitivities",
+                epsilon=0.2764312848667339,
+                delta=1e-5,
+                mechanisms=[
+                    ComputeBudgetMechanisms(6, 40, NoiseKind.LAPLACE, 1, 2),
+                    ComputeBudgetMechanisms(2, 80, NoiseKind.GAUSSIAN, 1, 4)
+                ],
+                expected_pipeline_noise_std=20),
+            ComputeBudgetTestCase(
+                name="multiple_weights_and_sensitivities",
+                epsilon=0.780797891312483,
+                delta=1e-5,
+                mechanisms=[
+                    ComputeBudgetMechanisms(4, 10, NoiseKind.LAPLACE, 4, 2),
+                    ComputeBudgetMechanisms(6, 40, NoiseKind.GAUSSIAN, 2, 4)
+                ],
+                expected_pipeline_noise_std=20),
+            ComputeBudgetTestCase(
+                name="multiple_weights_and_sensitivities_variants",
+                epsilon=0.9165937807680077,
+                delta=1e-6,
+                mechanisms=[
+                    ComputeBudgetMechanisms(4, 20, NoiseKind.LAPLACE, 4, 2),
+                    ComputeBudgetMechanisms(6, 80, NoiseKind.GAUSSIAN, 2, 4),
+                    ComputeBudgetMechanisms(1, 80, NoiseKind.GAUSSIAN, 3, 6),
+                    ComputeBudgetMechanisms(5, 15, NoiseKind.LAPLACE, 8, 3),
+                ],
+                expected_pipeline_noise_std=40)
+        ]
+
+        for case in testcases:
+            accountant = PLDBudgetAccountant(case.epsilon, case.delta, 1e-2)
+            actual_mechanisms = []
+            for mechanism in case.mechanisms:
+                for _ in range(0, mechanism.count):
+                    actual_mechanisms.append(
+                        (mechanism.expected_noise_std,
+                         accountant.request_budget(
+                             mechanism.noise_kind,
+                             weight=mechanism.weight,
+                             sensitivity=mechanism.sensitivity)))
+            self.assertEqual(
+                len(actual_mechanisms), len(accountant._mechanisms),
+                f"failed test {case.name} expected len {len(actual_mechanisms)} "
+                f"got len {len(accountant._mechanisms)}")
+            if case.delta > 0:
+                compare_pld = accountant._compose_distributions(
+                    case.expected_pipeline_noise_std)
+                actual_epsilon = compare_pld.get_epsilon_for_delta(case.delta)
+                self.assertAlmostEqual(
+                    case.epsilon, actual_epsilon, 3,
+                    f"failed test {case.name} expected epsilon {case.epsilon} got {actual_epsilon}"
+                )
+            accountant.compute_budgets()
+            self.assertEqual(
+                case.expected_pipeline_noise_std, accountant.minimum_noise_std,
+                f"failed test {case.name} expected pipeline noise {case.expected_pipeline_noise_std} "
+                f"got {accountant.minimum_noise_std}")
+            for actual_mechanism_tuple in actual_mechanisms:
+                expected_mechanism_noise_std, actual_mechanism = actual_mechanism_tuple
+                self.assertEqual(
+                    expected_mechanism_noise_std,
+                    actual_mechanism.noise_standard_deviation,
+                    f"failed test {case.name} expected mechanism noise {expected_mechanism_noise_std} "
+                    f"got {actual_mechanism.noise_standard_deviation}")
 
 
 if __name__ == '__main__':

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -97,31 +97,30 @@ class PLDBudgetAccountantTest(unittest.TestCase):
             mechanisms: []
 
         testcases = [
-
             ComputeBudgetTestCase(name="standard_laplace",
                                   epsilon=4,
                                   delta=0,
                                   mechanisms=[
                                       ComputeBudgetMechanisms(
-                                          2, 0.5, NoiseKind.LAPLACE, 1, 1)
+                                          2, 0.25, NoiseKind.LAPLACE, 1, 1)
                                   ],
-                                  expected_pipeline_noise_std=1),
+                                  expected_pipeline_noise_std=0.5),
             ComputeBudgetTestCase(name="standard_laplace_weights",
                                   epsilon=4,
                                   delta=0,
                                   mechanisms=[
                                       ComputeBudgetMechanisms(
-                                          2, 0.25, NoiseKind.LAPLACE, 2, 1)
+                                          2, 0.125, NoiseKind.LAPLACE, 2, 1)
                                   ],
-                                  expected_pipeline_noise_std=0.5),
+                                  expected_pipeline_noise_std=0.25),
             ComputeBudgetTestCase(name="standard_laplace_sensitivities",
                                   epsilon=3,
                                   delta=0,
                                   mechanisms=[
                                       ComputeBudgetMechanisms(
-                                          2, 2, NoiseKind.LAPLACE, 1, 3)
+                                          2, 1, NoiseKind.LAPLACE, 1, 3)
                                   ],
-                                  expected_pipeline_noise_std=4),
+                                  expected_pipeline_noise_std=2),
             ComputeBudgetTestCase(name="laplace_mechanisms",
                                   epsilon=0.19348133991361996,
                                   delta=1e-3,

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -102,25 +102,25 @@ class PLDBudgetAccountantTest(unittest.TestCase):
                                   delta=0,
                                   mechanisms=[
                                       ComputeBudgetMechanisms(
-                                          2, 0.25, NoiseKind.LAPLACE, 1, 1)
+                                          2, 0.7071067811865476, NoiseKind.LAPLACE, 1, 1)
                                   ],
-                                  expected_pipeline_noise_std=0.5),
+                                  expected_pipeline_noise_std=0.7071067811865476),
             ComputeBudgetTestCase(name="standard_laplace_weights",
                                   epsilon=4,
                                   delta=0,
                                   mechanisms=[
                                       ComputeBudgetMechanisms(
-                                          2, 0.125, NoiseKind.LAPLACE, 2, 1)
+                                          2, 0.7071067811865476, NoiseKind.LAPLACE, 2, 1)
                                   ],
-                                  expected_pipeline_noise_std=0.25),
+                                  expected_pipeline_noise_std=1.4142135623730951),
             ComputeBudgetTestCase(name="standard_laplace_sensitivities",
                                   epsilon=3,
                                   delta=0,
                                   mechanisms=[
                                       ComputeBudgetMechanisms(
-                                          2, 1, NoiseKind.LAPLACE, 1, 3)
+                                          2, 2.82842712474619, NoiseKind.LAPLACE, 1, 3)
                                   ],
-                                  expected_pipeline_noise_std=2),
+                                  expected_pipeline_noise_std=0.9428090415820634),
             ComputeBudgetTestCase(name="laplace_mechanisms",
                                   epsilon=0.19348133991361996,
                                   delta=1e-3,


### PR DESCRIPTION
## Description

Functionality that gives the user the ability to input epsilon and delta values, compute a pipeline budget where the noise is adjusted for the given epsilon.

_Input_: Epsilon and Delta, _Output_: Minimized noise

Related to #35 

## Affected Dependencies

N/A

## How has this been tested?

Unit tests where the calculated noise value is compared to the noise value returned by the PLD library for the same epsilon and delta. 

eg. 
```
compare_pld = accountant._compose_distributions(expected_noise)
self.assertAlmostEqual(epsilon, compare_pld.get_epsilon_for_delta(delta), 3)
```
The `expected_noise` should match the calculated noise from PipelineDP because the same epsilon and delta are input.

```
accountant = PLDBudgetAccountant(epsilon, delta)
accountant.compute_budgets()
self.assertEqual(expected_noise, accountant.minimum_noise)
```

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
