### PR TITLE
Fix for spark map_tuple

### DIFF
--- a/pipeline_dp/pipeline_operations.py
+++ b/pipeline_dp/pipeline_operations.py
@@ -207,7 +207,7 @@ class SparkRDDOperations(PipelineOperations):
         return rdd.flatMap(fn)
 
     def map_tuple(self, rdd, fn, stage_name: str = None):
-        return rdd.map(fn)
+        return rdd.map(lambda x: fn(*x))
 
     def map_values(self, rdd, fn, stage_name: str = None):
         return rdd.mapValues(fn)

--- a/tests/pipeline_operations_test.py
+++ b/tests/pipeline_operations_test.py
@@ -156,12 +156,11 @@ class SparkRDDOperationsTest(parameterized.TestCase):
         self.assertDictEqual(result, {'a': 2, 'b': 1})
 
     def test_reduce_accumulators_per_key(self):
-        spark_operations = SparkRDDOperations()
         data = [(1, 11), (2, 22), (3, 33), (1, 14), (2, 25), (1, 16)]
         dist_data = SparkRDDOperationsTest.sc.parallelize(data)
-        rdd = spark_operations.map_values(dist_data, SumAccumulator,
+        rdd = self.ops.map_values(dist_data, SumAccumulator,
                                           "Wrap into accumulators")
-        result = spark_operations\
+        result = self.ops\
             .reduce_accumulators_per_key(rdd, "Reduce accumulator per key")\
             .map(lambda row: (row[0], row[1].get_metrics()))\
             .collect()

--- a/tests/pipeline_operations_test.py
+++ b/tests/pipeline_operations_test.py
@@ -159,7 +159,7 @@ class SparkRDDOperationsTest(parameterized.TestCase):
         data = [(1, 11), (2, 22), (3, 33), (1, 14), (2, 25), (1, 16)]
         dist_data = SparkRDDOperationsTest.sc.parallelize(data)
         rdd = self.ops.map_values(dist_data, SumAccumulator,
-                                          "Wrap into accumulators")
+                                  "Wrap into accumulators")
         result = self.ops\
             .reduce_accumulators_per_key(rdd, "Reduce accumulator per key")\
             .map(lambda row: (row[0], row[1].get_metrics()))\


### PR DESCRIPTION
map_tuples was implemented as map in SparkRDDPipelineOperation. This PR fixes that and adds tests.

Along the way, the creation of SparkRDDOperations() was moved to setUpClass(cls), to match BeamOperations unittests.