### PR TITLE
Spark privacy id count

### DIFF
--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -116,6 +116,43 @@ class PrivateRDD:
 
         return dp_result
 
+    def privacy_id_count(
+            self, privacy_id_count_params: aggregate_params.PrivacyIdCountParams
+    ) -> RDD:
+        """Computes DP Privacy ID count.
+
+        Args:
+            privacy_id_count_params: parameters for calculation
+        """
+
+        ops = pipeline_dp.SparkRDDBackend()
+        dp_engine = pipeline_dp.DPEngine(self._budget_accountant, ops)
+
+        params = pipeline_dp.AggregateParams(
+            noise_kind=privacy_id_count_params.noise_kind,
+            metrics=[pipeline_dp.Metrics.PRIVACY_ID_COUNT],
+            max_partitions_contributed=privacy_id_count_params.
+            max_partitions_contributed,
+            max_contributions_per_partition=1,
+            public_partitions=privacy_id_count_params.public_partitions)
+
+        data_extractors = pipeline_dp.DataExtractors(
+            partition_extractor=lambda x: privacy_id_count_params.
+            partition_extractor(x[1]),
+            privacy_id_extractor=lambda x: x[0],
+            # PrivacyIdCount ignores values.
+            value_extractor=lambda x: None)
+
+        dp_result = dp_engine.aggregate(self._rdd, params, data_extractors)
+        # dp_result : (partition_key, [dp_privacy_id_count])
+
+        # aggregate() returns a list of metrics for each partition key.
+        # Here is only one metric - privacy_id_count. Remove list.
+        dp_result = ops.map_values(dp_result, lambda v: v[0], "Unnest list")
+        # dp_result : (partition_key, dp_privacy_id_count)
+
+        return dp_result
+
 
 def make_private(rdd: RDD,
                  budget_accountant: budget_accounting.BudgetAccountant,

--- a/tests/private_spark_test.py
+++ b/tests/private_spark_test.py
@@ -143,6 +143,46 @@ class PrivateRDDTest(unittest.TestCase):
         result = prdd.count(count_params)
         self.assertEqual([(0, "count0"), (1, "count1")], result.collect())
 
+    @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
+    def test_privacy_id_count(self, mock_aggregate):
+        dist_data = PrivateRDDTest.sc.parallelize([])
+        budget_accountant = budget_accounting.NaiveBudgetAccountant(1, 1e-10)
+
+        def privacy_id_extractor(x):
+            return f"pid{x%10}"
+
+        prdd = private_spark.make_private(dist_data, budget_accountant,
+                                          privacy_id_extractor)
+
+        privacy_id_count_params = agg.PrivacyIdCountParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            max_partitions_contributed=2,
+            budget_weight=1,
+            partition_extractor=lambda x: f"pk:{x // 10}")
+        prdd.privacy_id_count(privacy_id_count_params)
+
+        mock_aggregate.assert_called_once()
+
+        args = mock_aggregate.call_args[0]
+
+        rdd = dist_data.map(lambda x: (privacy_id_extractor(x), x))
+        self.assertListEqual(args[0].collect(), rdd.collect())
+
+        params = pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            metrics=[pipeline_dp.Metrics.PRIVACY_ID_COUNT],
+            max_partitions_contributed=privacy_id_count_params.
+            max_partitions_contributed,
+            max_contributions_per_partition=1,
+            public_partitions=privacy_id_count_params.public_partitions)
+        self.assertEqual(args[1], params)
+
+        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize([
+            (0, ["count0"]), (1, ["count1"])
+        ])
+        result = prdd.privacy_id_count(privacy_id_count_params)
+        self.assertEqual([(0, "count0"), (1, "count1")], result.collect())
+
     @classmethod
     def tearDownClass(cls):
         cls.sc.stop()

--- a/tests/private_spark_test.py
+++ b/tests/private_spark_test.py
@@ -73,7 +73,7 @@ class PrivateRDDTest(unittest.TestCase):
             high=5,
             budget_weight=1,
             public_partitions=None,
-            partition_extractor=lambda x: "pk" + str(x // 10),
+            partition_extractor=lambda x: f"pk:{x // 10}",
             value_extractor=lambda x: x)
         prdd.sum(sum_params)
 
@@ -118,7 +118,7 @@ class PrivateRDDTest(unittest.TestCase):
             max_contributions_per_partition=3,
             budget_weight=1,
             public_partitions=None,
-            partition_extractor=lambda x: "pk" + str(x // 10))
+            partition_extractor=lambda x: f"pk:{x // 10}")
         prdd.count(count_params)
 
         mock_aggregate.assert_called_once()


### PR DESCRIPTION
## Description
Add Privacy ID Count Transform to Spark's public API.
- use f-string.

## How has this been tested?
Unit tested.