### PR TITLE
Fix corner cases for DP mean and sum computations

### DIFF
--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -271,6 +271,9 @@ def compute_dp_sum(sum: float, dp_params: MeanVarParams):
     linf_sensitivity = dp_params.max_contributions_per_partition * max(
         abs(dp_params.min_value), abs(dp_params.max_value))
 
+    if linf_sensitivity == 0:
+        return 0
+
     return _add_random_noise(
         sum,
         dp_params.eps,
@@ -312,6 +315,8 @@ def _compute_mean(
     Returns:
         The anonymized mean.
     """
+    if min_value == max_value:
+        return min_value
     middle = compute_middle(min_value, max_value)
     linf_sensitivity = max_contributions_per_partition * abs(middle - min_value)
 

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -379,6 +379,23 @@ class DPComputationsTest(unittest.TestCase):
                                expected_sum / expected_count,
                                delta=0.1)
 
+    def test_compute_dp_mean_equal_min_max(self):
+        params = dp_computations.MeanVarParams(
+            eps=0.5,
+            delta=1e-10,
+            min_value=42.0,
+            max_value=42.0, # = min_value
+            max_partitions_contributed=1,
+            max_contributions_per_partition=1,
+            noise_kind=NoiseKind.LAPLACE)
+
+
+        count, sum, mean = dp_computations.compute_dp_mean(count=10,
+                                        sum=400,
+                                        dp_params=params)
+        self.assertEqual(mean, 42.0)
+
+
     def test_compute_dp_var(self):
         params = dp_computations.MeanVarParams(
             eps=10,

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -302,6 +302,18 @@ class DPComputationsTest(unittest.TestCase):
                                   delta=params.delta,
                                   l2_sensitivity=l2_sensitivity)
 
+    def test_compute_dp_sum_min_max_zero(self):
+        params = dp_computations.MeanVarParams(
+            eps=0.5,
+            delta=1e-10,
+            min_value=0,
+            max_value=0,
+            max_partitions_contributed=1,
+            max_contributions_per_partition=1,
+            noise_kind=NoiseKind.LAPLACE)
+
+        self.assertEqual(0, dp_computations.compute_dp_sum(10, params))
+
     def test_equally_split_budget(self):
         # The number of mechanisms must be bigger than 0.
         with self.assertRaises(ValueError):
@@ -384,17 +396,15 @@ class DPComputationsTest(unittest.TestCase):
             eps=0.5,
             delta=1e-10,
             min_value=42.0,
-            max_value=42.0, # = min_value
+            max_value=42.0,  # = min_value
             max_partitions_contributed=1,
             max_contributions_per_partition=1,
             noise_kind=NoiseKind.LAPLACE)
 
-
         count, sum, mean = dp_computations.compute_dp_mean(count=10,
-                                        sum=400,
-                                        dp_params=params)
+                                                           sum=400,
+                                                           dp_params=params)
         self.assertEqual(mean, 42.0)
-
 
     def test_compute_dp_var(self):
         params = dp_computations.MeanVarParams(


### PR DESCRIPTION
This PR fixes:

min_value = max_value = 0 => dp_sum = 0
min_value = max_value => dp_mean = min_value