### PR TITLE
Add SumParams to movie example and tests

### DIFF
--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -52,24 +52,28 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
     dp_engine = pipeline_dp.DPEngine(budget_accountant, ops)
 
     # Specify which DP aggregated metrics to compute.
-    params = pipeline_dp.AggregateParams(metrics=[pipeline_dp.Metrics.COUNT],
-                                         max_partitions_contributed=2,
-                                         max_contributions_per_partition=1,
-                                         low=1,
-                                         high=5,
-                                         public_partitions=public_partitions)
+    params = pipeline_dp.AggregateParams(
+        noise_kind=pipeline_dp.aggregate_params.NoiseKind.LAPLACE,
+        metrics=[pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.SUM],
+        max_partitions_contributed=2,
+        max_contributions_per_partition=1,
+        low=1,
+        high=5,
+        public_partitions=public_partitions)
 
-    # Specify how to extract is privacy_id, partition_key and value from an
+    # Specify how to extract privacy_id, partition_key and value from an
     # element of movie view collection.
     data_extractors = pipeline_dp.DataExtractors(
         partition_extractor=lambda mv: mv.movie_id,
         privacy_id_extractor=lambda mv: mv.user_id,
         value_extractor=lambda mv: mv.rating)
-
+    # TODO Not sure if we want the client to have to make these calls to budget accountant
+    # but without these there will be epsilon, delta, and empty mechanisms errors
+    budget_accountant.request_budget(pipeline_dp.MechanismType.LAPLACE)
+    budget_accountant.compute_budgets()
     # Run aggregation.
     dp_result = dp_engine.aggregate(movie_views, params, data_extractors)
 
-    budget_accountant.compute_budgets()
     return dp_result
 
 

--- a/examples/movie_view_ratings.py
+++ b/examples/movie_view_ratings.py
@@ -53,7 +53,7 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
 
     # Specify which DP aggregated metrics to compute.
     params = pipeline_dp.AggregateParams(
-        noise_kind=pipeline_dp.aggregate_params.NoiseKind.LAPLACE,
+        noise_kind=pipeline_dp.NoiseKind.LAPLACE,
         metrics=[pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.SUM],
         max_partitions_contributed=2,
         max_contributions_per_partition=1,
@@ -67,13 +67,11 @@ def calc_dp_rating_metrics(movie_views, ops, public_partitions):
         partition_extractor=lambda mv: mv.movie_id,
         privacy_id_extractor=lambda mv: mv.user_id,
         value_extractor=lambda mv: mv.rating)
-    # TODO Not sure if we want the client to have to make these calls to budget accountant
-    # but without these there will be epsilon, delta, and empty mechanisms errors
-    budget_accountant.request_budget(pipeline_dp.MechanismType.LAPLACE)
-    budget_accountant.compute_budgets()
+
     # Run aggregation.
     dp_result = dp_engine.aggregate(movie_views, params, data_extractors)
 
