### PR TITLE
Combiner tests

### DIFF
--- a/pipeline_dp/accumulator.py
+++ b/pipeline_dp/accumulator.py
@@ -1,3 +1,5 @@
+# Deprecation warning: Accumulator Framework in this file is deprecated in
+#  favour of Combiner framework (combiner.py) and will be removed soon.
 import abc
 import copy
 import typing

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -189,7 +189,7 @@ class CompoundCombiner(Combiner):
         return (privacy_id_count, metrics)
 
 
-def create_compound_combiners(
+def create_compound_combiner(
         aggregate_params: pipeline_dp.AggregateParams,
         budget_accountant: budget_accounting.BudgetAccountant
 ) -> CompoundCombiner:

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -22,7 +22,7 @@ from pipeline_dp.pipeline_backend import PipelineBackend
 from pipeline_dp.report_generator import ReportGenerator
 from pipeline_dp.accumulator import Accumulator
 from pipeline_dp.accumulator import CompoundAccumulatorFactory
-from pipeline_dp.combiners import create_compound_combiners, Combiner, CompoundCombiner
+from pipeline_dp.combiners import create_compound_combiner, Combiner, CompoundCombiner
 
 import pydp.algorithms.partition_selection as partition_selection
 
@@ -72,7 +72,7 @@ class DPEngine:
 
         self._report_generators.append(ReportGenerator(params))
 
-        combiner = create_compound_combiners(params, self._budget_accountant)
+        combiner = create_compound_combiner(params, self._budget_accountant)
 
         if params.public_partitions is not None:
             col = self._drop_not_public_partitions(col,

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -1,7 +1,9 @@
+import unittest.mock as mock
+
 from absl.testing import absltest
 from absl.testing import parameterized
 import pipeline_dp
-import pipeline_dp.combiners as combiners
+import pipeline_dp.combiners as dp_combiners
 import pipeline_dp.budget_accounting as ba
 
 import numpy as np
@@ -26,13 +28,71 @@ def _create_aggregate_params():
         metrics=[pipeline_dp.Metrics.COUNT])
 
 
-class CountAccumulatorTest(parameterized.TestCase):
+class CreateCompoundCombinersTest(parameterized.TestCase):
+
+    def _create_aggregate_params(self, metrics: list):
+        return pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            metrics=metrics,
+            max_partitions_contributed=0,
+            max_contributions_per_partition=0,
+            budget_weight=10.0)
+
+    @parameterized.named_parameters(
+        dict(testcase_name='count',
+             metrics=[pipeline_dp.Metrics.COUNT],
+             expected_combiner_types=[dp_combiners.CountCombiner]),
+        dict(testcase_name='sum',
+             metrics=[pipeline_dp.Metrics.SUM],
+             expected_combiner_types=[dp_combiners.SumCombiner]),
+        dict(testcase_name='privacy_id_count',
+             metrics=[pipeline_dp.Metrics.PRIVACY_ID_COUNT],
+             expected_combiner_types=[dp_combiners.PrivacyIdCountCombiner]),
+        dict(testcase_name='count, sum, privacy_id_count',
+             metrics=[
+                 pipeline_dp.Metrics.SUM, pipeline_dp.Metrics.COUNT,
+                 pipeline_dp.Metrics.PRIVACY_ID_COUNT
+             ],
+             expected_combiner_types=[
+                 dp_combiners.CountCombiner, dp_combiners.SumCombiner,
+                 dp_combiners.PrivacyIdCountCombiner
+             ]),
+    )
+    def test_create_compound_combiner(self, metrics, expected_combiner_types):
+        # Arrange.
+        aggregate_params = self._create_aggregate_params(metrics)
+
+        # Mock budget accountant.
+        budget_accountant = mock.Mock()
+        mock_budgets = [
+            f"budget{i}" for i in range(len(expected_combiner_types))
+        ]
+        budget_accountant.request_budget = mock.Mock(side_effect=mock_budgets)
+
+        # Act.
+        compound_combiner = dp_combiners.create_compound_combiners(
+            aggregate_params, budget_accountant)
+
+        # Assert
+        budget_accountant.request_budget.assert_called_with(
+            pipeline_dp.aggregate_params.MechanismType.GAUSSIAN,
+            weight=aggregate_params.budget_weight)
+        # Check correctness of intenal combiners
+        combiners = compound_combiner._combiners
+        self.assertLen(combiners, len(expected_combiner_types))
+        for combiner, expect_type, expected_budget in zip(
+                combiners, expected_combiner_types, mock_budgets):
+            self.assertIsInstance(combiner, expect_type)
+            self.assertEqual(combiner._params._mechanism_spec, expected_budget)
+
+
+class CountCombinerTest(parameterized.TestCase):
 
     def _create_combiner(self, no_noise):
         mechanism_spec = _create_mechism_spec(no_noise)
         aggregate_params = _create_aggregate_params()
