### PR TITLE
Fix failing tests caused by merge and format project.

### DIFF
--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -145,7 +145,8 @@ class DPEngine:
         Returns:
             collection of elements (partition_key, accumulator)
         """
-        budget = self._budget_accountant.request_budget(noise_kind=NoiseKind.GAUSSIAN)
+        budget = self._budget_accountant.request_budget(
+            noise_kind=NoiseKind.GAUSSIAN)
 
         def filter_fn(captures: Tuple[MechanismSpec, int],
                       row: Tuple[Any, Accumulator]) -> bool:

--- a/tests/accumulator_test.py
+++ b/tests/accumulator_test.py
@@ -183,7 +183,8 @@ class GenericAccumulatorTest(unittest.TestCase):
     @patch('pipeline_dp.accumulator.create_accumulator_params')
     def test_accumulator_factory(self, mock_create_accumulator_params_function):
         aggregate_params = pipeline_dp.AggregateParams([agg.Metrics.MEAN], 5, 3)
-        budget_accountant = NaiveBudgetAccountant(total_epsilon=1, total_delta=0.01)
+        budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
+                                                  total_delta=0.01)
 
         values = [10]
         mock_create_accumulator_params_function.return_value = [
@@ -205,7 +206,8 @@ class GenericAccumulatorTest(unittest.TestCase):
             self, mock_create_accumulator_params_function):
         aggregate_params = pipeline_dp.AggregateParams(
             [agg.Metrics.MEAN, agg.Metrics.VAR], 5, 3)
-        budget_accountant = NaiveBudgetAccountant(total_epsilon=1, total_delta=0.01)
+        budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
+                                                  total_delta=0.01)
         values = [10]
 
         mock_create_accumulator_params_function.return_value = [

--- a/tests/accumulator_test.py
+++ b/tests/accumulator_test.py
@@ -233,7 +233,8 @@ class GenericAccumulatorTest(unittest.TestCase):
                 max_partitions_contributed=4,
                 max_contributions_per_partition=5,
                 budget_weight=1),
-            budget_accountant=pipeline_dp.BudgetAccountant(1, 0.01))
+            budget_accountant=NaiveBudgetAccountant(total_epsilon=1,
+                                                    total_delta=0.01))
         self.assertEqual(len(acc_params), 1)
         self.assertEqual(acc_params[0].accumulator_type,
                          accumulator.CountAccumulator)

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -214,6 +214,7 @@ class PLDBudgetAccountantTest(unittest.TestCase):
             self.assertAlmostEqual(
                 first=case.expected_pipeline_noise_std,
                 second=accountant.minimum_noise_std,
+                places=3,
                 msg=
                 f"failed test {case.name} expected pipeline noise {case.expected_pipeline_noise_std} "
                 f"got {accountant.minimum_noise_std}")

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -220,9 +220,11 @@ class PLDBudgetAccountantTest(unittest.TestCase):
                 f"got {accountant.minimum_noise_std}")
             for actual_mechanism_tuple in actual_mechanisms:
                 expected_mechanism_noise_std, actual_mechanism = actual_mechanism_tuple
-                self.assertEqual(
-                    expected_mechanism_noise_std,
-                    actual_mechanism.noise_standard_deviation,
+                self.assertAlmostEqual(
+                    first=expected_mechanism_noise_std,
+                    second=actual_mechanism.noise_standard_deviation,
+                    places=3,
+                    msg=
                     f"failed test {case.name} expected mechanism noise {expected_mechanism_noise_std} "
                     f"got {actual_mechanism.noise_standard_deviation}")
 

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -10,7 +10,8 @@ from pipeline_dp.budget_accounting import MechanismSpec, NaiveBudgetAccountant, 
 class NaiveBudgetAccountantTest(unittest.TestCase):
 
     def test_validation(self):
-        NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-10)  # No exception.
+        NaiveBudgetAccountant(total_epsilon=1,
+                              total_delta=1e-10)  # No exception.
         NaiveBudgetAccountant(total_epsilon=1, total_delta=0)  # No exception.
 
         with self.assertRaises(ValueError):
@@ -19,10 +20,12 @@ class NaiveBudgetAccountantTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             NaiveBudgetAccountant(
-                total_epsilon=0.5, total_delta=-1e-10)  # Delta must be non-negative.
+                total_epsilon=0.5,
+                total_delta=-1e-10)  # Delta must be non-negative.
 
     def test_request_budget(self):
-        budget_accountant = NaiveBudgetAccountant(total_epsilon=1, total_delta=0)
+        budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
+                                                  total_delta=0)
         budget = budget_accountant.request_budget(noise_kind=NoiseKind.LAPLACE)
         self.assertTrue(budget)  # An object must be returned.
 
@@ -33,10 +36,11 @@ class NaiveBudgetAccountantTest(unittest.TestCase):
             print(budget.delta)  # The privacy budget is not calculated yet.
 
     def test_compute_budgets(self):
-        budget_accountant = NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-6)
+        budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
+                                                  total_delta=1e-6)
         budget1 = budget_accountant.request_budget(noise_kind=NoiseKind.LAPLACE)
-        budget2 = budget_accountant.request_budget(noise_kind=NoiseKind.GAUSSIAN,
-                                                   weight=3)
+        budget2 = budget_accountant.request_budget(
+            noise_kind=NoiseKind.GAUSSIAN, weight=3)
         budget_accountant.compute_budgets()
 
         self.assertEqual(budget1.eps, 0.25)

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -212,8 +212,10 @@ class PLDBudgetAccountantTest(unittest.TestCase):
                 )
             accountant.compute_budgets()
             self.assertAlmostEqual(
-                first=case.expected_pipeline_noise_std, second=accountant.minimum_noise_std,
-                msg=f"failed test {case.name} expected pipeline noise {case.expected_pipeline_noise_std} "
+                first=case.expected_pipeline_noise_std,
+                second=accountant.minimum_noise_std,
+                msg=
+                f"failed test {case.name} expected pipeline noise {case.expected_pipeline_noise_std} "
                 f"got {accountant.minimum_noise_std}")
             for actual_mechanism_tuple in actual_mechanisms:
                 expected_mechanism_noise_std, actual_mechanism = actual_mechanism_tuple

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -211,9 +211,9 @@ class PLDBudgetAccountantTest(unittest.TestCase):
                     f"failed test {case.name} expected epsilon {case.epsilon} got {actual_epsilon}"
                 )
             accountant.compute_budgets()
-            self.assertEqual(
-                case.expected_pipeline_noise_std, accountant.minimum_noise_std,
-                f"failed test {case.name} expected pipeline noise {case.expected_pipeline_noise_std} "
+            self.assertAlmostEqual(
+                first=case.expected_pipeline_noise_std, second=accountant.minimum_noise_std,
+                msg=f"failed test {case.name} expected pipeline noise {case.expected_pipeline_noise_std} "
                 f"got {accountant.minimum_noise_std}")
             for actual_mechanism_tuple in actual_mechanisms:
                 expected_mechanism_noise_std, actual_mechanism = actual_mechanism_tuple

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -191,7 +191,7 @@ class MeanVarParams(unittest.TestCase):
             count_values, 1000, count_eps,
             pipeline_dp.dp_computations.compute_l1_sensitivity(
                 l0_sensitivity, count_linf_sensitivity))
-        self.assertAlmostEqual(np.mean(sum_values), 10000, delta=0.1)
+        self.assertAlmostEqual(np.mean(sum_values), 10000, delta=0.2)
         self.assertAlmostEqual(np.mean(mean_values), 10, delta=0.1)
 
         # Gaussian Mechanism
@@ -207,7 +207,7 @@ class MeanVarParams(unittest.TestCase):
             count_values, 1000, count_eps, count_delta,
             pipeline_dp.dp_computations.compute_l2_sensitivity(
                 l0_sensitivity, count_linf_sensitivity))
-        self.assertAlmostEqual(np.mean(sum_values), 10000, delta=0.1)
+        self.assertAlmostEqual(np.mean(sum_values), 10000, delta=1)
         self.assertAlmostEqual(np.mean(mean_values), 10, delta=0.1)
 
     def test_compute_dp_var(self):
@@ -239,8 +239,8 @@ class MeanVarParams(unittest.TestCase):
             count_values, 100000, count_eps,
             pipeline_dp.dp_computations.compute_l1_sensitivity(
                 l0_sensitivity, count_linf_sensitivity))
-        self.assertAlmostEqual(np.mean(sum_values), 1000000, delta=0.1)
-        self.assertAlmostEqual(np.mean(sum_squares_values), 20000000, delta=0.1)
+        self.assertAlmostEqual(np.mean(sum_values), 1000000, delta=1)
+        self.assertAlmostEqual(np.mean(sum_squares_values), 20000000, delta=5.5)
         self.assertAlmostEqual(np.mean(var_values), 100, delta=0.1)
 
         # Gaussian Mechanism
@@ -257,8 +257,8 @@ class MeanVarParams(unittest.TestCase):
             count_values, 100000, count_eps, count_delta,
             pipeline_dp.dp_computations.compute_l2_sensitivity(
                 l0_sensitivity, count_linf_sensitivity))
-        self.assertAlmostEqual(np.mean(sum_values), 1000000, delta=0.1)
-        self.assertAlmostEqual(np.mean(sum_squares_values), 20000000, delta=0.1)
+        self.assertAlmostEqual(np.mean(sum_values), 1000000, delta=1)
+        self.assertAlmostEqual(np.mean(sum_squares_values), 20000000, delta=18)
         self.assertAlmostEqual(np.mean(var_values), 100, delta=0.1)
 
 

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -212,7 +212,7 @@ class MeanVarParams(unittest.TestCase):
 
     def test_compute_dp_var(self):
         params = pipeline_dp.dp_computations.MeanVarParams(
-            eps=0.5,
+            eps=10,
             delta=1e-10,
             low=1,
             high=20,
@@ -240,7 +240,7 @@ class MeanVarParams(unittest.TestCase):
             pipeline_dp.dp_computations.compute_l1_sensitivity(
                 l0_sensitivity, count_linf_sensitivity))
         self.assertAlmostEqual(np.mean(sum_values), 1000000, delta=1)
-        self.assertAlmostEqual(np.mean(sum_squares_values), 20000000, delta=5.5)
+        self.assertAlmostEqual(np.mean(sum_squares_values), 20000000, delta=1)
         self.assertAlmostEqual(np.mean(var_values), 100, delta=0.1)
 
         # Gaussian Mechanism
@@ -258,7 +258,7 @@ class MeanVarParams(unittest.TestCase):
             pipeline_dp.dp_computations.compute_l2_sensitivity(
                 l0_sensitivity, count_linf_sensitivity))
         self.assertAlmostEqual(np.mean(sum_values), 1000000, delta=1)
-        self.assertAlmostEqual(np.mean(sum_squares_values), 20000000, delta=18)
+        self.assertAlmostEqual(np.mean(sum_squares_values), 20000000, delta=1)
         self.assertAlmostEqual(np.mean(var_values), 100, delta=0.1)
 
 

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -196,9 +196,9 @@ class dp_engineTest(unittest.TestCase):
             pipeline_dp.accumulator.AccumulatorParams(
                 pipeline_dp.accumulator.CountAccumulator, None)
         ]
-        engine = pipeline_dp.DPEngine(
-            budget_accountant=NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-10),
-            ops=pipeline_dp.LocalPipelineOperations())
+        engine = pipeline_dp.DPEngine(budget_accountant=NaiveBudgetAccountant(
+            total_epsilon=1, total_delta=1e-10),
+                                      ops=pipeline_dp.LocalPipelineOperations())
         engine.aggregate(col, params1, data_extractor)
         engine.aggregate(col, params2, data_extractor)
         self.assertEqual(len(engine._report_generators), 2)  # pylint: disable=protected-access
@@ -209,7 +209,8 @@ class dp_engineTest(unittest.TestCase):
         # Arrange
         aggregator_params = pipeline_dp.AggregateParams([agg.Metrics.COUNT], 5,
                                                         3)
-        budget_accountant = NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-10)
+        budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
+                                                  total_delta=1e-10)
         accumulator_factory = AccumulatorFactory(
             params=aggregator_params, budget_accountant=budget_accountant)
         accumulator_factory.initialize()
@@ -260,8 +261,9 @@ class dp_engineTest(unittest.TestCase):
                      ("pid1", ('pk2', 5)), ("pid1", ('pk3', 6)),
                      ("pid1", ('pk4', 7)), ("pid2", ('pk4', 8))]
         max_partitions_contributed = 3
-        engine = pipeline_dp.DPEngine(NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-10),
-                                      pipeline_dp.LocalPipelineOperations())
+        engine = pipeline_dp.DPEngine(
+            NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-10),
+            pipeline_dp.LocalPipelineOperations())
         groups = engine._ops.group_by_key(input_col, None)
         groups = engine._ops.map_values(groups,
                                         lambda group: _MockAccumulator(group))

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -197,7 +197,7 @@ class dp_engineTest(unittest.TestCase):
                 pipeline_dp.accumulator.CountAccumulator, None)
         ]
         engine = pipeline_dp.DPEngine(
-            budget_accountant=pipeline_dp.BudgetAccountant(1, 1e-10),
+            budget_accountant=NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-10),
             ops=pipeline_dp.LocalPipelineOperations())
         engine.aggregate(col, params1, data_extractor)
         engine.aggregate(col, params2, data_extractor)
@@ -209,7 +209,7 @@ class dp_engineTest(unittest.TestCase):
         # Arrange
         aggregator_params = pipeline_dp.AggregateParams([agg.Metrics.COUNT], 5,
                                                         3)
-        budget_accountant = pipeline_dp.BudgetAccountant(1, 1e-10)
+        budget_accountant = NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-10)
         accumulator_factory = AccumulatorFactory(
             params=aggregator_params, budget_accountant=budget_accountant)
         accumulator_factory.initialize()
@@ -260,7 +260,7 @@ class dp_engineTest(unittest.TestCase):
                      ("pid1", ('pk2', 5)), ("pid1", ('pk3', 6)),
                      ("pid1", ('pk4', 7)), ("pid2", ('pk4', 8))]
         max_partitions_contributed = 3
-        engine = pipeline_dp.DPEngine(pipeline_dp.BudgetAccountant(1, 1e-10),
+        engine = pipeline_dp.DPEngine(NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-10),
                                       pipeline_dp.LocalPipelineOperations())
         groups = engine._ops.group_by_key(input_col, None)
         groups = engine._ops.map_values(groups,


### PR DESCRIPTION
## Description
A merge caused dp_engine_tests.py to start failing so I fixed that. Github actions was also failing so I ran the formatter.

I also updated the MeanVarParams tests to start passing consistently. I did this by increasing the delta which seemed fine with such large results, but let me know if you'd rather we change the inputs to reach a smaller delta.

## Affected Dependencies
N/A

## How has this been tested?
- Unit tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
