### PR TITLE
Add report generator for dp_engine

### DIFF
--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -25,9 +25,9 @@ class NoiseKind(Enum):
 
 
 class MechanismType(Enum):
-    LAPLACE = 'laplace'
-    GAUSSIAN = 'gaussian'
-    GENERIC = 'generic'
+    LAPLACE = 'Laplace'
+    GAUSSIAN = 'Gaussian'
+    GENERIC = 'Truncated Geometric'
 
 
 class NormKind(Enum):

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -133,6 +133,9 @@ class DPEngine:
         col = self._ops.sample_fixed_per_key(
             col, max_contributions_per_partition,
             "Sample per (privacy_id, partition_key)")
+        self._add_report_stage(
+            f"Per-partition contribution: randomly selected not "
+            f"more than {max_contributions_per_partition} contributions")
         # ((privacy_id, partition_key), [value])
         col = self._ops.map_values(
             col, aggregator_fn,
@@ -147,8 +150,11 @@ class DPEngine:
         col = self._ops.sample_fixed_per_key(col, max_partitions_contributed,
                                              "Sample per privacy_id")
 
-        # (privacy_id, [(partition_key, aggregator)])
+        self._add_report_stage(
+            f"Contribution bounding: randomly selected not more than "
+            f"{max_partitions_contributed} partitions per user")
 
+        # (privacy_id, [(partition_key, aggregator)])
         def unnest_cross_partition_bound_sampled_per_key(pid_pk_v):
             pid, pk_values = pid_pk_v
             return (((pid, pk), v) for (pk, v) in pk_values)

--- a/pipeline_dp/report_generator.py
+++ b/pipeline_dp/report_generator.py
@@ -24,7 +24,7 @@ class ReportGenerator:
         """Constructs a report based on stages and metrics."""
         if self._params is None:
             return ""
-        title = f"Computing metrics: {[m.value[0] for m in self._params.metrics]}"
+        title = f"Computing metrics: {[m.value for m in self._params.metrics]}"
         result = [f"Differentially private: {title}"]
         for i, stage_str in enumerate(self._stages):
             if hasattr(stage_str, "__call__"):

--- a/pipeline_dp/report_generator.py
+++ b/pipeline_dp/report_generator.py
@@ -25,7 +25,7 @@ class ReportGenerator:
         if self._params is None:
             return ""
         title = f"Computing metrics: {[m.value[0] for m in self._params.metrics]}"
-        result = [f"Differential private: {title}"]
+        result = [f"Differentially private: {title}"]
         for i, stage_str in enumerate(self._stages):
             if hasattr(stage_str, "__call__"):
                 result.append(f"{i+1}. {stage_str()}")

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -12,8 +12,9 @@ import pipeline_dp
 from pipeline_dp.budget_accounting import NaiveBudgetAccountant
 import pydp.algorithms.partition_selection as partition_selection
 from pipeline_dp import aggregate_params as agg
-from pipeline_dp.accumulator import CountAccumulator
 from pipeline_dp.accumulator import AccumulatorFactory
+from pipeline_dp.accumulator import CountAccumulator
+from pipeline_dp.report_generator import ReportGenerator
 from pipeline_dp.pipeline_operations import PipelineOperations
 """DPEngine Test"""
 
@@ -196,17 +197,27 @@ class DpEngineTest(unittest.TestCase):
             pipeline_dp.accumulator.AccumulatorParams(
                 pipeline_dp.accumulator.CountAccumulator, None)
         ]
-        engine = pipeline_dp.DPEngine(budget_accountant=NaiveBudgetAccountant(
-            total_epsilon=1, total_delta=1e-10),
+        budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
+                                                  total_delta=1e-10)
+        engine = pipeline_dp.DPEngine(budget_accountant=budget_accountant,
                                       ops=pipeline_dp.LocalPipelineOperations())
         engine.aggregate(col, params1, data_extractor)
         engine.aggregate(col, params2, data_extractor)
         self.assertEqual(len(engine._report_generators), 2)  # pylint: disable=protected-access