-        params = combiners.CombinerParams(mechanism_spec, aggregate_params)
-        return combiners.CountCombiner(params)
+        params = dp_combiners.CombinerParams(mechanism_spec, aggregate_params)
+        return dp_combiners.CountCombiner(params)
 
     @parameterized.named_parameters(
         dict(testcase_name='no_noise', no_noise=True),
@@ -71,13 +131,58 @@ class CountAccumulatorTest(parameterized.TestCase):
             np.var(noisified_values) > 1)  # check that noise is added
 
 
-class SumAccumulatorTest(parameterized.TestCase):
+class PrivacyIdCountCombinerTest(parameterized.TestCase):
 
     def _create_combiner(self, no_noise):
         mechanism_spec = _create_mechism_spec(no_noise)
         aggregate_params = _create_aggregate_params()
-        params = combiners.CombinerParams(mechanism_spec, aggregate_params)
-        return combiners.SumCombiner(params)
+        params = dp_combiners.CombinerParams(mechanism_spec, aggregate_params)
+        return dp_combiners.PrivacyIdCountCombiner(params)
+
+    @parameterized.named_parameters(
+        dict(testcase_name='no_noise', no_noise=True),
+        dict(testcase_name='noise', no_noise=False),
+    )
+    def test_create_accumulator(self, no_noise):
+        combiner = self._create_combiner(no_noise)
+        self.assertEqual(0, combiner.create_accumulator([]))
+        self.assertEqual(1, combiner.create_accumulator([1, 2]))
+
+    @parameterized.named_parameters(
+        dict(testcase_name='no_noise', no_noise=True),
+        dict(testcase_name='noise', no_noise=False),
+    )
+    def test_merge_accumulators(self, no_noise):
+        combiner = self._create_combiner(no_noise)
+        self.assertEqual(0, combiner.merge_accumulators(0, 0))
+        self.assertEqual(5, combiner.merge_accumulators(1, 4))
+
+    def test_compute_metrics_no_noise(self):
+        combiner = self._create_combiner(no_noise=True)
+        self.assertAlmostEqual(3, combiner.compute_metrics(3), delta=1e-5)
+
+    def test_compute_metrics_with_noise(self):
+        combiner = self._create_combiner(no_noise=False)
+        accumulator = 5
+        noisified_values = [
+            combiner.compute_metrics(accumulator) for _ in range(1000)
+        ]
+        # Standard deviation for the noise is about 1.37. So we set a large
+        # delta here.
+        self.assertAlmostEqual(accumulator,
+                               np.mean(noisified_values),
+                               delta=0.5)
+        self.assertTrue(
+            np.var(noisified_values) > 1)  # check that noise is added
+
+
+class SumCombinerTest(parameterized.TestCase):
+
+    def _create_combiner(self, no_noise):
+        mechanism_spec = _create_mechism_spec(no_noise)
+        aggregate_params = _create_aggregate_params()
+        params = dp_combiners.CombinerParams(mechanism_spec, aggregate_params)
+        return dp_combiners.SumCombiner(params)
 
     @parameterized.named_parameters(
         dict(testcase_name='no_noise', no_noise=True),
@@ -119,15 +224,16 @@ class SumAccumulatorTest(parameterized.TestCase):
             np.var(noisified_values) > 1)  # check that noise is added
 
 
-class CompoundAccumulatorTest(parameterized.TestCase):
+class CompoundCombinerTest(parameterized.TestCase):
 
     def _create_combiner(self, no_noise):
         mechanism_spec = _create_mechism_spec(no_noise)
         aggregate_params = _create_aggregate_params()
-        params = combiners.CombinerParams(mechanism_spec, aggregate_params)
-        return combiners.CompoundCombiner(
-            [combiners.CountCombiner(params),
-             combiners.SumCombiner(params)])
+        params = dp_combiners.CombinerParams(mechanism_spec, aggregate_params)
+        return dp_combiners.CompoundCombiner([
+            dp_combiners.CountCombiner(params),
+            dp_combiners.SumCombiner(params)
+        ])
 
     @parameterized.named_parameters(
         dict(testcase_name='no_noise', no_noise=True),

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -70,7 +70,7 @@ class CreateCompoundCombinersTest(parameterized.TestCase):
         budget_accountant.request_budget = mock.Mock(side_effect=mock_budgets)
 
         # Act.
-        compound_combiner = dp_combiners.create_compound_combiners(
+        compound_combiner = dp_combiners.create_compound_combiner(
             aggregate_params, budget_accountant)
 
         # Assert


### PR DESCRIPTION
This PR:

1.Fixes dp_engine_test, which were broken after [PR](https://github.com/OpenMined/PipelineDP/pull/156) which introduced usage of CombinerFramework instead of Accumulator Framework
2.Adds tests for PrivacyIdCombiner and CreateCompoundAccumulator