+    budget_accountant.compute_budgets()
     return dp_result
 
 

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -33,6 +33,13 @@ def create_accumulator_params(
         accumulator_params.append(
             AccumulatorParams(accumulator_type=CountAccumulator,
                               constructor_params=CountParams()))
+    if pipeline_dp.Metrics.SUM in aggregation_params.metrics:
+        budget = budget_accountant.request_budget(
+            aggregation_params.noise_kind.convert_to_mechanism_type())
+        sum_params = SumParams(budget, aggregation_params)
+        accumulator_params.append(
+            AccumulatorParams(accumulator_type=SumAccumulator,
+                              constructor_params=sum_params))
     else:
         raise NotImplemented()  # implementation will be done later
     return accumulator_params
@@ -257,9 +264,34 @@ class VectorSummationAccumulator(Accumulator):
         return dp_computations.add_noise_vector(self._vec_sum, self._params)
 
 
-@dataclass
 class SumParams:
-    noise: dp_computations.MeanVarParams
+    """Parameters for a sum accumulator.
+
+    Wraps epsilon and delta from the budget which are lazily loaded.
+    AggregateParams are copied into a MeanVarParams instance.
+    """
+
+    def __init__(self, budget: pipeline_dp.budget_accounting.MechanismSpec,
+                 aggregate_params: aggregate_params.AggregateParams):
+        self._budget = budget
+        self._aggregate_params = aggregate_params
+
+    @property
+    def eps(self):
+        return self._budget.eps
+
+    @property
+    def delta(self):
+        return self._budget.delta
+
+    @property
+    def mean_var_params(self):
+        return dp_computations.MeanVarParams(
+            self.eps, self.delta, self._aggregate_params.low,
+            self._aggregate_params.high,
+            self._aggregate_params.max_partitions_contributed,
+            self._aggregate_params.max_contributions_per_partition,
+            self._aggregate_params.noise_kind)
 
 
 class SumAccumulator(Accumulator):
@@ -278,4 +310,4 @@ class SumAccumulator(Accumulator):
 
     def compute_metrics(self) -> float:
         return pipeline_dp.dp_computations.compute_dp_sum(
-            self._sum, self._params.noise)
+            self._sum, self._params.mean_var_params)

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -40,8 +40,7 @@ def create_accumulator_params(
         accumulator_params.append(
             AccumulatorParams(accumulator_type=SumAccumulator,
                               constructor_params=sum_params))
-    else:
-        raise NotImplemented()  # implementation will be done later
+
     return accumulator_params
 
 

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -265,7 +265,7 @@ class VectorSummationAccumulator(Accumulator):
 
 
 class SumParams:
-    """Parameters for a sum accumulator.
+    """Parameters for a SumAccumulator.
 
     Wraps epsilon and delta from the budget which are lazily loaded.
     AggregateParams are copied into a MeanVarParams instance.

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -17,6 +17,12 @@ class NoiseKind(Enum):
     LAPLACE = 'laplace'
     GAUSSIAN = 'gaussian'
 
+    def convert_to_mechanism_type(self):
+        if self.value == NoiseKind.LAPLACE.value:
+            return MechanismType.LAPLACE
+        elif self.value == NoiseKind.GAUSSIAN.value:
+            return MechanismType.GAUSSIAN
+
 
 class MechanismType(Enum):
     LAPLACE = 'laplace'
@@ -36,6 +42,7 @@ class AggregateParams:
     """Specifies parameters for function DPEngine.aggregate()
 
   Args:
+    noise_kind: Kind of noise to use for the calculation.
     metrics: Metrics to compute.
     max_partitions_contributed: Bounds the number of partitions in which one
       unit of privacy (e.g., a user) can participate.
@@ -48,6 +55,7 @@ class AggregateParams:
       the result.
   """
 
+    noise_kind: NoiseKind
     metrics: Iterable[Metrics]
     max_partitions_contributed: int
     max_contributions_per_partition: int

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -42,7 +42,7 @@ class AggregateParams:
     """Specifies parameters for function DPEngine.aggregate()
 
   Args:
-    noise_kind: Kind of noise to use for the calculation.
+    noise_kind: Kind of noise to use for the DP calculations.
     metrics: Metrics to compute.
     max_partitions_contributed: Bounds the number of partitions in which one
       unit of privacy (e.g., a user) can participate.

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -165,6 +165,7 @@ class DPEngine:
         """
         budget = self._budget_accountant.request_budget(
             mechanism_type=MechanismType.GENERIC)
+        self._budget_accountant.compute_budgets()
 
         def filter_fn(captures: Tuple[MechanismSpec, int],
                       row: Tuple[Any, Accumulator]) -> bool:

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -165,7 +165,6 @@ class DPEngine:
         """
         budget = self._budget_accountant.request_budget(
             mechanism_type=MechanismType.GENERIC)
-        self._budget_accountant.compute_budgets()
 
         def filter_fn(captures: Tuple[MechanismSpec, int],
                       row: Tuple[Any, Accumulator]) -> bool:

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -172,6 +172,7 @@ class DpEngineTest(unittest.TestCase):
             partition_extractor=lambda x: f"pk{x}",
             value_extractor=lambda x: x)
         params1 = pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
             max_partitions_contributed=3,
             max_contributions_per_partition=2,
             low=1,
@@ -182,6 +183,7 @@ class DpEngineTest(unittest.TestCase):
             ],
         )
         params2 = pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
             max_partitions_contributed=1,
             max_contributions_per_partition=3,
             low=2,
@@ -207,8 +209,11 @@ class DpEngineTest(unittest.TestCase):
     def test_aggregate_computation_graph_verification(self,
                                                       mock_bound_contributions):
         # Arrange
-        aggregator_params = pipeline_dp.AggregateParams([agg.Metrics.COUNT], 5,
-                                                        3)
+        aggregator_params = pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            metrics=[agg.Metrics.COUNT],
+            max_partitions_contributed=5,
+            max_contributions_per_partition=3)
         budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
                                                   total_delta=1e-10)
         accumulator_factory = AccumulatorFactory(
@@ -304,8 +309,11 @@ class DpEngineTest(unittest.TestCase):
 
     def test_aggregate_private_partition_selection_keep_everything(self):
         # Arrange
-        aggregator_params = pipeline_dp.AggregateParams([agg.Metrics.COUNT], 1,
-                                                        1)
+        aggregator_params = pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            metrics=[agg.Metrics.COUNT],
+            max_partitions_contributed=1,
+            max_contributions_per_partition=1)
         # Set a large budget for having the small noise and keeping all
         # partition keys.
         budget_accountant = NaiveBudgetAccountant(total_epsilon=1000,
@@ -337,8 +345,11 @@ class DpEngineTest(unittest.TestCase):
 
     def test_aggregate_private_partition_selection_drop_many(self):
         # Arrange
-        aggregator_params = pipeline_dp.AggregateParams([agg.Metrics.COUNT], 1,
-                                                        1)
+        aggregator_params = pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            metrics=[agg.Metrics.COUNT],
+            max_partitions_contributed=1,
+            max_contributions_per_partition=1)
         # Set a large budget for having the small noise and keeping all
         # partition keys.
         budget_accountant = NaiveBudgetAccountant(total_epsilon=1,

--- a/tests/report_generator_test.py
+++ b/tests/report_generator_test.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+import pipeline_dp
 from pipeline_dp.aggregate_params import AggregateParams, Metrics
 from pipeline_dp.report_generator import ReportGenerator
 
@@ -17,7 +18,8 @@ class ReportGeneratorTest(unittest.TestCase):
                        "\n1. Eat between (1, 5) snacks"
                        "\n2. Eat a maximum of snack varieties total: 2"
                        "\n3. Eat a maximum of a single snack variety: 1")
-        params = AggregateParams(max_partitions_contributed=2,
+        params = AggregateParams(noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+                                 max_partitions_contributed=2,
                                  max_contributions_per_partition=1,
                                  low=1,
                                  high=5,


### PR DESCRIPTION
## Description
Add functionality for SumAccumulator through SumParams.

## Affected Dependencies
None.

## How has this been tested?
- `GenericAccumulatorTest.test_create_accumulator_params_with_sum_params`
- `SumAccumulatorTest.test_without_noise`
- `SumAccumulatorTest.test_with_noise`
- `movie_view_ratings.calc_dp_rating_metrics`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
