### PR TITLE
Implementation of `_select_private_partitions`

### DIFF
--- a/pipeline_dp/__init__.py
+++ b/pipeline_dp/__init__.py
@@ -7,3 +7,4 @@ from pipeline_dp.dp_engine import DPEngine
 from pipeline_dp.pipeline_operations import LocalPipelineOperations
 from pipeline_dp.pipeline_operations import BeamOperations
 from pipeline_dp.pipeline_operations import SparkRDDOperations
+from pipeline_dp import accumulator

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -8,9 +8,9 @@ from pipeline_dp.aggregate_params import AggregateParams
 from pipeline_dp.budget_accounting import BudgetAccountant, Budget
 from pipeline_dp.pipeline_operations import PipelineOperations
 from pipeline_dp.report_generator import ReportGenerator
+from pipeline_dp.accumulator import Accumulator
 
 from pydp.algorithms.partition_selection import create_truncated_geometric_partition_strategy
-from .accumulator import Accumulator
 
 
 @dataclass
@@ -120,9 +120,9 @@ class DPEngine:
 
         Args:
             col: collection, with types for each element: 
-                (partition_key, accumulator: Accumulator)
-            max_partitions_contributed: how many contributed partitions we can get at 
-                most from this operations.
+                (partition_key, Accumulator)
+            max_partitions_contributed: maximum amount of partitions that one privacy unit
+                might contribute.
         
         Returns:
             collection of elements (partition_key, accumulator)
@@ -130,7 +130,7 @@ class DPEngine:
         budget = self._budget_accountant.request_budget(weight=1, use_eps=True, use_delta=True)
         
         def filter_fn(captures: Tuple[Budget, int], row: Tuple[Any, Accumulator]) -> bool:
-            """Lazily create a partition selection strategy and use it to determine which 
+            """Lazily creates a partition selection strategy and uses it to determine which 
             partitions to keep."""
             budget, max_partitions = captures 
             accumulator = row[1] 

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -138,7 +138,7 @@ class DPEngine:
                 budget.eps, budget.delta, 
                 max_partitions
             )
-            return partition_selection_strategy.should_keep(accumulator.privay_id_count)            
+            return partition_selection_strategy.should_keep(accumulator.privacy_id_count)            
         # make filter_fn serializable
         filter_fn = partial(filter_fn, (budget, max_partitions_contributed))
         return self._ops.filter(col, filter_fn)

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -129,11 +129,11 @@ class DPEngine:
         """
         budget = self._budget_accountant.request_budget(weight=1, use_eps=True, use_delta=True)
         
-        def filter_fn(captures: Tuple[Budget, int], row: Any) -> bool:
+        def filter_fn(captures: Tuple[Budget, int], row: Tuple[Any, Accumulator]) -> bool:
             """Lazily create a partition selection strategy and use it to determine which 
             partitions to keep."""
             budget, max_partitions = captures 
