### PR TITLE
private_spark aggregations new tests and small fixes

### DIFF
--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -105,7 +105,7 @@ class PrivateRDD:
             partition_extractor=lambda x: count_params.partition_extractor(x[1]
                                                                           ),
             privacy_id_extractor=lambda x: x[0],
-            value_extractor=lambda x: count_params.value_extractor(x[1]))
+            value_extractor=lambda x: None)
 
         dp_result = dp_engine.aggregate(self._rdd, params, data_extractors)
         # dp_result : (partition_key, [dp_count])

--- a/tests/private_spark_test.py
+++ b/tests/private_spark_test.py
@@ -20,6 +20,11 @@ class PrivateRDDTest(unittest.TestCase):
         conf = pyspark.SparkConf()
         cls.sc = SparkContext.getOrCreate(conf=conf)
 
+    @classmethod
+    def value_per_key_within_tolerance(self, expected, actual, tolerance):
+        return actual[0] == expected[0] and abs(actual[1] -
+                                                expected[1]) <= tolerance
+
     def test_map(self):
         data = [(1, 11), (2, 12)]
         dist_data = PrivateRDDTest.sc.parallelize(data)
@@ -55,30 +60,34 @@ class PrivateRDDTest(unittest.TestCase):
         self.assertEqual(result._budget_accountant, prdd._budget_accountant)
 
     @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
-    def test_sum(self, mock_aggregate):
-        dist_data = PrivateRDDTest.sc.parallelize([])
+    def test_sum_calls_aggregate_with_correct_params(self, mock_aggregate):
+        # Arrange
+        dist_data = PrivateRDDTest.sc.parallelize([(1, 1.0, "pk1"),
+                                                   (2, 2.0, "pk1")])
+        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize([(3.0,
+                                                                      ["pk1"])])
         budget_accountant = budget_accounting.NaiveBudgetAccountant(1, 1e-10)
 
         def privacy_id_extractor(x):
-            return f"pid{x%10}"
+            return x[1]
 
         prdd = private_spark.make_private(dist_data, budget_accountant,
                                           privacy_id_extractor)
+        sum_params = agg.SumParams(noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+                                   max_partitions_contributed=2,
+                                   max_contributions_per_partition=3,
+                                   min_value=1,
+                                   max_value=5,
+                                   budget_weight=1,
+                                   public_partitions=None,
+                                   partition_extractor=lambda x: x[0],
+                                   value_extractor=lambda x: x)
 
-        sum_params = agg.SumParams(
-            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
-            max_partitions_contributed=2,
-            max_contributions_per_partition=3,
-            min_value=1,
-            max_value=5,
-            budget_weight=1,
-            public_partitions=None,
-            partition_extractor=lambda x: f"pk:{x // 10}",
-            value_extractor=lambda x: x)
-        prdd.sum(sum_params)
+        # Act
+        actual_result = prdd.sum(sum_params)
 
+        # Assert
         mock_aggregate.assert_called_once()
-
         args = mock_aggregate.call_args[0]
 
         rdd = dist_data.map(lambda x: (privacy_id_extractor(x), x))
@@ -95,19 +104,55 @@ class PrivateRDDTest(unittest.TestCase):
             public_partitions=sum_params.public_partitions)
         self.assertEqual(args[1], params)
 
