### PR TITLE
Computing privacy id count in CompoundAccumulator

### DIFF
--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -51,14 +51,15 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
     dp_engine = pipeline_dp.DPEngine(budget_accountant, ops)
 
     # Specify which DP aggregated metrics to compute.
-    params = pipeline_dp.AggregateParams(metrics=[
-        pipeline_dp.Metrics.COUNT,
-    ],
-                                         max_partitions_contributed=2,
-                                         max_contributions_per_partition=1,
-                                         low=1,
-                                         high=5,
-                                         public_partitions=public_partitions)
+    params = pipeline_dp.AggregateParams(
+        metrics=[
+            pipeline_dp.Metrics.COUNT,
+        ],
+        max_partitions_contributed=2,
+        max_contributions_per_partition=1,
+        low=1,
+        high=5,
+        public_partitions=public_partitions)
 
     # Specify how to extract is privacy_id, partition_key and value from an element of movie view collection.
     data_extractors = pipeline_dp.DataExtractors(

--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -51,15 +51,14 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
     dp_engine = pipeline_dp.DPEngine(budget_accountant, ops)
 
     # Specify which DP aggregated metrics to compute.
-    params = pipeline_dp.AggregateParams(
-        metrics=[
-            pipeline_dp.Metrics.COUNT,
-        ],
-        max_partitions_contributed=2,
-        max_contributions_per_partition=1,
-        low=1,
-        high=5,
-        public_partitions=public_partitions)
+    params = pipeline_dp.AggregateParams(metrics=[
+        pipeline_dp.Metrics.COUNT,
+    ],
+                                         max_partitions_contributed=2,
+                                         max_contributions_per_partition=1,
+                                         low=1,
+                                         high=5,
+                                         public_partitions=public_partitions)
 
     # Specify how to extract is privacy_id, partition_key and value from an element of movie view collection.
     data_extractors = pipeline_dp.DataExtractors(

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -47,7 +47,7 @@ class Accumulator(abc.ABC):
 
     @abc.abstractmethod
     def add_value(self, value):
-        """Add 'value' to accumulate.
+        """Adds 'value' to accumulate.
         Args:
           value: value to be added.
 
@@ -111,7 +111,7 @@ class CompoundAccumulator(Accumulator):
         self._privacy_id_count = 1
 
     def add_value(self, value):
-        """Add 'value' to accumulate.
+        """Adds 'value' to accumulate.
 
         The assumption is that value correspond to privacy id which is already
         known for self.

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -47,7 +47,7 @@ class Accumulator(abc.ABC):
 
     @abc.abstractmethod
     def add_value(self, value):
-        """Adds the value to each of the accumulator.
+        """Add 'value' to accumulate.
         Args:
           value: value to be added.
 
@@ -93,7 +93,7 @@ class Accumulator(abc.ABC):
 
 
 class CompoundAccumulator(Accumulator):
-    """Accumulator for computing multiple metrics.
+    """Accumulator for computing multiple metrics at once.
 
     CompoundAccumulator contains one or more accumulators of other types for
     computing multiple metrics.
@@ -104,14 +104,14 @@ class CompoundAccumulator(Accumulator):
     def __init__(self, accumulators: typing.Iterable['Accumulator']):
         """Constructs CompoundAccumulator.
 
-        The assumption is that all accumulators contain data from the same
-        privacy id.
+        The assumption is that each accumulator from 'accumulators' contain data
+        from the same privacy id.
         """
         self._accumulators = accumulators
         self._privacy_id_count = 1
 
     def add_value(self, value):
-        """Add value to accumulate.
+        """Add 'value' to accumulate.
 
         The assumption is that value correspond to privacy id which is already
         known for self.
@@ -155,7 +155,7 @@ class CompoundAccumulator(Accumulator):
 
     @property
     def privacy_id_count(self):
-        """Returns the number of privacy ids which contributed in aggregations."""
+        """Returns the number of privacy ids which contributed to 'self'."""
         return self._privacy_id_count
 
     def compute_metrics(self):

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -43,16 +43,16 @@ class Accumulator(abc.ABC):
 
     Accumulators are objects that encapsulate aggregations and computations of
     differential private metrics.
-  """
+    """
 
     @abc.abstractmethod
     def add_value(self, value):
         """Adds the value to each of the accumulator.
-    Args:
-      value: value to be added.
+        Args:
+          value: value to be added.
 
-    Returns: self.
-    """
+        Returns: self.
+        """
         pass
 
     def _check_mergeable(self, accumulator: 'Accumulator'):
@@ -66,13 +66,14 @@ class Accumulator(abc.ABC):
     def add_accumulator(self, accumulator: 'Accumulator') -> 'Accumulator':
         """Merges the accumulator to self and returns self.
 
-       Sub-class implementation is responsible for checking that types of
-       self and accumulator are the same.
-      Args:
-        accumulator:
+        Sub-class implementation is responsible for checking that types of
+        self and accumulator are the same.
 
-      Returns: self
-    """
+        Args:
+         accumulator:
+
+        Returns: self
+        """
         pass
 
     @abc.abstractmethod
@@ -98,13 +99,24 @@ class CompoundAccumulator(Accumulator):
     computing multiple metrics.
     For example it can contain [CountAccumulator,  SumAccumulator].
     CompoundAccumulator delegates all operations to the internal accumulators.
-  """
+    """
 
     def __init__(self, accumulators: typing.Iterable['Accumulator']):
-        self.accumulators = accumulators
+        """Constructs CompoundAccumulator.
+
+        The assumption is that all accumulators contain data from the same
+        privacy id.
+        """
+        self._accumulators = accumulators
+        self._privacy_id_count = 1
 
     def add_value(self, value):
-        for accumulator in self.accumulators:
+        """Add value to accumulate.
+
+        The assumption is that value correspond to privacy id which is already
+        known for self.
+        """
+        for accumulator in self._accumulators:
             accumulator.add_value(value)
         return self
 
@@ -112,17 +124,23 @@ class CompoundAccumulator(Accumulator):
       'CompoundAccumulator':
         """Merges the accumulators of the CompoundAccumulators.
 
-    The expectation is that the internal accumulators are of the same type and
-    are in the same order."""
+        The expectation is that the internal accumulators are of the same type
+        and are in the same order.
+
+        The assumption is that self and accumulator have data from
+        non-overlapping set of privacy ids.
+        """
         self._check_mergeable(accumulator)
-        if len(accumulator.accumulators) != len(self.accumulators):
+        if len(accumulator._accumulators) != len(self._accumulators):
             raise ValueError(
                 "Accumulators in the input are not of the same size." +
-                f" Expected size = {len(self.accumulators)}" +
-                f" received size = {len(accumulator.accumulators)}.")
+                f" Expected size = {len(self._accumulators)}" +
+                f" received size = {len(accumulator._accumulators)}.")
+
+        self._privacy_id_count += accumulator._privacy_id_count
 
         for pos, (base_accumulator_type, to_add_accumulator_type) in enumerate(
-                zip(self.accumulators, accumulator.accumulators)):
+                zip(self._accumulators, accumulator._accumulators)):
             if type(base_accumulator_type) != type(to_add_accumulator_type):
                 raise TypeError(
                     "The type of the accumulators don't match at "
@@ -130,16 +148,20 @@ class CompoundAccumulator(Accumulator):
                     f"!= {type(to_add_accumulator_type).__name__}.")
 
         for (base_accumulator,
-             to_add_accumulator) in zip(self.accumulators,
-                                        accumulator.accumulators):
+             to_add_accumulator) in zip(self._accumulators,
+                                        accumulator._accumulators):
             base_accumulator.add_accumulator(to_add_accumulator)
         return self
 
+    @property
+    def privacy_id_count(self):
+        """Returns the number of privacy ids which contributed in aggregations."""
+        return self._privacy_id_count
+
     def compute_metrics(self):
-        """Computes and returns a list of metrics computed by internal
-    accumulators."""
+        """Returns a list of metrics computed by internal accumulators."""
         return [
-            accumulator.compute_metrics() for accumulator in self.accumulators
+            accumulator.compute_metrics() for accumulator in self._accumulators
         ]
 
 
@@ -162,10 +184,6 @@ class AccumulatorFactory:
             accumulators.append(
                 accumulator_param.accumulator_type(
                     accumulator_param.constructor_params, values))
-
-        # No need to create CompoundAccumulator if there is only 1 accumulator.
-        if len(accumulators) == 1:
-            return accumulators[0]
 
         return CompoundAccumulator(accumulators)
 

--- a/tests/accumulator_test.py
+++ b/tests/accumulator_test.py
@@ -214,8 +214,8 @@ class GenericAccumulatorTest(unittest.TestCase):
         accumulator_factory.initialize()
         created_accumulator = accumulator_factory.create(values)
 
-        self.assertTrue(isinstance(created_accumulator,
-                                   accumulator.CompoundAccumulator))
+        self.assertTrue(
+            isinstance(created_accumulator, accumulator.CompoundAccumulator))
         self.assertEqual(created_accumulator.compute_metrics(), [10])
         mock_create_accumulator_params_function.assert_called_with(
             aggregate_params, budget_accountant)


### PR DESCRIPTION
In order to apply private partition selection ([doc](https://github.com/google/differential-privacy/blob/main/common_docs/Differential_Privacy_Computations_In_Data_Pipelines.pdf), section **Private partition selection**, page 12) it's required to know privacy id count per partition key. This PR implements computation of  privacy id count in `CompoundAccumulator`. 

**Note:** Since we need to have `privacy_id_count`, the optimization which returns specific Accumulator (instead of `CompoundAccumulator`) is removed.

This PR also contains some small polishing.