-            accumulator = row[1] # type: Accumulator
+            accumulator = row[1] 
             partition_selection_strategy = create_truncated_geometric_partition_strategy(
                 budget.eps, budget.delta, 
                 max_partitions

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -7,6 +7,7 @@ import abc
 import apache_beam as beam
 import apache_beam.transforms.combiners as combiners
 import typing
+import collections
 
 
 class PipelineOperations(abc.ABC):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,3 +6,4 @@ pytest
 pylint
 yapf
 git+https://github.com/google/differential-privacy.git@327972c1ae710e8cd0a4754fffdd78c3500272ee#subdirectory=python
+python-dp

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -1,10 +1,26 @@
 import collections
+from unittest.mock import patch
 import numpy as np
 import unittest
 
 import pipeline_dp
+import pydp.algorithms.partition_selection as partition_selection
 """DPEngine Test"""
 
+class _MockPartitionStrategy(partition_selection.PartitionSelectionStrategy):
+    def __init__(self, eps, delta, max_partitions_contributed, min_users):
+        self.eps = eps
+        self.delta = delta
+        self.max_partitions_contributed = max_partitions_contributed
+        self.min_users = min_users
+
+    def should_keep(self, num_users: int) -> bool:
+        return num_users > self.min_users
+
+def _mock_partition_strategy_factory(min_users):
+    def partition_strategy_factory(e, d, mpc):
+        return _MockPartitionStrategy(e, d, mpc, min_users)
+    return partition_strategy_factory
 
 class dp_engineTest(unittest.TestCase):
     aggregator_fn = lambda input_values: (len(input_values), np.sum(
@@ -137,6 +153,72 @@ class dp_engineTest(unittest.TestCase):
         engine.aggregate(None, params2, None)
         self.assertEqual(len(engine._report_generators), 2)  # pylint: disable=protected-access
 
+    def _mock_and_assert_private_partitions(self, engine: pipeline_dp.DPEngine, groups, 
+                                            min_users, expected_partitions,
+                                            max_partitions_contributed):
+        with patch("pipeline_dp.dp_engine.create_truncated_geometric_partition_strategy",
+                   new=_mock_partition_strategy_factory(min_users)) as mock_factory:
+            data_filtered = engine._select_private_partitions(groups, max_partitions_contributed)
+            engine._budget_accountant.compute_budgets()
+            self.assertListEqual(list(data_filtered), expected_partitions)
+
+    def test_select_private_partitions(self):
+        input_col = [
+            ("pid1", ( 'pk1', 1 )), 
+            ("pid1", ( 'pk1', 2 )), 
+            ("pid1", ( 'pk2', 3 )),
+            ("pid1", ( 'pk2', 4 )), 
+            ("pid1", ( 'pk2', 5 )), 
+            ("pid1", ( 'pk3', 6 )),
+            ("pid1", ( 'pk4', 7 )), 
+            ("pid2", ( 'pk4', 8 ))
+        ]
+        max_partitions_contributed = 3
+        engine = pipeline_dp.DPEngine(
+            pipeline_dp.BudgetAccountant(1, 1e-10),
+            pipeline_dp.LocalPipelineOperations()
+        )
+        groups = engine._ops.group_by_key(input_col, None)
+        expected_data_filtered = [
+            ("pid1", [
+                ( 'pk1', 1 ),
+                ( 'pk1', 2 ),
+                ( 'pk2', 3 ),
+                ( 'pk2', 4 ),
+                ( 'pk2', 5 ),
+                ( 'pk3', 6 ),
+                ( 'pk4', 7 ),
+            ]),
+            ("pid", [
+                ('pk4', 8)
+            ])
+        ]
+        self._mock_and_assert_private_partitions(
+            engine, groups, 0, expected_data_filtered, 
+            max_partitions_contributed
+        )
+        expected_data_filtered = [
+            ("pid1", [
+                ( 'pk1', 1 ),
+                ( 'pk1', 2 ),
+                ( 'pk2', 3 ),
+                ( 'pk2', 4 ),
+                ( 'pk2', 5 ),
+                ( 'pk3', 6 ),
+                ( 'pk4', 7 ),
+            ]),
+        ]
+        self._mock_and_assert_private_partitions(
+            engine, groups, 3, expected_data_filtered, 
+            max_partitions_contributed
+        )
+        expected_data_filtered = []
+        self._mock_and_assert_private_partitions(
+            engine, groups, 100, expected_data_filtered,
+            max_partitions_contributed
+        )
+            
+            
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
Implementation of pipelined `_select_private_partitions` as specified in #8 using `pydp.algorithms.partition_selection.PartitionSelectionStrategy`. 

## Affected Dependencies
**New Dependency:** OpenMined/PyDP aka `python-dp`.

## How has this been tested?
- Mocking `create_*_parititon_strategy` to deterministically generate private partitions.
- Passing toy data through the `_select_private_partitions` function
- Measuring expected result against outcome

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
