### PR TITLE
Add PrivacyIdCount Transform to Beam's public API.

### DIFF
--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -145,3 +145,27 @@ class CountParams:
     partition_extractor: Callable
     value_extractor: Callable
     budget_weight: float = 1
+
+
+@dataclass
+class PrivacyIdCountParams:
+    """Specifies parameters for differentially-private privacy id count calculation.
+
+    Args:
+        noise_kind: Kind of noise to use for the DP calculations.
+        max_partitions_contributed: Bounds the number of partitions in which one
+            unit of privacy (e.g., a user) can participate.
+        public_partitions: A collection of partition keys that will be present in
+            the result.
+        partition_extractor: A function for partition id extraction from an RDD record.
+        value_extractor: A function for extraction of value
+            for which the sum will be calculated.
+
+    """
+
+    noise_kind: NoiseKind
+    max_partitions_contributed: int
+    public_partitions: Union[Iterable, 'PCollection', 'RDD']
+    partition_extractor: Callable
+    value_extractor: Callable
+    budget_weight: float = 1

--- a/tests/private_beam_test.py
+++ b/tests/private_beam_test.py
@@ -22,7 +22,7 @@ class PrivateBeamTest(unittest.TestCase):
     def privacy_id_extractor(x):
         return f"pid:{x}"
 
-    def test_MakePrivate_transform_succeeds(self):
+    def test_make_private_transform_succeeds(self):
         runner = fn_api_runner.FnApiRunner()
         with beam.Pipeline(runner=runner) as pipeline:
             # Arrange
@@ -87,7 +87,7 @@ class PrivateBeamTest(unittest.TestCase):
             # Assert
             self.assertIsInstance(transformed, private_beam.PrivatePCollection)
 
-    def test_transform_with_return_anonymized_enabled_returns_PCollection(self):
+    def test_transform_with_return_anonymized_enabled_returns_pcollection(self):
         runner = fn_api_runner.FnApiRunner()
         with beam.Pipeline(runner=runner) as pipeline:
             # Arrange
@@ -108,7 +108,7 @@ class PrivateBeamTest(unittest.TestCase):
             self.assertIsInstance(transformed, pvalue.PCollection)
 
     @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
-    def test_sum(self, mock_aggregate):
+    def test_sum_calls_aggregate_with_params(self, mock_aggregate):
         runner = fn_api_runner.FnApiRunner()
         with beam.Pipeline(runner=runner) as pipeline:
             # Arrange
@@ -155,7 +155,7 @@ class PrivateBeamTest(unittest.TestCase):
             self.assertEqual(args[1], params)
 
     @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
-    def test_count(self, mock_aggregate):
+    def test_count_calls_aggregate_with_params(self, mock_aggregate):
         runner = fn_api_runner.FnApiRunner()
         with beam.Pipeline(runner=runner) as pipeline:
             # Arrange
@@ -197,7 +197,49 @@ class PrivateBeamTest(unittest.TestCase):
                 public_partitions=count_params.public_partitions)
             self.assertEqual(args[1], params)
 
-    def test_Map(self):
+    @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
+    def test_privacy_id_count_calls_aggregate_with_params(self, mock_aggregate):
+        runner = fn_api_runner.FnApiRunner()
+        with beam.Pipeline(runner=runner) as pipeline:
+            # Arrange
+            pcol = pipeline | 'Create produce' >> beam.Create(
+                [1, 2, 3, 4, 5, 6])
+            budget_accountant = budget_accounting.NaiveBudgetAccountant(
+                total_epsilon=1, total_delta=0.01)
+            private_collection = (
+                pcol | 'Create private collection' >> private_beam.MakePrivate(
+                    budget_accountant=budget_accountant,
+                    privacy_id_extractor=PrivateBeamTest.privacy_id_extractor))
+
+            privacy_id_count_params = aggregate_params.PrivacyIdCountParams(
+                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+                max_partitions_contributed=2,
+                budget_weight=1,
+                public_partitions=[],
+                partition_extractor=lambda x: f"pk:{x // 10}",
+                value_extractor=lambda x: x)
+
+            # Act
+            transformer = private_beam.PrivacyIdCount(
+                privacy_id_count_params=privacy_id_count_params)
+            private_collection | transformer
+
+            # Assert
+            self.assertEqual(transformer._budget_accountant, budget_accountant)
+            mock_aggregate.assert_called_once()
+
+            args = mock_aggregate.call_args[0]
+
+            params = pipeline_dp.AggregateParams(
+                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+                metrics=[pipeline_dp.Metrics.PRIVACY_ID_COUNT],
+                max_partitions_contributed=privacy_id_count_params.
+                max_partitions_contributed,
+                max_contributions_per_partition=1,
+                public_partitions=privacy_id_count_params.public_partitions)
+            self.assertEqual(args[1], params)
+
+    def test_map_returns_correct_results_and_accountant(self):
         runner = fn_api_runner.FnApiRunner()
         with beam.Pipeline(runner=runner) as pipeline:
             # Arrange
@@ -225,7 +267,7 @@ class PrivateBeamTest(unittest.TestCase):
                         pcol_input)))
             self.assertEqual(transformed._budget_accountant, budget_accountant)
 
-    def test_FlatMap(self):
+    def test_flatmap_returns_correct_results_and_accountant(self):
 
         def flat_map_fn(x):
             return [(x[0], x[1] + i) for i in range(2)]


### PR DESCRIPTION
Add PrivacyIdCount Transform to Beam's public API.
Make test names more descriptive and change test names to a consistent format (snake case).

## How has this been tested?
- Unit tested.
