### PR TITLE
Fix run tests action on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.dev.txt ]; then pip install -r requirements.dev.txt; fi
+          pip install -r requirements.dev.txt
 
       - name: Run pytest
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements.dev.txt ]; then pip install -r requirements.dev.txt; fi
+        pip install -r requirements.dev.txt
 
     - name: Check formatting
       run: |


### PR DESCRIPTION
`if [ -f ... ]` doesn't work on Windows. And it looks we don't need to check existing of this file, so it's better to remove it.

**Note:** There are tests that are still failing on Windows namely 
```
pipeline_operations_test.py::SparkRDDOperationsTest::*
pipeline_operations_test.py::MultiProcLocalPipelineOperationsTest::*
```

Separate issues for fixing these tests will be created.