### PR TITLE
Added MultiProcLocalPipelineOperations

### DIFF
--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -4,7 +4,6 @@ from enum import Enum
 from functools import partial
 import os
 import multiprocessing as mp
-from tkinter import W
 from pipeline_dp import accumulator
 import random
 import numpy as np

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -374,19 +374,14 @@ class _LazyMultiProcIterator:
         """Utilizes the `multiprocessing.Pool.map` for distributed execution of 
         a function `job` on an iterable `job_inputs`.
 
-        Parameters
-        ==========
-        job: 
-            the function to be called on each input
+        Args:
+            job: the function to be called on each input
 
-        job_inputs: 
-            iterable containing all the inputs
+            job_inputs: iterable containing all the inputs
 
-        chunksize: 
-            see [multiprocessing.Pool.map signature](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.map).  
+            chunksize: see [multiprocessing.Pool.map signature](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.map).  
 
-        n_jobs: 
-            see [multiprocessing.Pool constructor](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool) arguments
+            n_jobs: see [multiprocessing.Pool constructor](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool) arguments
         """
         self.job = job
         self.chunksize = chunksize
@@ -407,8 +402,7 @@ class _LazyMultiProcIterator:
         return self._pool
 
     def _trigger_iterations(self):
-        """Trigger the Pool operation that iterates over inputs and produces outputs.
-        """
+        """Trigger the Pool operation that iterates over inputs and produces outputs."""
         if self._outputs is None:
             self._outputs = self._init_pool().map(
                 _pool_worker, 

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -5,7 +5,7 @@ from functools import partial
 import os
 import multiprocessing as mp
 from tkinter import W
-from . import accumulator
+from pipeline_dp import accumulator
 import random
 import numpy as np
 

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -505,15 +505,15 @@ class MultiProcLocalPipelineOperations(PipelineOperations):
         return (row for row, keep in zip(col, ordered_predicates) if keep)
 
     def filter_by_key(self, col,
-                      public_partitions,
+                      keys_to_keep,
                       data_extractors,
                       stage_name: typing.Optional[str] = None):
         def mapped_fn(captures, row):
-            public_partitions_, data_extractors_ = captures
+            keys_to_keep_, data_extractors_ = captures
             key = data_extractors_.partition_extractor(row)
-            return key, (key in public_partitions_)
+            return key, (key in keys_to_keep_)
 
-        mapped_fn = partial(mapped_fn, (public_partitions, data_extractors))
+        mapped_fn = partial(mapped_fn, (keys_to_keep, data_extractors))
         ordered_key_keep = self.map(col, mapped_fn, stage_name)
         return ((key, row) for row, (key, keep) in zip(col, ordered_key_keep) if keep)
 

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -5,7 +5,6 @@ import os
 import multiprocessing as mp
 from . import accumulator
 import random
-from tkinter import W
 import numpy as np
 
 import abc
@@ -329,7 +328,7 @@ class LocalPipelineOperations(PipelineOperations):
     def reduce_accumulators_per_key(self, col, stage_name: str = None):
         raise NotImplementedError()
 
-class MultiProcLocalPipeLineOperations(PipelineOperations):
+class MultiProcLocalPipelineOperations(PipelineOperations):
     def __init__(self, n_jobs: typing.Optional[int]=None,
                 chunksize: int=1,
                 ordered=True, 

--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -511,8 +511,6 @@ class MultiProcLocalPipelineOperations(PipelineOperations):
         return self.map(col, lambda x: (x[0], fn(x[1])), stage_name)
 
     def group_by_key(self, col, stage_name: typing.Optional[str] = None):
-        # NOTE - this cannot be implemented in an ordered manner without (almost) serial execution!
-        #   both keys and groups will be out of order
         return _LazyMultiProcGroupByIterator(col, self.chunksize, 
                                              self.n_jobs, 
                                              **self.pool_kwargs)
@@ -562,14 +560,4 @@ class MultiProcLocalPipelineOperations(PipelineOperations):
                                            self.n_jobs, **self.pool_kwargs)
 
     def reduce_accumulators_per_key(self, col, stage_name: typing.Optional[str] = None):
-        """Reduces the input collection so that all elements per each key are merged.
-
-        Args:
-          col: input collection which contains tuples (key, accumulator)
-          stage_name: name of the stage
-
-        Returns:
-          A collection of tuples (key, accumulator).
-
-        """
         return self.map_values(col, accumulator.merge)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,7 +2,11 @@ numpy
 apache-beam
 absl-py
 pyspark
+
+# pytest stuff
 pytest
+pytest-timeout
+
 pylint
 yapf
 git+https://github.com/google/differential-privacy.git@327972c1ae710e8cd0a4754fffdd78c3500272ee#subdirectory=python

--- a/tests/pipeline_operations_test.py
+++ b/tests/pipeline_operations_test.py
@@ -412,23 +412,23 @@ class MultiProcLocalPipelineOperationsTest(unittest.TestCase):
             privacy_id_extractor=cls.privacy_id_extract,
             value_extractor=cls.value_extract)
 
-    def sortDataset(self, data):
+    def _sort_dataset(self, data):
         if isinstance(data, (str, int, float)):
             return data
         if isinstance(data, tuple):
-            return tuple(self.sortDataset(x) for x in data)
+            return tuple(self._sort_dataset(x) for x in data)
         data = list(data)
         def sortfn(x):
             # make everything a sortable thing!
             if isinstance(x, list):
-                return self.sortDataset(tuple(x))
+                return self._sort_dataset(tuple(x))
             return x
         return sorted(data, key=sortfn)
 
     def assertDatasetsEqual(self, first, second, toplevel=True):
         if toplevel:
-            first = self.sortDataset(first)
-            second = self.sortDataset(second)
+            first = self._sort_dataset(first)
+            second = self._sort_dataset(second)
         self.assertEqual(type(first), type(second))
         if isinstance(first, (str, int, float)):
             self.assertEqual(first, second)


### PR DESCRIPTION
## Description
Created a `multiprocessing` equivalent of `LocalPipelineOperations`, but with `n_jobs`. Most of the functionality should be exactly the same as `LocalPipelineOperations` but run on multi-threaded environment.  
Differences are:
- `MultiProcLocalPipelineOperations.group_by_key`, `samples_fixed_per_key` and `count_per_element` will be **out of order** because the processes contributing to the groups are running out of order, even if `ordered=True` was passed.
- ~We cannot guarantee full laziness of any of the functions. `multiprocessing` strives when we use "partial laziness", i.e. we launch jobs asynchronously and return sometime later to collect the results. During this time - the process pool works to later provide us with immediate results.~ EDIT: No longer true. Implemented classes that trigger iterations only when needed.


## Affected Dependencies
None.

## How has this been tested?
Most tests were taken from the `LocalPipelineOperations` tests, some were modified/removed:
- Anything relying on the order of values for `group_by_key`, `samples_fixed_per_key` and `count_per_element` was modified to not rely on order
- ~Anything relying on the laziness was removed. `multiprocessing.Pool.imap` isn't truly lazy in the full sense of the word.~ EDIT: No longer true. Added tests for laziness.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
