### PR TITLE
Add select_partitions() to private_spark

### DIFF
--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -153,6 +153,30 @@ class PrivateRDD:
 
         return dp_result
 
+    def select_partitions(self,
+                          select_partitions_params: aggregate_params.SelectPartitionsParams,
+                          partition_extractor: Callable
+                          ) -> RDD:
+        """Computes a collection of PrivatePCollection partition keys using DP.
+
+        Args:
+            select_partitions_params: parameters for calculation
+            partition_extractor: function for extracting partition key from the input collection
+        """
+
+        backend = pipeline_dp.SparkRDDBackend()
+        dp_engine = pipeline_dp.DPEngine(self._budget_accountant, backend)
+
+        params = pipeline_dp.SelectPartitionsParams(
+            max_partitions_contributed=select_partitions_params.max_partitions_contributed)
+
+        data_extractors = pipeline_dp.DataExtractors(
+            partition_extractor=lambda x: partition_extractor(x[1]),
+            privacy_id_extractor=lambda x: x[0]
+        )
+
+        return dp_engine.select_partitions(self._rdd, params,
+                                           data_extractors)
 
 def make_private(rdd: RDD,
                  budget_accountant: budget_accounting.BudgetAccountant,

--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -153,10 +153,10 @@ class PrivateRDD:
 
         return dp_result
 
-    def select_partitions(self,
-                          select_partitions_params: aggregate_params.SelectPartitionsParams,
-                          partition_extractor: Callable
-                          ) -> RDD:
+    def select_partitions(
+            self,
+            select_partitions_params: aggregate_params.SelectPartitionsParams,
+            partition_extractor: Callable) -> RDD:
         """Computes a collection of PrivatePCollection partition keys using DP.
 
         Args:
@@ -168,15 +168,15 @@ class PrivateRDD:
         dp_engine = pipeline_dp.DPEngine(self._budget_accountant, backend)
 
         params = pipeline_dp.SelectPartitionsParams(
-            max_partitions_contributed=select_partitions_params.max_partitions_contributed)
+            max_partitions_contributed=select_partitions_params.
+            max_partitions_contributed)
 
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: partition_extractor(x[1]),
-            privacy_id_extractor=lambda x: x[0]
-        )
+            privacy_id_extractor=lambda x: x[0])
 
-        return dp_engine.select_partitions(self._rdd, params,
-                                           data_extractors)
+        return dp_engine.select_partitions(self._rdd, params, data_extractors)
+
 
 def make_private(rdd: RDD,
                  budget_accountant: budget_accounting.BudgetAccountant,

--- a/tests/private_beam_test.py
+++ b/tests/private_beam_test.py
@@ -525,7 +525,7 @@ class PrivateBeamTest(unittest.TestCase):
             self.assertEqual(transformed._budget_accountant, budget_accountant)
 
     @patch('pipeline_dp.dp_engine.DPEngine.select_partitions')
-    def test_select_partitions_calls_aggregate_with_params(
+    def test_select_partitions_calls_select_partitions_with_params(
             self, mock_select_partitions):
         runner = fn_api_runner.FnApiRunner()
         with beam.Pipeline(runner=runner) as pipeline:

--- a/tests/private_spark_test.py
+++ b/tests/private_spark_test.py
@@ -184,11 +184,13 @@ class PrivateRDDTest(unittest.TestCase):
         self.assertEqual([(0, "count0"), (1, "count1")], result.collect())
 
     @patch('pipeline_dp.dp_engine.DPEngine.select_partitions')
-    def test_select_partitions_calls_select_partitions_with_correct_params(self, mock_aggregate):
+    def test_select_partitions_calls_select_partitions_with_correct_params(
+            self, mock_aggregate):
         # Arrange
         dist_data = PrivateRDDTest.sc.parallelize([(1, "pk1"), (2, "pk2")])
         expected_result_partitions = ["pk1", "pk2"]
-        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize(expected_result_partitions)
+        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize(
+            expected_result_partitions)
         budget_accountant = budget_accounting.NaiveBudgetAccountant(
             total_epsilon=1, total_delta=0.01)
         max_partitions_contributed = 2
@@ -205,7 +207,8 @@ class PrivateRDDTest(unittest.TestCase):
 
         select_partitions_params = agg.SelectPartitionsParams(
             max_partitions_contributed=max_partitions_contributed)
-        actual_result = prdd.select_partitions(select_partitions_params, partition_extractor)
+        actual_result = prdd.select_partitions(select_partitions_params,
+                                               partition_extractor)
 
         # Assert
         mock_aggregate.assert_called_once()
@@ -215,7 +218,9 @@ class PrivateRDDTest(unittest.TestCase):
 
         self.assertListEqual(actual_rdd, [(1, (1, "pk1")), (2, (2, "pk2"))])
 
-        self.assertEqual(actual_select_partition_params.max_partitions_contributed, max_partitions_contributed)
+        self.assertEqual(
+            actual_select_partition_params.max_partitions_contributed,
+            max_partitions_contributed)
         self.assertEqual(actual_result.collect(), expected_result_partitions)
 
     def test_select_partitions_returns_sensible_result(self):
@@ -242,7 +247,8 @@ class PrivateRDDTest(unittest.TestCase):
 
         select_partitions_params = agg.SelectPartitionsParams(
             max_partitions_contributed=max_partitions_contributed)
-        actual_result = prdd.select_partitions(select_partitions_params, partition_extractor)
+        actual_result = prdd.select_partitions(select_partitions_params,
+                                               partition_extractor)
         budget_accountant.compute_budgets()
 
         # Assert

--- a/tests/private_spark_test.py
+++ b/tests/private_spark_test.py
@@ -183,6 +183,73 @@ class PrivateRDDTest(unittest.TestCase):
         result = prdd.privacy_id_count(privacy_id_count_params)
         self.assertEqual([(0, "count0"), (1, "count1")], result.collect())
 
+    @patch('pipeline_dp.dp_engine.DPEngine.select_partitions')
+    def test_select_partitions_calls_select_partitions_with_correct_params(self, mock_aggregate):
+        # Arrange
+        dist_data = PrivateRDDTest.sc.parallelize([(1, "pk1"), (2, "pk2")])
+        expected_result_partitions = ["pk1", "pk2"]
+        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize(expected_result_partitions)
+        budget_accountant = budget_accounting.NaiveBudgetAccountant(
+            total_epsilon=1, total_delta=0.01)
+        max_partitions_contributed = 2
+
+        def privacy_id_extractor(x):
+            return x[0]
+
+        def partition_extractor(x):
+            return {x[1]}
+
+        # Act
+        prdd = private_spark.make_private(dist_data, budget_accountant,
+                                          privacy_id_extractor)
+
+        select_partitions_params = agg.SelectPartitionsParams(
+            max_partitions_contributed=max_partitions_contributed)
+        actual_result = prdd.select_partitions(select_partitions_params, partition_extractor)
+
+        # Assert
+        mock_aggregate.assert_called_once()
+        actual_args = mock_aggregate.call_args[0]
+        actual_rdd = actual_args[0].collect()
+        actual_select_partition_params = actual_args[1]
+
+        self.assertListEqual(actual_rdd, [(1, (1, "pk1")), (2, (2, "pk2"))])
+
+        self.assertEqual(actual_select_partition_params.max_partitions_contributed, max_partitions_contributed)
+        self.assertEqual(actual_result.collect(), expected_result_partitions)
+
+    def test_select_partitions_returns_sensible_result(self):
+        # Arrange
+        col = [(u, "pk1") for u in range(50)]
+        col += [(50 + u, "pk2") for u in range(50)]
+        dist_data = PrivateRDDTest.sc.parallelize(col)
+
+        # Use very high epsilon and delta to minimize noise and test
+        # flakiness.
+        budget_accountant = budget_accounting.NaiveBudgetAccountant(
+            total_epsilon=800, total_delta=0.999)
+        max_partitions_contributed = 2
+
+        def privacy_id_extractor(x):
+            return x[0]
+
+        def partition_extractor(x):
+            return x[1]
+
+        # Act
+        prdd = private_spark.make_private(dist_data, budget_accountant,
+                                          privacy_id_extractor)
+
+        select_partitions_params = agg.SelectPartitionsParams(
+            max_partitions_contributed=max_partitions_contributed)
+        actual_result = prdd.select_partitions(select_partitions_params, partition_extractor)
+        budget_accountant.compute_budgets()
+
+        # Assert
+        # This is a health check to validate that the result is sensible.
+        # Hence, we use a very large tolerance to reduce test flakiness.
+        self.assertEqual(sorted(actual_result.collect()), ["pk1", "pk2"])
+
     @classmethod
     def tearDownClass(cls):
         cls.sc.stop()


### PR DESCRIPTION
Add select_partitions() to private_spark

## Description
Add select_partitions() to private_spark. Fix typo in the select_partitions() tests in private_beam

## How has this been tested?
- Unit tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
