### PR TITLE
Debugging by removing multiple budget accountants in accumulator

### DIFF
--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -30,22 +30,20 @@ def create_accumulator_params(
 ) -> typing.List[AccumulatorParams]:
     accumulator_params = []
     mechanism_type = aggregation_params.noise_kind.convert_to_mechanism_type()
+    budget_accountant = budget_accountant.request_budget(
+        mechanism_type)
     if pipeline_dp.Metrics.COUNT in aggregation_params.metrics:
-        budget_count = budget_accountant.request_budget(mechanism_type)
-        count_params = CountParams(budget_count, aggregation_params)
+        count_params = CountParams(budget_accountant, aggregation_params)
         accumulator_params.append(
             AccumulatorParams(accumulator_type=CountAccumulator,
                               constructor_params=count_params))
     if pipeline_dp.Metrics.SUM in aggregation_params.metrics:
-        budget_sum = budget_accountant.request_budget(mechanism_type)
-        sum_params = SumParams(budget_sum, aggregation_params)
+        sum_params = SumParams(budget_accountant, aggregation_params)
         accumulator_params.append(
             AccumulatorParams(accumulator_type=SumAccumulator,
                               constructor_params=sum_params))
     if pipeline_dp.Metrics.PRIVACY_ID_COUNT in aggregation_params.metrics:
-        budget_privacy_id_count = budget_accountant.request_budget(
-            mechanism_type)
-        privacy_id_count_params = PrivacyIdCountParams(budget_privacy_id_count,
+        privacy_id_count_params = PrivacyIdCountParams(budget_accountant,
                                                        aggregation_params)
         accumulator_params.append(
             AccumulatorParams(accumulator_type=PrivacyIdCountAccumulator,


### PR DESCRIPTION
## Description
This appears to fix the large noise variation in the demo: [Colab that pulls from OpenMined:main](https://colab.sandbox.google.com/drive/1paOyAew60fOe-v7ZSr0To-ZmUz5MzhWe#scrollTo=k_Nu7EO3jPI1) 

As shown in : [Colab that pulls from this branch jspacek:debug-demo-sum](https://colab.sandbox.google.com/drive/13dxBoNkvD9WeMMkPasatnfwDGuqHMP5t#scrollTo=k_Nu7EO3jPI1) there are no negative results after running the demo multiple times.

I'm not sure this should be the fix; perhaps another bit of code further down the line needs to divide the noise by the number of mechanisms in the budget accountant?

## Affected Dependencies

## How has this been tested?
TODO likely a new test in dp_engine_test e2e

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
