### PR TITLE
Implement reduce_accumulators_per_key in BeamOperations.

### DIFF
--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -5,6 +5,7 @@ import pipeline_dp
 
 from dataclasses import dataclass
 
+
 @dataclass
 class MeanVarParams:
     """The parameters used for computing the dp sum, count, mean, variance."""
@@ -23,7 +24,8 @@ class MeanVarParams:
         if metric == pipeline_dp.Metrics.COUNT:
             return self.max_contributions_per_partition
         if metric == pipeline_dp.Metrics.SUM:
-            return self.max_contributions_per_partition * max(abs(self.low), abs(self.high))
+            return self.max_contributions_per_partition * max(
+                abs(self.low), abs(self.high))
         # TODO: add values for mean and variance
         raise ValueError("Invalid metric")
 
@@ -47,19 +49,23 @@ def apply_laplace_mechanism(value: float, eps: float, l1_sensitivity: float):
     return value + np.random.laplace(0, l1_sensitivity / eps)
 
 
-def apply_gaussian_mechanism(value: float, eps: float, delta: float, l2_sensitivity: float):
+def apply_gaussian_mechanism(value: float, eps: float, delta: float,
+                             l2_sensitivity: float):
     sigma = compute_sigma(eps, delta, l2_sensitivity)
     # TODO: use the secure noise instead of np.random
     return value + np.random.normal(0, sigma)
 
 
-def _add_random_noise(value: float, eps: float, delta: float, l0_sensitivity: float,
-                      linf_sensitivity: float, noise_kind: pipeline_dp.NoiseKind):
+def _add_random_noise(value: float, eps: float, delta: float,
+                      l0_sensitivity: float, linf_sensitivity: float,
+                      noise_kind: pipeline_dp.NoiseKind):
     if noise_kind == pipeline_dp.NoiseKind.LAPLACE:
-        l1_sensitivity = compute_l1_sensitivity(l0_sensitivity, linf_sensitivity)
+        l1_sensitivity = compute_l1_sensitivity(l0_sensitivity,
+                                                linf_sensitivity)
         return apply_laplace_mechanism(value, eps, l1_sensitivity)
     if noise_kind == pipeline_dp.NoiseKind.GAUSSIAN:
-        l2_sensitivity = compute_l2_sensitivity(l0_sensitivity, linf_sensitivity)
+        l2_sensitivity = compute_l2_sensitivity(l0_sensitivity,
+                                                linf_sensitivity)
         return apply_gaussian_mechanism(value, eps, delta, l2_sensitivity)
     raise ValueError("Noise kind must be either Laplace or Gaussian.")
 
@@ -77,8 +83,9 @@ def compute_dp_count(count: int, dp_params: MeanVarParams):
     l0_sensitivity = dp_params.l0_sensitivity()
     linf_sensitivity = dp_params.linf_sensitivity(pipeline_dp.Metrics.COUNT)
 
-    return _add_random_noise(count, dp_params.eps, dp_params.delta, l0_sensitivity,
-                             linf_sensitivity, dp_params.noise_kind)
+    return _add_random_noise(count, dp_params.eps, dp_params.delta,
+                             l0_sensitivity, linf_sensitivity,
+                             dp_params.noise_kind)
 
 
 def compute_dp_sum(sum: float, dp_params: MeanVarParams):
@@ -94,5 +101,6 @@ def compute_dp_sum(sum: float, dp_params: MeanVarParams):
     l0_sensitivity = dp_params.l0_sensitivity()
     linf_sensitivity = dp_params.linf_sensitivity(pipeline_dp.Metrics.SUM)
 
