### PR TITLE
Introduce AccumulatorFactory hierarchy

### DIFF
--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -18,7 +18,7 @@ def merge(accumulators: typing.Iterable['Accumulator']) -> 'Accumulator':
     return reduce(lambda acc1, acc2: acc1.add_accumulator(acc2), accumulators)
 
 
-def create_accumulator_factories(
+def _create_accumulator_factories(
     aggregation_params: pipeline_dp.AggregateParams,
     budget_accountant: budget_accounting.BudgetAccountant
 ) -> typing.List['AccumulatorFactory']:
@@ -199,7 +199,7 @@ class CompoundAccumulatorFactory(AccumulatorFactory):
                  budget_accountant: budget_accounting.BudgetAccountant):
         self._params = params
         self._budget_accountant = budget_accountant
-        self._accumulator_factories = create_accumulator_factories(
+        self._accumulator_factories = _create_accumulator_factories(
             params, budget_accountant)
 
     def create(self, values: typing.List) -> Accumulator:

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -204,8 +204,8 @@ class CompoundAccumulatorFactory(AccumulatorFactory):
             self) -> typing.List[budget_accounting.MechanismSpec]:
         """Returns MechanismSpecs of accumulators which will be created."""
         return [
-            acc.constructor_params._mechanism_spec
-            for acc in self._accumulator_params
+            factory._params._mechanism_spec
+            for factory in self._accumulator_factories
         ]
 
 

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -176,6 +176,11 @@ class CompoundAccumulator(Accumulator):
 
 
 class AccumulatorFactory(abc.ABC):
+    """Abstract base class for all accumulator factories.
+
+    Each concrete implementation of AccumulatorFactory creates Accumulator of
+    the specific type.
+    """
 
     @abc.abstractmethod
     def create(self, values: typing.List) -> Accumulator:
@@ -183,8 +188,12 @@ class AccumulatorFactory(abc.ABC):
 
 
 class CompoundAccumulatorFactory(AccumulatorFactory):
-    """TODO: Factory for producing the appropriate Accumulator depending on the
-    AggregateParams and BudgetAccountant."""
+    """Factory for creating CompoundAccumulator.
+
+    CompoundAccumulatorFactory contains one or more AccumulatorFactories which
+    create accumulators for specific metrics. These AccumulatorFactories are
+    created based on pipeline_dp.AggregateParams.
+    """
 
     def __init__(self, params: pipeline_dp.AggregateParams,
                  budget_accountant: budget_accounting.BudgetAccountant):
@@ -210,7 +219,7 @@ class CompoundAccumulatorFactory(AccumulatorFactory):
 
 
 class AccumulatorClassParams:
-    """Parameters for a an accumulator.
+    """Parameters for an accumulator.
 
     Wraps epsilon and delta from the MechanismSpec which are lazily loaded.
     AggregateParams are copied into a MeanVarParams instance.

--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -13,45 +13,34 @@ from pipeline_dp import budget_accounting
 import numpy as np
 
 
-@dataclass
-class AccumulatorParams:
-    accumulator_type: type
-    constructor_params: typing.Any
-
-
 def merge(accumulators: typing.Iterable['Accumulator']) -> 'Accumulator':
     """Merges the accumulators."""
     return reduce(lambda acc1, acc2: acc1.add_accumulator(acc2), accumulators)
 
 
-def create_accumulator_params(
+def create_accumulator_factories(
     aggregation_params: pipeline_dp.AggregateParams,
     budget_accountant: budget_accounting.BudgetAccountant
-) -> typing.List[AccumulatorParams]:
-    accumulator_params = []
+) -> typing.List['AccumulatorFactory']:
+    factories = []
     mechanism_type = aggregation_params.noise_kind.convert_to_mechanism_type()
     if pipeline_dp.Metrics.COUNT in aggregation_params.metrics:
         budget_count = budget_accountant.request_budget(mechanism_type)
         count_params = CountParams(budget_count, aggregation_params)