-        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize([
-            (0, ["sum0"]), (1, ["sum1"])
-        ])
-        result = prdd.sum(sum_params)
-        self.assertEqual([(0, "sum0"), (1, "sum1")], result.collect())
+        self.assertEqual(actual_result.collect(), [(3.0, "pk1")])
+
+    def test_sum_calls_returns_sensible_result(self):
+        # Arrange
+        col = [(f"{u}", "pk1", 100.0) for u in range(30)]
+        col += [(f"{u + 30}", "pk1", -100.0) for u in range(30)]
+
+        dist_data = PrivateRDDTest.sc.parallelize(col)
+        # Use very high epsilon and delta to minimize noise and test
+        # flakiness.
+        budget_accountant = budget_accounting.NaiveBudgetAccountant(
+            total_epsilon=800, total_delta=0.999)
+
+        def privacy_id_extractor(x):
+            return x[0]
+
+        prdd = private_spark.make_private(dist_data, budget_accountant,
+                                          privacy_id_extractor)
+        sum_params = agg.SumParams(noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+                                   max_partitions_contributed=2,
+                                   max_contributions_per_partition=3,
+                                   min_value=1,
+                                   max_value=2,
+                                   budget_weight=1,
+                                   public_partitions=None,
+                                   partition_extractor=lambda x: x[1],
+                                   value_extractor=lambda x: x[2])
+
+        # Act
+        actual_result = prdd.sum(sum_params)
+        budget_accountant.compute_budgets()
+
+        # Assert
+        # This is a health check to validate that the result is sensible.
+        # Hence, we use a very large tolerance to reduce test flakiness.
+        self.assertTrue(
+            self.value_per_key_within_tolerance(actual_result.collect()[0],
+                                                ["pk1", 90.0], 5.0))
 
     @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
-    def test_count(self, mock_aggregate):
-        dist_data = PrivateRDDTest.sc.parallelize([])
+    def test_count_calls_aggregate_with_correct_params(self, mock_aggregate):
+        # Arrange
+        dist_data = PrivateRDDTest.sc.parallelize([(1, "pk1"), (2, "pk1")])
+        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize([(2,
+                                                                      ["pk1"])])
         budget_accountant = budget_accounting.NaiveBudgetAccountant(1, 1e-10)
 
         def privacy_id_extractor(x):
-            return f"pid{x%10}"
+            return x[0]
 
         prdd = private_spark.make_private(dist_data, budget_accountant,
                                           privacy_id_extractor)
@@ -118,13 +163,14 @@ class PrivateRDDTest(unittest.TestCase):
             max_contributions_per_partition=3,
             budget_weight=1,
             public_partitions=None,
-            partition_extractor=lambda x: f"pk:{x // 10}")
-        prdd.count(count_params)
+            partition_extractor=lambda x: x[1])
 
+        # Act
+        actual_result = prdd.count(count_params)
+
+        # Assert
         mock_aggregate.assert_called_once()
-
         args = mock_aggregate.call_args[0]
-
         rdd = dist_data.map(lambda x: (privacy_id_extractor(x), x))
         self.assertListEqual(args[0].collect(), rdd.collect())
 
@@ -137,32 +183,68 @@ class PrivateRDDTest(unittest.TestCase):
             public_partitions=count_params.public_partitions)
         self.assertEqual(args[1], params)
 
-        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize([
-            (0, ["count0"]), (1, ["count1"])
-        ])
-        result = prdd.count(count_params)
-        self.assertEqual([(0, "count0"), (1, "count1")], result.collect())
+        self.assertEqual(actual_result.collect(), [(2, "pk1")])
 
-    @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
-    def test_privacy_id_count(self, mock_aggregate):
-        dist_data = PrivateRDDTest.sc.parallelize([])
-        budget_accountant = budget_accounting.NaiveBudgetAccountant(1, 1e-10)
+    def test_count_calls_returns_sensible_result(self):
+        # Arrange
+        col = [(u, "pk1") for u in range(30)]
+        dist_data = PrivateRDDTest.sc.parallelize(col)
+
+        # Use very high epsilon and delta to minimize noise and test
+        # flakiness.
+        budget_accountant = budget_accounting.NaiveBudgetAccountant(
+            total_epsilon=800, total_delta=0.999)
 
         def privacy_id_extractor(x):
-            return f"pid{x%10}"
+            return x[0]
 
         prdd = private_spark.make_private(dist_data, budget_accountant,
                                           privacy_id_extractor)
 