+        budget_accountant.compute_budgets()
         self.assertEqual(
             engine._report_generators[0].report(),
-            "Differentially private: Computing metrics: ['p', 'c', 'm']"
-            "\n1. Per-partition contribution: randomly selected not more than 2 contributions"
-            "\n2. Contribution bounding: randomly selected not more than 3 partitions per user"
+            "Differentially private: Computing metrics: ['privacy_id_count', 'count', 'mean']"
+            "\n1. Per-partition contribution bounding: randomly selected not more than 2 contributions"
+            "\n2. Cross-partition contribution bounding: randomly selected not more than 3 partitions per user"
+            "\n3. Private Partition selection: using Truncated Geometric method with (eps= 1.0, delta = 1e-10)"
+        )
+        self.assertEqual(
+            engine._report_generators[1].report(),
+            "Differentially private: Computing metrics: ['variance', 'sum', 'mean']"
+            "\n1. Public partition selection: dropped non public partitions"
+            "\n2. Per-partition contribution bounding: randomly selected not more than 3 contributions"
+            "\n3. Cross-partition contribution bounding: randomly selected not more than 1 partitions per user"
         )
 
     @patch('pipeline_dp.DPEngine._bound_contributions')
@@ -270,9 +281,7 @@ class DpEngineTest(unittest.TestCase):
                      ("pid1", ('pk2', 5)), ("pid1", ('pk3', 6)),
                      ("pid1", ('pk4', 7)), ("pid2", ('pk4', 8))]
         max_partitions_contributed = 3
-        engine = pipeline_dp.DPEngine(
-            NaiveBudgetAccountant(total_epsilon=1, total_delta=1e-10),
-            pipeline_dp.LocalPipelineOperations())
+        engine = self.create_dp_engine_default()
         groups = engine._ops.group_by_key(input_col, None)
         groups = engine._ops.map_values(groups,
                                         lambda group: _MockAccumulator(group))
@@ -395,14 +404,10 @@ class DpEngineTest(unittest.TestCase):
         dp_engine = pipeline_dp.DPEngine(accountant, ops)
         aggregator_params = pipeline_dp.AggregateParams(
             noise_kind=pipeline_dp.NoiseKind.LAPLACE,
-            metrics=[agg.Metrics.COUNT],
+            metrics=[],
             max_partitions_contributed=1,
             max_contributions_per_partition=1)
-        data_extractor = pipeline_dp.DataExtractors(
-            privacy_id_extractor=lambda x: x,
-            partition_extractor=lambda x: f"pk{x//2}",
-            value_extractor=lambda x: x)
-        dp_engine.aggregate([], aggregator_params, data_extractor)
+        dp_engine._report_generators.append(ReportGenerator(aggregator_params))
         dp_engine._add_report_stage("DP Engine Test")
         return dp_engine
 

--- a/tests/report_generator_test.py
+++ b/tests/report_generator_test.py
@@ -13,7 +13,7 @@ class ReportGeneratorTest(unittest.TestCase):
         self.assertEqual("", ReportGenerator(None).report())
 
     def test_report_params(self):
-        test_report = ("Differential private: Computing metrics: "
+        test_report = ("Differentially private: Computing metrics: "
                        "['p', 'c', 'm', 's', 'v']"
                        "\n1. Eat between (1, 5) snacks"
                        "\n2. Eat a maximum of snack varieties total: 2"

--- a/tests/report_generator_test.py
+++ b/tests/report_generator_test.py
@@ -13,11 +13,12 @@ class ReportGeneratorTest(unittest.TestCase):
         self.assertEqual("", ReportGenerator(None).report())
 
     def test_report_params(self):
-        test_report = ("Differentially private: Computing metrics: "
-                       "['p', 'c', 'm', 's', 'v']"
-                       "\n1. Eat between (1, 5) snacks"
-                       "\n2. Eat a maximum of snack varieties total: 2"
-                       "\n3. Eat a maximum of a single snack variety: 1")
+        test_report = (
+            "Differentially private: Computing metrics: "
+            "['privacy_id_count', 'count', 'mean', 'sum', 'variance']"
+            "\n1. Eat between (1, 5) snacks"
+            "\n2. Eat a maximum of snack varieties total: 2"
+            "\n3. Eat a maximum of a single snack variety: 1")
         params = AggregateParams(noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
                                  max_partitions_contributed=2,
                                  max_contributions_per_partition=1,


### PR DESCRIPTION
## Description

This adds the report generator stages for aggregate params and contribution bounding.
It also adds a helper method for the tests so that they do not break when testing private functions.

It does not include the report stages for noise kind settings as this will be done following a refactoring. 

## Affected Dependencies
N/A

## How has this been tested?
- dp_engine_test

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