-        accumulator_params.append(
-            AccumulatorParams(accumulator_type=CountAccumulator,
-                              constructor_params=count_params))
+        factories.append(CountAccumulatorFactory(count_params))
     if pipeline_dp.Metrics.SUM in aggregation_params.metrics:
         budget_sum = budget_accountant.request_budget(mechanism_type)
         sum_params = SumParams(budget_sum, aggregation_params)
-        accumulator_params.append(
-            AccumulatorParams(accumulator_type=SumAccumulator,
-                              constructor_params=sum_params))
+        factories.append(SumAccumulatorFactory(sum_params))
     if pipeline_dp.Metrics.PRIVACY_ID_COUNT in aggregation_params.metrics:
         budget_privacy_id_count = budget_accountant.request_budget(
             mechanism_type)
         privacy_id_count_params = PrivacyIdCountParams(budget_privacy_id_count,
                                                        aggregation_params)
-        accumulator_params.append(
-            AccumulatorParams(accumulator_type=PrivacyIdCountAccumulator,
-                              constructor_params=privacy_id_count_params))
+        factories.append(
+            PrivacyIdCountAccumulatorFactory(privacy_id_count_params))
 
-    return accumulator_params
+    return factories
 
 
 class Accumulator(abc.ABC):
@@ -186,25 +175,28 @@ class CompoundAccumulator(Accumulator):
         ]
 
 
-class AccumulatorFactory:
-    """Factory for producing the appropriate Accumulator depending on the
+class AccumulatorFactory(abc.ABC):
+
+    @abc.abstractmethod
+    def create(self, values: typing.List) -> Accumulator:
+        pass
+
+
+class CompoundAccumulatorFactory(AccumulatorFactory):
+    """TODO: Factory for producing the appropriate Accumulator depending on the
     AggregateParams and BudgetAccountant."""
 
     def __init__(self, params: pipeline_dp.AggregateParams,
                  budget_accountant: budget_accounting.BudgetAccountant):
         self._params = params
         self._budget_accountant = budget_accountant
-
-    def initialize(self):
-        self._accumulator_params = create_accumulator_params(
-            self._params, self._budget_accountant)
+        self._accumulator_factories = create_accumulator_factories(
+            params, budget_accountant)
 
     def create(self, values: typing.List) -> Accumulator:
         accumulators = []
-        for accumulator_param in self._accumulator_params:
-            accumulators.append(
-                accumulator_param.accumulator_type(
-                    accumulator_param.constructor_params, values))
+        for factory in self._accumulator_factories:
+            accumulators.append(factory.create(values))
 
         return CompoundAccumulator(accumulators)
 
@@ -276,6 +268,15 @@ class PrivacyIdCountAccumulator(Accumulator):
                                                 self._params.mean_var_params)
 
 
+class PrivacyIdCountAccumulatorFactory(AccumulatorFactory):
+
+    def __init__(self, params: PrivacyIdCountParams):
+        self._params = params
+
+    def create(self, values: typing.List) -> PrivacyIdCountAccumulator:
+        return PrivacyIdCountAccumulator(self._params, values)
+
+
 class CountParams(AccumulatorClassParams):
     pass
 
@@ -298,6 +299,15 @@ class CountAccumulator(Accumulator):
     def compute_metrics(self) -> float:
         return dp_computations.compute_dp_count(self._count,
                                                 self._params.mean_var_params)
+
+
+class CountAccumulatorFactory(AccumulatorFactory):
+
+    def __init__(self, params: CountParams):
+        self._params = params
+
+    def create(self, values: typing.List) -> CountAccumulator:
+        return CountAccumulator(self._params, values)
 
 
 _FloatVector = Union[Tuple[float], np.ndarray]
@@ -368,3 +378,12 @@ class SumAccumulator(Accumulator):
     def compute_metrics(self) -> float:
         return dp_computations.compute_dp_sum(self._sum,
                                               self._params.mean_var_params)
+
+
+class SumAccumulatorFactory(AccumulatorFactory):
+
+    def __init__(self, params: SumParams):
+        self._params = params
+
+    def create(self, values: typing.List) -> SumAccumulator:
+        return SumAccumulator(self._params, values)

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -22,7 +22,6 @@ from pipeline_dp.accumulator import CompoundAccumulatorFactory
 import pydp.algorithms.partition_selection as partition_selection
 
 
-
 @dataclass
 class DataExtractors:
     """Data extractors.

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -10,7 +10,7 @@ from pipeline_dp.budget_accounting import BudgetAccountant, MechanismSpec
 from pipeline_dp.pipeline_operations import PipelineOperations
 from pipeline_dp.report_generator import ReportGenerator
 from pipeline_dp.accumulator import Accumulator