+        count_params = agg.CountParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            max_partitions_contributed=2,
+            max_contributions_per_partition=3,
+            budget_weight=1,
+            public_partitions=None,
+            partition_extractor=lambda x: x[1])
+
+        # Act
+        actual_result = prdd.count(count_params)
+        budget_accountant.compute_budgets()
+
+        # Assert
+        # This is a health check to validate that the result is sensible.
+        # Hence, we use a very large tolerance to reduce test flakiness.
+        self.assertTrue(
+            self.value_per_key_within_tolerance(actual_result.collect()[0],
+                                                ("pk1", 30.0), 5.0))
+
+    @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
+    def test_privacy_id_count_calls_aggregate_with_correct_params(
+            self, mock_aggregate):
+        # Arrange
+        dist_data = PrivateRDDTest.sc.parallelize([(1, "pk1"), (2, "pk1")])
+        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize([(2,
+                                                                      ["pk1"])])
+        budget_accountant = budget_accounting.NaiveBudgetAccountant(1, 1e-10)
+
+        def privacy_id_extractor(x):
+            return x[0]
+
+        prdd = private_spark.make_private(dist_data, budget_accountant,
+                                          privacy_id_extractor)
         privacy_id_count_params = agg.PrivacyIdCountParams(
             noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
             max_partitions_contributed=2,
             budget_weight=1,
-            partition_extractor=lambda x: f"pk:{x // 10}")
-        prdd.privacy_id_count(privacy_id_count_params)
+            partition_extractor=lambda x: x[1])
 
+        # Act
+        actual_result = prdd.privacy_id_count(privacy_id_count_params)
+
+        # Assert
         mock_aggregate.assert_called_once()
-
         args = mock_aggregate.call_args[0]
 
         rdd = dist_data.map(lambda x: (privacy_id_extractor(x), x))
@@ -177,11 +259,36 @@ class PrivateRDDTest(unittest.TestCase):
             public_partitions=privacy_id_count_params.public_partitions)
         self.assertEqual(args[1], params)
 
-        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize([
-            (0, ["count0"]), (1, ["count1"])
-        ])
-        result = prdd.privacy_id_count(privacy_id_count_params)
-        self.assertEqual([(0, "count0"), (1, "count1")], result.collect())
+        self.assertEqual([(2, "pk1")], actual_result.collect())
+
+    def test_privacy_id_count_returns_sensible_result(self):
+        # Arrange
+        col = [(u, "pk1") for u in range(30)]
+        dist_data = PrivateRDDTest.sc.parallelize(col)
+        budget_accountant = budget_accounting.NaiveBudgetAccountant(
+            total_epsilon=800, total_delta=0.999)
+
+        def privacy_id_extractor(x):
+            return x[0]
+
+        prdd = private_spark.make_private(dist_data, budget_accountant,
+                                          privacy_id_extractor)
+        privacy_id_count_params = agg.PrivacyIdCountParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            max_partitions_contributed=2,
+            budget_weight=1,
+            partition_extractor=lambda x: x[1])
+
+        # Act
+        actual_result = prdd.privacy_id_count(privacy_id_count_params)
+        budget_accountant.compute_budgets()
+
+        # Assert
+        # This is a health check to validate that the result is sensible.
+        # Hence, we use a very large tolerance to reduce test flakiness.
+        self.assertTrue(
+            self.value_per_key_within_tolerance(actual_result.collect()[0],
+                                                ("pk1", 30.0), 5.0))
 
     @patch('pipeline_dp.dp_engine.DPEngine.select_partitions')
     def test_select_partitions_calls_select_partitions_with_correct_params(


### PR DESCRIPTION
private_spark aggregations new tests and small fixes

## Description
- Add "*_returns_sensible_result" tests to the rest of private_spark aggregations
- Make all tests style and structure in private_spark_tests consistent with each other
- Fix configuration error in the count implementation of private_spark

## How has this been tested?
- Unit tests

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
