### PR TITLE
Fixes CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,48 +10,51 @@ on:
 
 jobs:
   linting:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ["3.9"]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.dev.txt
 
-    - name: Check formatting
-      run: |
-        yapf --diff --recursive pipeline_dp tests
+      - name: Check formatting
+        run: |
+          yapf --diff --recursive pipeline_dp tests
 
   test:
-    runs-on:  ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     needs: [linting]
     strategy:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.dev.txt
+          python -m pip install -r requirements.dev.txt
 
       - name: Run pytest
         run: |

--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from pyspark import RDD
 from typing import Callable
 
@@ -24,7 +23,7 @@ class PrivateRDD:
             self._rdd = rdd
         self._budget_accountant = budget_accountant
 
-    def map(self, fn: Callable) -> PrivateRDD:
+    def map(self, fn: Callable) -> 'PrivateRDD':
         """A Spark map equivalent.
 
         Keeps track of privacy_id for each element.
@@ -35,7 +34,7 @@ class PrivateRDD:
         rdd = self._rdd.mapValues(fn)
         return make_private(rdd, self._budget_accountant, None)
 
-    def flat_map(self, fn: Callable) -> PrivateRDD:
+    def flat_map(self, fn: Callable) -> 'PrivateRDD':
         """A Spark flatMap equivalent.
 
         Keeps track of privacy_id for each element.

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -508,8 +508,11 @@ class DpEngineTest(unittest.TestCase):
 
         self.assertEqual(5, len(list(output)))
 
-    @unittest.skipIf(sys.platform == "win32",
-                     "There are some problems with PySpark setup on Windows")
+    @unittest.skipIf(
+        sys.platform == "win32" or
+        (sys.version_info.minor <= 7 and sys.version_info.major == 3),
+        "There are some problems with PySpark setup on older python and Windows"
+    )
     def test_run_e2e_spark(self):
         import pyspark
         conf = pyspark.SparkConf()

--- a/tests/pipeline_operations_test.py
+++ b/tests/pipeline_operations_test.py
@@ -80,8 +80,10 @@ class BeamOperationsTest(parameterized.TestCase):
                                   beam_util.equal_to([(6, 2), (7, 2), (8, 1)]))
 
 
-@unittest.skipIf(sys.platform == "win32",
-                 "There are some problems with PySpark setup on Windows")
+@unittest.skipIf(sys.platform == "win32" or sys.platform == 'darwin' or (
+    sys.version_info.minor <= 7 and sys.version_info.major == 3
+), "There are some problems with PySpark setup on older python and Windows and macOS"
+                )
 class SparkRDDOperationsTest(parameterized.TestCase):
 
     @classmethod
@@ -363,8 +365,8 @@ class LocalPipelineOperationsTest(unittest.TestCase):
                           ("bread", ["sourdough"])])
 
 
-@unittest.skipIf(sys.platform == 'win32',
-                 "Problems with serialisation on Windows")
+@unittest.skipIf(sys.platform == 'win32' or sys.platform == 'darwin',
+                 "Problems with serialisation on Windows and macOS")
 class MultiProcLocalPipelineOperationsTest(unittest.TestCase):
 
     @staticmethod

--- a/tests/private_spark_test.py
+++ b/tests/private_spark_test.py
@@ -9,8 +9,10 @@ from pipeline_dp import aggregate_params as agg
 from pipeline_dp import budget_accounting, private_spark
 
 
-@unittest.skipIf(sys.platform == "win32",
-                 "There are some problems with PySpark setup on Windows")
+@unittest.skipIf(
+    sys.platform == "win32" or
+    (sys.version_info.minor <= 7 and sys.version_info.major == 3),
+    "There are some problems with PySpark setup on older python and Windows")
 class PrivateRDDTest(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
## Description
Fixes the following problems in CI
* Incorrect set up of python version to default ones. e.g. `platform linux -- Python 3.8.10, pytest-6.2.5, py-1.11.0, pluggy-1.0.0` in logs of `test (ubuntu-latest, 3.9)`
 (https://github.com/OpenMined/PipelineDP/runs/4612071048?check_suite_focus=true) 
* Fixes import from future annotations
* Version 3.10 translate to 3.1 because it's a number
* Disable version 3.10 because it's not supported in pydp https://pypi.org/project/python-dp/
* Skip Spark tests in macOS because the latest macOS has some serialization problems (because it changes fork to spawn). See a similar issue in https://github.com/pytest-dev/pytest-flask/issues/104
* Skip Spark tests in versions <3.8 because of some serialization problems

## Affected Dependencies
N/A

## How has this been tested?
poetry run pytest tests/  
All green in https://github.com/XinyuYe/PipelineDP/runs/4670474812?check_suite_focus=true

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