-from pipeline_dp.accumulator import AccumulatorFactory
+from pipeline_dp.accumulator import CompoundAccumulatorFactory
 
 import pydp.algorithms.partition_selection as partition_selection
 
@@ -54,9 +54,8 @@ class DPEngine:
             return None
         self._report_generators.append(ReportGenerator(params))
 
-        accumulator_factory = AccumulatorFactory(
+        accumulator_factory = CompoundAccumulatorFactory(
             params=params, budget_accountant=self._budget_accountant)
-        accumulator_factory.initialize()
         aggregator_fn = accumulator_factory.create
 
         if params.public_partitions is not None:

--- a/tests/accumulator_test.py
+++ b/tests/accumulator_test.py
@@ -15,8 +15,8 @@ import pipeline_dp.accumulator as accumulator
 class CompoundAccumulatorTest(unittest.TestCase):
 
     def test_with_mean_and_sum_squares(self):
-        mean_acc = MeanAccumulator(params=[], values=[])
-        sum_squares_acc = SumOfSquaresAccumulator(params=[], values=[])
+        mean_acc = MeanAccumulator(values=[])
+        sum_squares_acc = SumOfSquaresAccumulator(values=[])
         compound_accumulator = accumulator.CompoundAccumulator(
             [mean_acc, sum_squares_acc])
 
@@ -30,13 +30,13 @@ class CompoundAccumulatorTest(unittest.TestCase):
         self.assertEqual(computed_metrics, [3.5, 25])
 
     def test_adding_accumulator(self):
-        mean_acc1 = MeanAccumulator(params=None, values=[5])
-        sum_squares_acc1 = SumOfSquaresAccumulator(params=None, values=[5])
+        mean_acc1 = MeanAccumulator(values=[5])
+        sum_squares_acc1 = SumOfSquaresAccumulator(values=[5])
         compound_accumulator = accumulator.CompoundAccumulator(
             [mean_acc1, sum_squares_acc1])
 
-        mean_acc2 = MeanAccumulator(params=[], values=[])
-        sum_squares_acc2 = SumOfSquaresAccumulator(params=[], values=[])
+        mean_acc2 = MeanAccumulator(values=[])
+        sum_squares_acc2 = SumOfSquaresAccumulator(values=[])
         to_be_added_compound_accumulator = accumulator.CompoundAccumulator(
             [mean_acc2, sum_squares_acc2])
 
@@ -50,10 +50,10 @@ class CompoundAccumulatorTest(unittest.TestCase):
         self.assertEqual(computed_metrics, [4, 50])
 
     def test_adding_mismatched_accumulator_order_raises_exception(self):
-        mean_acc1 = MeanAccumulator(params=[], values=[11])
-        sum_squares_acc1 = SumOfSquaresAccumulator(params=[], values=[1])
-        mean_acc2 = MeanAccumulator(params=[], values=[22])
-        sum_squares_acc2 = SumOfSquaresAccumulator(params=[], values=[2])
+        mean_acc1 = MeanAccumulator(values=[11])
+        sum_squares_acc1 = SumOfSquaresAccumulator(values=[1])
+        mean_acc2 = MeanAccumulator(values=[22])
+        sum_squares_acc2 = SumOfSquaresAccumulator(values=[2])
 
         base_compound_accumulator = accumulator.CompoundAccumulator(
             [mean_acc1, sum_squares_acc1])
@@ -69,9 +69,9 @@ class CompoundAccumulatorTest(unittest.TestCase):
             "", str(context.exception))
 
     def test_adding_mismatched_accumulator_length_raises_exception(self):