-    return _add_random_noise(sum, dp_params.eps, dp_params.delta, l0_sensitivity, linf_sensitivity,
+    return _add_random_noise(sum, dp_params.eps, dp_params.delta,
+                             l0_sensitivity, linf_sensitivity,
                              dp_params.noise_kind)

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -71,7 +71,7 @@ class PipelineOperations(abc.ABC):
 
     @abc.abstractmethod
     def reduce_accumulators_per_key(self, col, stage_name: str):
-        """Reduce the input collection so that all elements per each key are merged.
+        """Reduces the input collection so that all elements per each key are merged.
 
             Args:
               col: input collection which contains tuples (key, accumulator)
@@ -175,7 +175,7 @@ class BeamOperations(PipelineOperations):
         return col | stage_name >> combiners.Count.PerElement()
 
     def reduce_accumulators_per_key(self, col, stage_name: str = None):
-
+        # TODO: Use merge function from the accumulator framework.
         def merge_accumulators(accumulators):
             res = None
             for acc in accumulators:

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -175,6 +175,7 @@ class BeamOperations(PipelineOperations):
         return col | stage_name >> combiners.Count.PerElement()
 
     def reduce_accumulators_per_key(self, col, stage_name: str = None):
+
         def merge_accumulators(accumulators):
             res = None
             for acc in accumulators:
@@ -183,6 +184,7 @@ class BeamOperations(PipelineOperations):
                 else:
                     res = acc
             return res
+
         return col | stage_name >> beam.CombinePerKey(merge_accumulators)
 
 

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -69,6 +69,20 @@ class PipelineOperations(abc.ABC):
     def count_per_element(self, col, stage_name: str):
         pass
 
+    @abc.abstractmethod
+    def reduce_accumulators_per_key(self, col, stage_name: str):
+        """Reduce the input collection so that all elements per each key are merged.
+
+            Args:
+              col: input collection which contains tuples (key, accumulator)
+              stage_name: name of the stage
+
+            Returns:
+              A collection of tuples (key, accumulator).
+
+            """
+        pass
+
 
 class BeamOperations(PipelineOperations):
     """Apache Beam adapter."""
@@ -160,6 +174,17 @@ class BeamOperations(PipelineOperations):
     def count_per_element(self, col, stage_name: str):
         return col | stage_name >> combiners.Count.PerElement()
 
+    def reduce_accumulators_per_key(self, col, stage_name: str = None):
+        def merge_accumulators(accumulators):
+            res = None
+            for acc in accumulators:
+                if res:
+                    res.add_accumulator(acc)
+                else:
+                    res = acc
+            return res
+        return col | stage_name >> beam.CombinePerKey(merge_accumulators)
+
 
 class SparkRDDOperations(PipelineOperations):
     """Apache Spark RDD adapter."""
@@ -227,6 +252,9 @@ class SparkRDDOperations(PipelineOperations):
         return rdd.map(lambda x: (x, 1))\
             .reduceByKey(lambda x, y: (x + y))
 
+    def reduce_accumulators_per_key(self, col, stage_name: str = None):
+        raise NotImplementedError()
+
 
 class LocalPipelineOperations(PipelineOperations):
     """Local Pipeline adapter."""
@@ -292,3 +320,6 @@ class LocalPipelineOperations(PipelineOperations):
 
     def count_per_element(self, col, stage_name: typing.Optional[str] = None):
         yield from collections.Counter(col).items()
+
+    def reduce_accumulators_per_key(self, col, stage_name: str = None):
+        raise NotImplementedError()

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -97,30 +97,33 @@ class PLDBudgetAccountantTest(unittest.TestCase):
             mechanisms: []
 
         testcases = [
-            ComputeBudgetTestCase(name="standard_laplace",
-                                  epsilon=4,
-                                  delta=0,
-                                  mechanisms=[
-                                      ComputeBudgetMechanisms(
-                                          2, 0.7071067811865476, NoiseKind.LAPLACE, 1, 1)
-                                  ],
-                                  expected_pipeline_noise_std=0.7071067811865476),
-            ComputeBudgetTestCase(name="standard_laplace_weights",
-                                  epsilon=4,
-                                  delta=0,
-                                  mechanisms=[
-                                      ComputeBudgetMechanisms(
-                                          2, 0.7071067811865476, NoiseKind.LAPLACE, 2, 1)
-                                  ],
-                                  expected_pipeline_noise_std=1.4142135623730951),
-            ComputeBudgetTestCase(name="standard_laplace_sensitivities",
-                                  epsilon=3,
-                                  delta=0,
-                                  mechanisms=[
-                                      ComputeBudgetMechanisms(
-                                          2, 2.82842712474619, NoiseKind.LAPLACE, 1, 3)
-                                  ],
-                                  expected_pipeline_noise_std=0.9428090415820634),
+            ComputeBudgetTestCase(
+                name="standard_laplace",
+                epsilon=4,
+                delta=0,
+                mechanisms=[
+                    ComputeBudgetMechanisms(2, 0.7071067811865476,
+                                            NoiseKind.LAPLACE, 1, 1)
+                ],
+                expected_pipeline_noise_std=0.7071067811865476),
+            ComputeBudgetTestCase(
+                name="standard_laplace_weights",
+                epsilon=4,
+                delta=0,
+                mechanisms=[
+                    ComputeBudgetMechanisms(2, 0.7071067811865476,
+                                            NoiseKind.LAPLACE, 2, 1)
+                ],
+                expected_pipeline_noise_std=1.4142135623730951),
+            ComputeBudgetTestCase(
+                name="standard_laplace_sensitivities",
+                epsilon=3,
+                delta=0,
+                mechanisms=[
+                    ComputeBudgetMechanisms(2, 2.82842712474619,
+                                            NoiseKind.LAPLACE, 1, 3)
+                ],
+                expected_pipeline_noise_std=0.9428090415820634),
             ComputeBudgetTestCase(name="laplace_mechanisms",
                                   epsilon=0.19348133991361996,
                                   delta=1e-3,

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -7,125 +7,170 @@ from pipeline_dp.dp_computations import *
 
 
 class MeanVarParams(unittest.TestCase):
+
     def test_l0_sensitivity(self):
-        params = pipeline_dp.dp_computations.MeanVarParams(eps=1, delta=1e-10, low=2, high=3,
-                                                           max_partitions_contributed=4,
-                                                           max_contributions_per_partition=5,
-                                                           noise_kind=pipeline_dp.NoiseKind.LAPLACE)
+        params = pipeline_dp.dp_computations.MeanVarParams(
+            eps=1,
+            delta=1e-10,
+            low=2,
+            high=3,
+            max_partitions_contributed=4,
+            max_contributions_per_partition=5,
+            noise_kind=pipeline_dp.NoiseKind.LAPLACE)
         self.assertEqual(params.l0_sensitivity(), 4)
 
     def test_l1_sensitivity(self):
-        self.assertEqual(pipeline_dp.dp_computations.compute_l1_sensitivity(l0_sensitivity=4,
-                                                                            linf_sensitivity=12),
-                         48)
+        self.assertEqual(
+            pipeline_dp.dp_computations.compute_l1_sensitivity(
+                l0_sensitivity=4, linf_sensitivity=12), 48)
 
     def test_l2_sensitivity(self):
-        self.assertEqual(pipeline_dp.dp_computations.compute_l2_sensitivity(l0_sensitivity=4,
-                                                                            linf_sensitivity=12),
-                         24)
+        self.assertEqual(
+            pipeline_dp.dp_computations.compute_l2_sensitivity(
+                l0_sensitivity=4, linf_sensitivity=12), 24)
 
     def test_linf_sensitivity(self):
-        params = pipeline_dp.dp_computations.MeanVarParams(eps=1, delta=1e-10, low=2, high=3,
-                                                           max_partitions_contributed=4,
-                                                           max_contributions_per_partition=5,
-                                                           noise_kind=pipeline_dp.NoiseKind.LAPLACE)
+        params = pipeline_dp.dp_computations.MeanVarParams(
+            eps=1,
+            delta=1e-10,
+            low=2,
+            high=3,
+            max_partitions_contributed=4,
+            max_contributions_per_partition=5,
+            noise_kind=pipeline_dp.NoiseKind.LAPLACE)
 
         # COUNT aggregation
-        self.assertEqual(params.linf_sensitivity(metric=pipeline_dp.Metrics.COUNT), 5)
+        self.assertEqual(
+            params.linf_sensitivity(metric=pipeline_dp.Metrics.COUNT), 5)
 
         # SUM aggregation
         # Positive low, positive high
-        self.assertEqual(params.linf_sensitivity(metric=pipeline_dp.Metrics.SUM), 15)
+        self.assertEqual(
+            params.linf_sensitivity(metric=pipeline_dp.Metrics.SUM), 15)
 
         # Negative low, positive high
         params.low = -2
-        self.assertEqual(params.linf_sensitivity(metric=pipeline_dp.Metrics.SUM), 15)
+        self.assertEqual(
+            params.linf_sensitivity(metric=pipeline_dp.Metrics.SUM), 15)
 
         # Negative low, negative high
         params.high = -1
-        self.assertEqual(params.linf_sensitivity(metric=pipeline_dp.Metrics.SUM), 10)
+        self.assertEqual(
+            params.linf_sensitivity(metric=pipeline_dp.Metrics.SUM), 10)
 
     def test_compute_sigma(self):
         self.assertEqual(
-            pipeline_dp.dp_computations.compute_sigma(eps=1, delta=1, l2_sensitivity=10),
+            pipeline_dp.dp_computations.compute_sigma(eps=1,
+                                                      delta=1,
+                                                      l2_sensitivity=10),
             np.sqrt(2 * np.log(1.25)) * 10)
         self.assertEqual(
-            pipeline_dp.dp_computations.compute_sigma(eps=0.5, delta=1e-10, l2_sensitivity=10),
+            pipeline_dp.dp_computations.compute_sigma(eps=0.5,
+                                                      delta=1e-10,
+                                                      l2_sensitivity=10),
             np.sqrt(2 * np.log(1.25 / 1e-10)) * 20)
 
     def _test_laplace_noise(self, results, value, eps, l1_sensitivity):
         self.assertAlmostEqual(np.mean(results), value, delta=0.1)
-        self.assertAlmostEqual(np.std(results), np.sqrt(2) * l1_sensitivity / eps, delta=0.1)
+        self.assertAlmostEqual(np.std(results),
+                               np.sqrt(2) * l1_sensitivity / eps,
+                               delta=0.1)
         self.assertAlmostEqual(skew(results), 0, delta=0.1)
         self.assertAlmostEqual(kurtosis(results), 3, delta=0.1)
 
     def _test_gaussian_noise(self, results, value, eps, delta, l2_sensitivity):
         self.assertAlmostEqual(np.mean(results), value, delta=0.1)
         self.assertAlmostEqual(np.std(results),
-                               pipeline_dp.dp_computations.compute_sigma(eps, delta,
-                                                                         l2_sensitivity),
+                               pipeline_dp.dp_computations.compute_sigma(
+                                   eps, delta, l2_sensitivity),
                                delta=0.1)
         self.assertAlmostEqual(skew(results), 0, delta=0.1)
         self.assertAlmostEqual(kurtosis(results), 0, delta=0.1)
 
     def test_apply_laplace_mechanism(self):
         results = [
-            pipeline_dp.dp_computations.apply_laplace_mechanism(value=20, eps=0.5, l1_sensitivity=1)
-            for _ in range(1000000)]
+            pipeline_dp.dp_computations.apply_laplace_mechanism(
+                value=20, eps=0.5, l1_sensitivity=1) for _ in range(1000000)
+        ]
         self._test_laplace_noise(results, value=20, eps=0.5, l1_sensitivity=1)
 
     def test_apply_gaussian_mechanism(self):
         results = [
-            pipeline_dp.dp_computations.apply_gaussian_mechanism(value=20, eps=0.5, delta=1e-10,
-                                                                 l2_sensitivity=1) for _ in
-            range(1000000)]
-        self._test_gaussian_noise(results, value=20, eps=0.5, delta=1e-10, l2_sensitivity=1)
+            pipeline_dp.dp_computations.apply_gaussian_mechanism(
+                value=20, eps=0.5, delta=1e-10, l2_sensitivity=1)
+            for _ in range(1000000)
+        ]
+        self._test_gaussian_noise(results,
+                                  value=20,
+                                  eps=0.5,
+                                  delta=1e-10,
+                                  l2_sensitivity=1)
 
     def test_compute_dp_count(self):
-        params = pipeline_dp.dp_computations.MeanVarParams(eps=0.5, delta=1e-10, low=2, high=3,
-                                                           max_partitions_contributed=1,
-                                                           max_contributions_per_partition=1,
-                                                           noise_kind=pipeline_dp.NoiseKind.LAPLACE)
+        params = pipeline_dp.dp_computations.MeanVarParams(
+            eps=0.5,
+            delta=1e-10,
+            low=2,
+            high=3,
+            max_partitions_contributed=1,
+            max_contributions_per_partition=1,
+            noise_kind=pipeline_dp.NoiseKind.LAPLACE)
         l0_sensitivity = params.l0_sensitivity()
         linf_sensitivity = params.linf_sensitivity(pipeline_dp.Metrics.COUNT)
 
         # Laplace Mechanism
-        l1_sensitivity = pipeline_dp.dp_computations.compute_l1_sensitivity(l0_sensitivity,
-                                                                            linf_sensitivity)
-        results = [pipeline_dp.dp_computations.compute_dp_count(count=10, dp_params=params) for _ in
-                   range(1000000)]
+        l1_sensitivity = pipeline_dp.dp_computations.compute_l1_sensitivity(
+            l0_sensitivity, linf_sensitivity)
+        results = [
+            pipeline_dp.dp_computations.compute_dp_count(count=10,
+                                                         dp_params=params)
+            for _ in range(1000000)
+        ]
         self._test_laplace_noise(results, 10, params.eps, l1_sensitivity)
 
         # Gaussian Mechanism
         params.noise_kind = pipeline_dp.NoiseKind.GAUSSIAN
-        l2_sensitivity = pipeline_dp.dp_computations.compute_l2_sensitivity(l0_sensitivity,
-                                                                            linf_sensitivity)
-        results = [pipeline_dp.dp_computations.compute_dp_count(count=10, dp_params=params) for _ in
-                   range(1000000)]
-        self._test_gaussian_noise(results, 10, params.eps, params.delta, l2_sensitivity)
+        l2_sensitivity = pipeline_dp.dp_computations.compute_l2_sensitivity(
+            l0_sensitivity, linf_sensitivity)
+        results = [
+            pipeline_dp.dp_computations.compute_dp_count(count=10,
+                                                         dp_params=params)
+            for _ in range(1000000)
+        ]
+        self._test_gaussian_noise(results, 10, params.eps, params.delta,
+                                  l2_sensitivity)
 
     def test_compute_dp_sum(self):
-        params = pipeline_dp.dp_computations.MeanVarParams(eps=0.5, delta=1e-10, low=2, high=3,
-                                                           max_partitions_contributed=1,
-                                                           max_contributions_per_partition=1,
-                                                           noise_kind=pipeline_dp.NoiseKind.LAPLACE)
+        params = pipeline_dp.dp_computations.MeanVarParams(
+            eps=0.5,
+            delta=1e-10,
+            low=2,
+            high=3,
+            max_partitions_contributed=1,
+            max_contributions_per_partition=1,
+            noise_kind=pipeline_dp.NoiseKind.LAPLACE)
         l0_sensitivity = params.l0_sensitivity()
         linf_sensitivity = params.linf_sensitivity(pipeline_dp.Metrics.SUM)
 
         # Laplace Mechanism
-        l1_sensitivity = pipeline_dp.dp_computations.compute_l1_sensitivity(l0_sensitivity,
-                                                                            linf_sensitivity)
-        results = [pipeline_dp.dp_computations.compute_dp_sum(sum=10, dp_params=params) for _ in
-                   range(1000000)]
+        l1_sensitivity = pipeline_dp.dp_computations.compute_l1_sensitivity(
+            l0_sensitivity, linf_sensitivity)
+        results = [
+            pipeline_dp.dp_computations.compute_dp_sum(sum=10, dp_params=params)
+            for _ in range(1000000)
+        ]
         self._test_laplace_noise(results, 10, params.eps, l1_sensitivity)
 
         # Gaussian Mechanism
         params.noise_kind = pipeline_dp.NoiseKind.GAUSSIAN
-        l2_sensitivity = pipeline_dp.dp_computations.compute_l2_sensitivity(l0_sensitivity,
-                                                                            linf_sensitivity)
-        results = [pipeline_dp.dp_computations.compute_dp_sum(sum=10, dp_params=params) for _ in
-                   range(1000000)]
-        self._test_gaussian_noise(results, 10, params.eps, params.delta, l2_sensitivity)
+        l2_sensitivity = pipeline_dp.dp_computations.compute_l2_sensitivity(
+            l0_sensitivity, linf_sensitivity)
+        results = [
+            pipeline_dp.dp_computations.compute_dp_sum(sum=10, dp_params=params)
+            for _ in range(1000000)
+        ]
+        self._test_gaussian_noise(results, 10, params.eps, params.delta,
+                                  l2_sensitivity)
 
 
 if __name__ == '__main__':

--- a/tests/pipeline_operations_test.py
+++ b/tests/pipeline_operations_test.py
@@ -309,13 +309,15 @@ class LocalPipelineOperationsTest(unittest.TestCase):
         some_dict = [("cheese", "brie"), ("bread", "sourdough"),
                      ("cheese", "swiss")]
 
-        self.assertEqual(list(self.ops.group_by_key(some_dict)), [
-                         ("cheese", ["brie", "swiss"]),
-                         ("bread", ["sourdough"])])
+        self.assertEqual(list(self.ops.group_by_key(some_dict)),
+                         [("cheese", ["brie", "swiss"]),
+                          ("bread", ["sourdough"])])
+
 
 # TODO: Extend the proper Accumulator class once it's available.
 class SumAccumulator:
     """A simple accumulator for testing purposes."""
+
     def __init__(self, v):
         self.sum = v
 
@@ -327,7 +329,7 @@ class SumAccumulator:
         return self.sum
 
     def add_accumulator(self,
-                      accumulator: 'SumAccumulator') -> 'SumAccumulator':
+                        accumulator: 'SumAccumulator') -> 'SumAccumulator':
         self.sum += accumulator.sum
         return self
 

