### PR TITLE
Improvement of the movie view example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: format
 format:
-	yapf -i -r pipeline_dp tests
+	yapf -i -r pipeline_dp tests examples
 
 .PHONY: lint
 lint:

--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -55,7 +55,6 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
         metrics=[
             pipeline_dp.Metrics.COUNT,
         ],
-        noise_kind=pipeline_dp.NoiseKind.LAPLACE,
         max_partitions_contributed=2,
         max_contributions_per_partition=1,
         low=1,

--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -26,10 +26,13 @@ from dataclasses import dataclass
 import pipeline_dp
 
 FLAGS = flags.FLAGS
-flags.DEFINE_string('input_file', '', 'The file with the movie view data')
+flags.DEFINE_string('input_file', None, 'The file with the movie view data')
 flags.DEFINE_string('output_file', None, 'Output file')
-flags.DEFINE_enum('framework', None, ['beam', 'spark'], 'Pipeline framework to use.')
-flags.DEFINE_list('public_partitions', None, 'List of comma-separated public partition keys')
+flags.DEFINE_enum('framework', None, ['beam', 'spark', 'local'],
+                  'Pipeline framework to use.')
+flags.DEFINE_list('public_partitions', None,
+                  'List of comma-separated public partition keys')
+
 
 @dataclass
 class MovieView:
@@ -50,15 +53,14 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
     # Specify which DP aggregated metrics to compute.
     params = pipeline_dp.AggregateParams(
         metrics=[
-            pipeline_dp.Metrics.PRIVACY_ID_COUNT, pipeline_dp.Metrics.COUNT,
-            pipeline_dp.Metrics.MEAN
+            pipeline_dp.Metrics.COUNT,
         ],
+        noise_kind=pipeline_dp.NoiseKind.LAPLACE,
         max_partitions_contributed=2,
         max_contributions_per_partition=1,
         low=1,
         high=5,
-        public_partitions=public_partitions
-    )
+        public_partitions=public_partitions)
 
     # Specify how to extract is privacy_id, partition_key and value from an element of movie view collection.
     data_extractors = pipeline_dp.DataExtractors(
@@ -69,6 +71,7 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
     # Run aggregation.
     dp_result = dp_engine.aggregate(movie_views, params, data_extractors)
 
+    budget_accountant.compute_budgets()
     return dp_result
 
 
@@ -98,7 +101,9 @@ def get_public_partitions():
     public_partitions = None
     if FLAGS.public_partitions is not None:
         print(FLAGS.public_partitions)
-        public_partitions = [int(partition) for partition in FLAGS.public_partitions]
+        public_partitions = [
+            int(partition) for partition in FLAGS.public_partitions
+        ]
     return public_partitions
 
 
@@ -106,10 +111,11 @@ def compute_on_beam():
     runner = fn_api_runner.FnApiRunner()  # local runner
     public_partitions = get_public_partitions()
     with beam.Pipeline(runner=runner) as pipeline:
-        movie_views = pipeline | beam.io.ReadFromText(FLAGS.input_file) | beam.ParDo(
-            ParseFile())
+        movie_views = pipeline | beam.io.ReadFromText(
+            FLAGS.input_file) | beam.ParDo(ParseFile())
         pipeline_operations = pipeline_dp.BeamOperations()
-        dp_result = calc_dp_rating_metrics(movie_views, pipeline_operations, public_partitions)
+        dp_result = calc_dp_rating_metrics(movie_views, pipeline_operations,
+                                           public_partitions)
         dp_result | beam.io.WriteToText(FLAGS.output_file)
 
 
@@ -132,12 +138,35 @@ def compute_on_spark():
         .mapPartitions(parse_partition)
     pipeline_operations = pipeline_dp.SparkRDDOperations()
     public_partitions = get_public_partitions()
-    dp_result = calc_dp_rating_metrics(movie_views, pipeline_operations, public_partitions)
+    dp_result = calc_dp_rating_metrics(movie_views, pipeline_operations,
+                                       public_partitions)
     dp_result.saveAsTextFile(FLAGS.output_file)
 
 
+def parse_file(filename):  # used for the local run
+    res = []
+    for line in open(filename):
+        line = line.strip()
+        if line[-1] == ':':
+            movie_id = int(line[:-1])
+        else:
+            res.append(parse_line(line, movie_id))
+    return res
+
+
+def write_to_file(col, filename):
+    with open(filename, 'w') as out:
+        out.write('\n'.join(map(str, col)))
+
+
 def compute_on_local():
-    raise NotImplementedError
+    public_partitions = get_public_partitions()
+    movie_views = parse_file(FLAGS.input_file)
+    pipeline_operations = pipeline_dp.LocalPipelineOperations()
+    dp_result = list(
+        calc_dp_rating_metrics(movie_views, pipeline_operations,
+                               public_partitions))
+    write_to_file(dp_result, FLAGS.output_file)
 
 
 def main(unused_argv):
@@ -151,4 +180,11 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
+    flags.mark_flag_as_required("input_file")
+    flags.mark_flag_as_required("output_file")
     app.run(main)
+
+
+# todo: add test for Spark pipeline map and map_tuples ops
+# todo: check map vs map_tuple in dp_endige
+# todo: make multi-process testn

--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -183,8 +183,3 @@ if __name__ == '__main__':
     flags.mark_flag_as_required("input_file")
     flags.mark_flag_as_required("output_file")
     app.run(main)
-
-
-# todo: add test for Spark pipeline map and map_tuples ops
-# todo: check map vs map_tuple in dp_endige
-# todo: make multi-process testn

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -58,7 +58,7 @@ class DPEngine:
         aggregator_fn = accumulator_factory.create
 
         # extract the columns
-        col = self._ops.map_tuple(
+        col = self._ops.map(
             col, lambda row: (data_extractors.privacy_id_extractor(row),
                               data_extractors.partition_extractor(row),
                               data_extractors.value_extractor(row)),


### PR DESCRIPTION
This PR contains the following changes:

1.Using LocalOperations in the example
2.Minor fixes of API usage (e.g. calling budget_account.compute_budgets() etc).
3.Limiting metrics only to COUNT (all others are not implemented yet)
4.Minor fix in dp_engine.aggregate (map_tuple -> map)  (it's not tested yet, since dp_engine.aggregate is not fully implemented), w/o this fix the example crashes instead of returning an intermediate result.
5.Making some flags to be required
6.Added examples folders for formating by `make format`