-        mean_acc1 = MeanAccumulator(params=[], values=[11])
-        sum_squares_acc1 = SumOfSquaresAccumulator(params=[], values=[1])
-        mean_acc2 = MeanAccumulator(params=[], values=[22])
+        mean_acc1 = MeanAccumulator(values=[11])
+        sum_squares_acc1 = SumOfSquaresAccumulator(values=[1])
+        mean_acc2 = MeanAccumulator(values=[22])
 
         base_compound_accumulator = accumulator.CompoundAccumulator(
             [mean_acc1, sum_squares_acc1])
@@ -86,7 +86,7 @@ class CompoundAccumulatorTest(unittest.TestCase):
             "Expected size = 2 received size = 1.", str(context.exception))
 
     def test_serialization_single_accumulator(self):
-        mean_acc = MeanAccumulator(params=[], values=[5, 6])
+        mean_acc = MeanAccumulator(values=[5, 6])
 
         serialized_obj = mean_acc.serialize()
         deserialized_obj = accumulator.Accumulator.deserialize(serialized_obj)
@@ -96,8 +96,8 @@ class CompoundAccumulatorTest(unittest.TestCase):
         self.assertEqual(mean_acc.count, deserialized_obj.count)
 
     def test_serialization_compound_accumulator(self):
-        mean_acc = MeanAccumulator(params=[], values=[15])
-        sum_squares_acc = SumOfSquaresAccumulator(params=[], values=[1])
+        mean_acc = MeanAccumulator(values=[15])
+        sum_squares_acc = SumOfSquaresAccumulator(values=[1])
         compound_accumulator = accumulator.CompoundAccumulator(
             [mean_acc, sum_squares_acc])
 
@@ -115,7 +115,7 @@ class CompoundAccumulatorTest(unittest.TestCase):
                          compound_accumulator.compute_metrics())
 
     def test_serialization_with_incompatible_serialized_object(self):
-        mean_accumulator = MeanAccumulator(params=[], values=[15])
+        mean_accumulator = MeanAccumulator(values=[15])
 
         serialized_obj = mean_accumulator.serialize()
 
@@ -145,8 +145,8 @@ class CompoundAccumulatorTest(unittest.TestCase):
 class GenericAccumulatorTest(unittest.TestCase):
 
     def test_merge_accumulators(self):
-        mean_accumulator1 = MeanAccumulator(params=[], values=[15])
-        mean_accumulator2 = MeanAccumulator(params=[], values=[5])
+        mean_accumulator1 = MeanAccumulator(values=[15])
+        mean_accumulator2 = MeanAccumulator(values=[5])
 
         merged_accumulator = accumulator.merge(
             [mean_accumulator1, mean_accumulator2])
@@ -174,8 +174,8 @@ class GenericAccumulatorTest(unittest.TestCase):
                              (42, 42))
 
     def test_merge_diff_type_throws_type_error(self):
