### PR TITLE
Fix GitHub actions for macOS by upgrading to python3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,9 +49,10 @@ jobs:
           submodules: true
 
       - name: Install dependencies
+        # In macOS, python && pip use python2 and python3 && pip3 use python3.
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.dev.txt
+          python -m pip install --upgrade pip || python3 -m pip install --upgrade pip
+          pip install -r requirements.dev.txt || pip3 install -r requirements.dev.txt
 
       - name: Run pytest
         run: |


### PR DESCRIPTION
## Description
GitHub actions for macOS are failing because python2 is being used instead of python3. This PR fixes that.

## How has this been tested?

## Checklist
- [+] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [+] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [+] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [+] My changes are covered by tests
