### PR TITLE
Making aggregate with private partition selection work

### DIFF
--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -52,15 +52,14 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
     dp_engine = pipeline_dp.DPEngine(budget_accountant, ops)
 
     # Specify which DP aggregated metrics to compute.
-    params = pipeline_dp.AggregateParams(
-        metrics=[
-            pipeline_dp.Metrics.COUNT,
-        ],
-        max_partitions_contributed=2,
-        max_contributions_per_partition=1,
-        low=1,
-        high=5,
-        public_partitions=public_partitions)
+    params = pipeline_dp.AggregateParams(metrics=[
+        pipeline_dp.Metrics.COUNT,
+    ],
+                                         max_partitions_contributed=2,
+                                         max_contributions_per_partition=1,
+                                         low=1,
+                                         high=5,
+                                         public_partitions=public_partitions)
 
     # Specify how to extract is privacy_id, partition_key and value from an element of movie view collection.
     data_extractors = pipeline_dp.DataExtractors(

--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -61,7 +61,8 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
                                          high=5,
                                          public_partitions=public_partitions)
 
-    # Specify how to extract is privacy_id, partition_key and value from an element of movie view collection.
+    # Specify how to extract is privacy_id, partition_key and value from an
+    # element of movie view collection.
     data_extractors = pipeline_dp.DataExtractors(
         partition_extractor=lambda mv: mv.movie_id,
         privacy_id_extractor=lambda mv: mv.user_id,

--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -45,7 +45,8 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
     """Computes dp metrics."""
 
     # Set the total privacy budget.
-    budget_accountant = pipeline_dp.BudgetAccountant(epsilon=1, delta=1e-6)
+    budget_accountant = pipeline_dp.NaiveBudgetAccountant(total_epsilon=1,
+                                                          total_delta=1e-6)
 
     # Create a DPEngine instance.
     dp_engine = pipeline_dp.DPEngine(budget_accountant, ops)

--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -52,9 +52,7 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
     dp_engine = pipeline_dp.DPEngine(budget_accountant, ops)
 
     # Specify which DP aggregated metrics to compute.
-    params = pipeline_dp.AggregateParams(metrics=[
-        pipeline_dp.Metrics.COUNT,
-    ],
+    params = pipeline_dp.AggregateParams(metrics=[pipeline_dp.Metrics.COUNT],
                                          max_partitions_contributed=2,
                                          max_contributions_per_partition=1,
                                          low=1,

--- a/pipeline_dp/__init__.py
+++ b/pipeline_dp/__init__.py
@@ -1,3 +1,4 @@
+from pipeline_dp.budget_accounting import BudgetAccountant
 from pipeline_dp.budget_accounting import NaiveBudgetAccountant
 from pipeline_dp.aggregate_params import AggregateParams
 from pipeline_dp.aggregate_params import Metrics

--- a/pipeline_dp/__init__.py
+++ b/pipeline_dp/__init__.py
@@ -1,4 +1,4 @@
-from pipeline_dp.budget_accounting import BudgetAccountant
+from pipeline_dp.budget_accounting import NaiveBudgetAccountant
 from pipeline_dp.aggregate_params import AggregateParams
 from pipeline_dp.aggregate_params import Metrics
 from pipeline_dp.aggregate_params import NoiseKind, NormKind

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -6,9 +6,9 @@ from functools import reduce
 
 from typing import Iterable, Optional, Tuple, Union
 import pipeline_dp
-from pipeline_dp import dp_computations
 from pipeline_dp import aggregate_params
 from pipeline_dp import dp_computations
+from pipeline_dp import budget_accounting
 import numpy as np
 
 
@@ -25,7 +25,7 @@ def merge(accumulators: typing.Iterable['Accumulator']) -> 'Accumulator':
 
 def create_accumulator_params(
     aggregation_params: pipeline_dp.AggregateParams,
-    budget_accountant: pipeline_dp.BudgetAccountant
+    budget_accountant: budget_accounting.BudgetAccountant
 ) -> typing.List[AccumulatorParams]:
     accumulator_params = []
     if pipeline_dp.Metrics.COUNT in aggregation_params.metrics:
@@ -148,7 +148,7 @@ class AccumulatorFactory:
     AggregateParams and BudgetAccountant."""
 
     def __init__(self, params: pipeline_dp.AggregateParams,
-                 budget_accountant: pipeline_dp.BudgetAccountant):
+                 budget_accountant: budget_accounting.BudgetAccountant):
         self._params = params
         self._budget_accountant = budget_accountant
 

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -197,7 +197,6 @@ class CountAccumulator(Accumulator):
 
     def __init__(self, params: CountParams, values):
         self._count = len(values)
-        self.privacy_id_count = 27  # todo remove, only for debug
 
     def add_value(self, value):
         self._count += 1

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -179,6 +179,7 @@ class CountAccumulator(Accumulator):
 
     def __init__(self, params: CountParams, values):
         self._count = len(values)
+        self.privacy_id_count = 27  # todo remove, only for debug
 
     def add_value(self, value):
         self._count += 1

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -76,7 +76,7 @@ class MechanismSpec:
         return
 
     def use_delta(self) -> bool:
-        return self.mechanism_type == MechanismType.GAUSSIAN
+        return self.mechanism_type != MechanismType.LAPLACE
 
 
 @dataclass

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -92,7 +92,8 @@ class DPEngine:
         # col : (partition_key, accumulator)
 
         # Compute DP metrics.
-        col = self._ops.map_values(col, lambda acc: acc.compute_metrics())
+        col = self._ops.map_values(col, lambda acc: acc.compute_metrics(),
+                                   "Compute DP` metrics")
 
         return col
 
@@ -178,4 +179,4 @@ class DPEngine:
 
         # make filter_fn serializable
         filter_fn = partial(filter_fn, (budget, max_partitions_contributed))
-        return self._ops.filter(col, filter_fn)
+        return self._ops.filter(col, filter_fn, "Filter private parititions")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -60,7 +60,7 @@ class DPEngine:
         aggregator_fn = accumulator_factory.create
 
         if params.public_partitions is not None:
-            # TODO: make aggregate with public partition work.
+            # TODO: make work with public partition.
             col = self._drop_not_public_partitions(col,
                                                    params.public_partitions,
                                                    data_extractors)

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -60,7 +60,7 @@ class _MockAccumulator(pipeline_dp.accumulator.Accumulator):
         return f"MockAccumulator({self.values_list})"
 
 
-class dp_engineTest(unittest.TestCase):
+class DpEngineTest(unittest.TestCase):
     aggregator_fn = lambda input_values: (len(input_values), np.sum(
         input_values), np.sum(np.square(input_values)))
 
@@ -77,7 +77,7 @@ class dp_engineTest(unittest.TestCase):
                 input_col,
                 max_partitions_contributed=max_partitions_contributed,
                 max_contributions_per_partition=max_contributions_per_partition,
-                aggregator_fn=dp_engineTest.aggregator_fn))
+                aggregator_fn=DpEngineTest.aggregator_fn))
 
         self.assertFalse(bound_result)
 
@@ -95,7 +95,7 @@ class dp_engineTest(unittest.TestCase):
                 input_col,
                 max_partitions_contributed=max_partitions_contributed,
                 max_contributions_per_partition=max_contributions_per_partition,
-                aggregator_fn=dp_engineTest.aggregator_fn))
+                aggregator_fn=DpEngineTest.aggregator_fn))
 
         expected_result = [(('pid1', 'pk2'), (2, 7, 25)),
                            (('pid1', 'pk1'), (2, 3, 5))]
@@ -115,7 +115,7 @@ class dp_engineTest(unittest.TestCase):
                 input_col,
                 max_partitions_contributed=max_partitions_contributed,
                 max_contributions_per_partition=max_contributions_per_partition,
-                aggregator_fn=dp_engineTest.aggregator_fn))
+                aggregator_fn=DpEngineTest.aggregator_fn))
 
         self.assertEqual(len(bound_result), 3)
         # Check contributions per partitions
@@ -140,7 +140,7 @@ class dp_engineTest(unittest.TestCase):
                 input_col,
                 max_partitions_contributed=max_partitions_contributed,
                 max_contributions_per_partition=max_contributions_per_partition,
-                aggregator_fn=dp_engineTest.aggregator_fn))
+                aggregator_fn=DpEngineTest.aggregator_fn))
 
         self.assertEqual(len(bound_result), 4)
         # Check contributions per partitions

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -168,8 +168,8 @@ class DpEngineTest(unittest.TestCase):
     def test_aggregate_report(self, mock_create_accumulator_params_function):
         col = [[1], [2], [3], [3]]
         data_extractor = pipeline_dp.DataExtractors(
-            privacy_id_extractor=lambda x: "pid" + str(x),
-            partition_extractor=lambda x: "pk" + str(x),
+            privacy_id_extractor=lambda x: f"pid{x}",
+            partition_extractor=lambda x: f"pk{x}",
             value_extractor=lambda x: x)
         params1 = pipeline_dp.AggregateParams(
             max_partitions_contributed=3,
@@ -217,8 +217,8 @@ class DpEngineTest(unittest.TestCase):
 
         col = [[1], [2], [3], [3]]
         data_extractor = pipeline_dp.DataExtractors(
-            privacy_id_extractor=lambda x: "pid" + str(x),
-            partition_extractor=lambda x: "pk" + str(x),
+            privacy_id_extractor=lambda x: f"pid{x}",
+            partition_extractor=lambda x: f"pk{x}",
             value_extractor=lambda x: x)
 
         mock_bound_contributions.return_value = [
@@ -314,7 +314,7 @@ class DpEngineTest(unittest.TestCase):
         col = list(range(10)) + list(range(100, 120))
         data_extractor = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x,
-            partition_extractor=lambda x: "pk" + str(x // 100),
+            partition_extractor=lambda x: f"pk{x//100}",
             value_extractor=lambda x: None)
 
         engine = pipeline_dp.DPEngine(budget_accountant=budget_accountant,
@@ -349,7 +349,7 @@ class DpEngineTest(unittest.TestCase):
         col = list(range(100))
         data_extractor = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x,
-            partition_extractor=lambda x: "pk" + str(x),
+            partition_extractor=lambda x: f"pk{x}",
             value_extractor=lambda x: None)
 
         engine = pipeline_dp.DPEngine(budget_accountant=budget_accountant,

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -302,6 +302,17 @@ class DpEngineTest(unittest.TestCase):
                                                  expected_data_filtered,
                                                  max_partitions_contributed)
 
+class DpEngineComputationGraphTest(unittest.TestCase):
+
+    def test_aggregate_private_partitions(self):
+        input_col = []
+        params = pipeline_dp.AggregateParams()
+
+        dp_engine = pipeline_dp.DPEngine(
+            NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-10),
+            pipeline_dp.LocalPipelineOperations())
+
+        res_col = dp_engine.aggregate(input_col, params)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR finishes implementation of the computation graph (which is implemented by `DPEngine.aggregate` ) for computing DP metrics with private partition selection. 