-        mean_accumulator1 = MeanAccumulator(params=[], values=[15])
-        sum_squares_acc = SumOfSquaresAccumulator(params=[], values=[1])
+        mean_accumulator1 = MeanAccumulator(values=[15])
+        sum_squares_acc = SumOfSquaresAccumulator(values=[1])
         vec_params = dp_computations.AdditiveVectorNoiseParams(
             eps_per_coordinate=0,
             delta_per_coordinate=0,
@@ -199,8 +199,8 @@ class GenericAccumulatorTest(unittest.TestCase):
         self.assertIn("The accumulator to be added is not of the same type"
                       "", str(context.exception))
 
-    @patch('pipeline_dp.accumulator.create_accumulator_params')
-    def test_accumulator_factory(self, mock_create_accumulator_params_function):
+    @patch('pipeline_dp.accumulator.create_accumulator_factories')
+    def test_accumulator_factory(self, mock_create_accumulator_factories):
         aggregate_params = pipeline_dp.AggregateParams(
             noise_kind=NoiseKind.GAUSSIAN,
             metrics=[agg.Metrics.MEAN],
@@ -210,24 +210,23 @@ class GenericAccumulatorTest(unittest.TestCase):
                                                   total_delta=0.01)
 
         values = [10]
-        mock_create_accumulator_params_function.return_value = [
-            accumulator.AccumulatorParams(MeanAccumulator, None)
+        mock_create_accumulator_factories.return_value = [
+            MeanAccumulatorFactory()
         ]
 
-        accumulator_factory = accumulator.AccumulatorFactory(
+        accumulator_factory = accumulator.CompoundAccumulatorFactory(
             aggregate_params, budget_accountant)
-        accumulator_factory.initialize()
         created_accumulator = accumulator_factory.create(values)
 
         self.assertTrue(
             isinstance(created_accumulator, accumulator.CompoundAccumulator))
         self.assertEqual(created_accumulator.compute_metrics(), [10])
-        mock_create_accumulator_params_function.assert_called_with(
+        mock_create_accumulator_factories.assert_called_with(
             aggregate_params, budget_accountant)
 
-    @patch('pipeline_dp.accumulator.create_accumulator_params')
+    @patch('pipeline_dp.accumulator.create_accumulator_factories')
     def test_accumulator_factory_multiple_types(
-            self, mock_create_accumulator_params_function):
+            self, mock_create_accumulator_factories):
         aggregate_params = pipeline_dp.AggregateParams(
             noise_kind=NoiseKind.GAUSSIAN,
             metrics=[agg.Metrics.MEAN, agg.Metrics.VAR],
@@ -237,24 +236,23 @@ class GenericAccumulatorTest(unittest.TestCase):
                                                   total_delta=0.01)
         values = [10]
 
-        mock_create_accumulator_params_function.return_value = [
-            accumulator.AccumulatorParams(MeanAccumulator, None),
-            accumulator.AccumulatorParams(SumOfSquaresAccumulator, None)
+        mock_create_accumulator_factories.return_value = [
+            MeanAccumulatorFactory(),
+            SumOfSquaresAccumulatorFactory()
         ]
 
-        accumulator_factory = accumulator.AccumulatorFactory(
+        accumulator_factory = accumulator.CompoundAccumulatorFactory(
             aggregate_params, budget_accountant)
-        accumulator_factory.initialize()
         created_accumulator = accumulator_factory.create(values)
 
         self.assertTrue(
             isinstance(created_accumulator, accumulator.CompoundAccumulator))
         self.assertEqual(created_accumulator.compute_metrics(), [10, 100])
-        mock_create_accumulator_params_function.assert_called_with(
+        mock_create_accumulator_factories.assert_called_with(
             aggregate_params, budget_accountant)
 
-    def test_create_accumulator_params_with_count_params(self):
-        acc_params = accumulator.create_accumulator_params(
+    def test_create_accumulator_factories_with_count_params(self):
+        acc_factories = accumulator.create_accumulator_factories(
             aggregation_params=pipeline_dp.AggregateParams(
                 noise_kind=NoiseKind.GAUSSIAN,
                 metrics=[pipeline_dp.Metrics.COUNT],
@@ -263,15 +261,12 @@ class GenericAccumulatorTest(unittest.TestCase):
                 budget_weight=1),
             budget_accountant=NaiveBudgetAccountant(total_epsilon=1,
                                                     total_delta=0.01))
-        self.assertEqual(len(acc_params), 1)
-        self.assertEqual(acc_params[0].accumulator_type,
-                         accumulator.CountAccumulator)
-        self.assertTrue(
-            isinstance(acc_params[0].constructor_params,
-                       accumulator.CountParams))
+        self.assertEqual(len(acc_factories), 1)
+        self.assertIsInstance(acc_factories[0],
+                              accumulator.CountAccumulatorFactory)
 
     def test_create_accumulator_params_with_sum_params(self):
-        acc_params = accumulator.create_accumulator_params(
+        acc_params = accumulator.create_accumulator_factories(
             aggregation_params=pipeline_dp.AggregateParams(
                 noise_kind=NoiseKind.GAUSSIAN,
                 metrics=[pipeline_dp.Metrics.SUM],
@@ -281,18 +276,16 @@ class GenericAccumulatorTest(unittest.TestCase):
             budget_accountant=NaiveBudgetAccountant(total_epsilon=1,
                                                     total_delta=0.01))
         self.assertEqual(len(acc_params), 1)
-        self.assertEqual(acc_params[0].accumulator_type,
-                         accumulator.SumAccumulator)
-        self.assertTrue(
-            isinstance(acc_params[0].constructor_params, accumulator.SumParams))
+        self.assertIsInstance(acc_params[0], accumulator.SumAccumulatorFactory)
+        self.assertTrue(isinstance(acc_params[0]._params,
+                                   accumulator.SumParams))
 
 
 class MeanAccumulator(accumulator.Accumulator):
 
-    def __init__(self, params, values: typing.Iterable[float] = []):
+    def __init__(self, values: typing.Iterable[float] = []):
         self.sum = sum(values)
         self.count = len(values)
-        self.params = params
 
     def add_value(self, v):
         self.sum += v
@@ -312,12 +305,17 @@ class MeanAccumulator(accumulator.Accumulator):
         return self.sum / self.count
 
 
+class MeanAccumulatorFactory(accumulator.AccumulatorFactory):
+
+    def create(self, values):
+        return MeanAccumulator(values)
+
+
 # Accumulator classes for testing
 class SumOfSquaresAccumulator(accumulator.Accumulator):
 
-    def __init__(self, params, values: typing.Iterable[float] = []):
+    def __init__(self, values: typing.Iterable[float] = []):
         self.sum_squares = sum([value * value for value in values])
-        self.params = params
 
     def add_value(self, v):
         self.sum_squares += v * v
@@ -332,6 +330,12 @@ class SumOfSquaresAccumulator(accumulator.Accumulator):
 
     def compute_metrics(self):
         return self.sum_squares
+
+
+class SumOfSquaresAccumulatorFactory(accumulator.AccumulatorFactory):
+
+    def create(self, values):
+        return SumOfSquaresAccumulator(values)
 
 
 class PrivacyIdCountAccumulatorTest(unittest.TestCase):

--- a/tests/accumulator_test.py
+++ b/tests/accumulator_test.py
@@ -199,7 +199,7 @@ class GenericAccumulatorTest(unittest.TestCase):
         self.assertIn("The accumulator to be added is not of the same type"
                       "", str(context.exception))
 
-    @patch('pipeline_dp.accumulator.create_accumulator_factories')
+    @patch('pipeline_dp.accumulator._create_accumulator_factories')
     def test_accumulator_factory(self, mock_create_accumulator_factories):
         aggregate_params = pipeline_dp.AggregateParams(
             noise_kind=NoiseKind.GAUSSIAN,
@@ -224,7 +224,7 @@ class GenericAccumulatorTest(unittest.TestCase):
         mock_create_accumulator_factories.assert_called_with(
             aggregate_params, budget_accountant)
 
-    @patch('pipeline_dp.accumulator.create_accumulator_factories')
+    @patch('pipeline_dp.accumulator._create_accumulator_factories')
     def test_accumulator_factory_multiple_types(
             self, mock_create_accumulator_factories):
         aggregate_params = pipeline_dp.AggregateParams(
@@ -252,7 +252,7 @@ class GenericAccumulatorTest(unittest.TestCase):
             aggregate_params, budget_accountant)
 
     def test_create_accumulator_factories_with_count_params(self):
-        acc_factories = accumulator.create_accumulator_factories(
+        acc_factories = accumulator._create_accumulator_factories(
             aggregation_params=pipeline_dp.AggregateParams(
                 noise_kind=NoiseKind.GAUSSIAN,
                 metrics=[pipeline_dp.Metrics.COUNT],
@@ -266,7 +266,7 @@ class GenericAccumulatorTest(unittest.TestCase):
                               accumulator.CountAccumulatorFactory)
 
     def test_create_accumulator_params_with_sum_params(self):
-        acc_params = accumulator.create_accumulator_factories(
+        acc_params = accumulator._create_accumulator_factories(
             aggregation_params=pipeline_dp.AggregateParams(
                 noise_kind=NoiseKind.GAUSSIAN,
                 metrics=[pipeline_dp.Metrics.SUM],

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -163,8 +163,8 @@ class DpEngineTest(unittest.TestCase):
         self.assertIsNone(
             pipeline_dp.DPEngine(None, None).aggregate(None, None, None))
 
-    @patch('pipeline_dp.accumulator.create_accumulator_params')
-    def test_aggregate_report(self, mock_create_accumulator_params_function):
+    @patch('pipeline_dp.accumulator.create_accumulator_factories')
+    def test_aggregate_report(self, mock_create_accumulator_factories_function):
         col = [[1], [2], [3], [3]]
         data_extractor = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: f"pid{x}",
@@ -193,9 +193,8 @@ class DpEngineTest(unittest.TestCase):
             ],
             public_partitions=list(range(1, 40)),
         )
-        mock_create_accumulator_params_function.return_value = [
-            pipeline_dp.accumulator.AccumulatorParams(
-                pipeline_dp.accumulator.CountAccumulator, None)
+        mock_create_accumulator_factories_function.return_value = [
+            pipeline_dp.accumulator.CountAccumulatorFactory(None)
         ]
         budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
                                                   total_delta=1e-10)
@@ -233,7 +232,6 @@ class DpEngineTest(unittest.TestCase):
                                                   total_delta=1e-10)
         accumulator_factory = CompoundAccumulatorFactory(
             params=aggregator_params, budget_accountant=budget_accountant)
-        accumulator_factory.initialize()
 
         col = [[1], [2], [3], [3]]
         data_extractor = pipeline_dp.DataExtractors(

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -13,7 +13,7 @@ from pipeline_dp.budget_accounting import NaiveBudgetAccountant
 import pydp.algorithms.partition_selection as partition_selection
 from pipeline_dp import aggregate_params as agg
 from pipeline_dp.accumulator import CountAccumulator
-from pipeline_dp.accumulator import AccumulatorFactory
+from pipeline_dp.accumulator import CompoundAccumulatorFactory
 """DPEngine Test"""
 
 
@@ -221,7 +221,7 @@ class DpEngineTest(unittest.TestCase):
             max_contributions_per_partition=3)
         budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
                                                   total_delta=1e-10)
-        accumulator_factory = AccumulatorFactory(
+        accumulator_factory = CompoundAccumulatorFactory(
             params=aggregator_params, budget_accountant=budget_accountant)
         accumulator_factory.initialize()
 


### PR DESCRIPTION
This PR is a refactoring of way how accumulators are created during aggregation. [`Accumulator`](https://github.com/OpenMined/PipelineDP/blob/0cb701891eca47c55ee2ba93bc1cf5470a30a242/pipeline_dp/accumulator.py#L57) is an object that does aggregation.

**Before this PR:**
`AccumulatorFactory` contains a list of `AccumulatorParams`. `AccumulatorParams` are used for creating accumulators during aggregation.

**After this PR:**
1. `AccumulatorFactory` is renamed to `CompoundAccumulatorFactory` 
2. Abstract `AccumulatorFactory` is introduced and concrete `AccumulatorFactory` creates corresponding accumulators (e.g.`CountAccumulatorFactory` creates `CountAccumulator`)

**Why this refactoring is needed?**
This PR is 1st step of refactoring of computing metrics with `CombineFn` functions (see [on the page](https://beam.apache.org/documentation/transforms/python/aggregation/combineperkey/)  example 5). Combing with `CombineFn` is more effective and required for more tight integration with Beam.

Also this refactoring itself makes creating of accumulators more direct and as a result more readable.