--- a/tests/pipeline_operations_test.py
+++ b/tests/pipeline_operations_test.py
@@ -77,12 +77,10 @@ class BeamOperationsTest(parameterized.TestCase):
 
     def test_reduce_accumulators_per_key(self):
         with test_pipeline.TestPipeline() as p:
-            col = p | "Create PCollection" >> beam.Create([(1, 6, 1), (2, 7, 1),
-                                                           (3, 6, 1), (4, 7, 1),
-                                                           (5, 8, 1)])\
-                  | "Wrap into accumulators" >> beam.Map(lambda row: (row[1], SumAccumulator(row[2])))
-            result = self.ops.reduce_accumulators_per_key(col) \
-                     |"Get accumulated values" >> beam.Map(lambda row: (row[0], row[1].get_metrics()))
+            col = p | "Create PCollection" >> beam.Create([(6, 1), (7, 1), (6, 1), (7, 1), (8, 1)])
+            col = self.ops.map_values(col, SumAccumulator, "Wrap into accumulators")
+            col = self.ops.reduce_accumulators_per_key(col)
+            result = col | "Get accumulated values" >> beam.Map(lambda row: (row[0], row[1].get_metrics()))
 
             assert_that(result, equal_to([(6, 2), (7, 2), (8, 1)]))
 


### PR DESCRIPTION
## Description
Implement reduce_accumulators_per_key in BeamOperations.

As the accumulators interface is still work in progress, this assumes the interface agreed in the documentation.

## Affected Dependencies
None

## How has this been tested?
- Added unit tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
