### PR TITLE
Adds utility analysis in packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import os
 
 packages = \
-['pipeline_dp']
+['pipeline_dp', 'utility_analysis']
 
 package_data = \
 {'': ['*']}


### PR DESCRIPTION
## Description
Adds utility analysis in packages. After building and installing, users should be able to import utility analysis library by using `import utility_analysis` directly.
Tested locally and install from the wheel file. It seems to work for me