### PR TITLE
Fix small grammar error (it's -> its)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Code sample showing private processing on Spark:
 budget_accountant = pipeline_dp.NaiveBudgetAccountant(total_epsilon=1,
                                                       total_delta=1e-6)
 
-# Wrap Spark's RDD into it's private version. You will use this private wrapper
+# Wrap Spark's RDD into its private version. You will use this private wrapper
 # for all further processing instead of the Spark's RDD. Using the wrapper ensures
 # that only private statistics can be released.
 private_movie_views = \


### PR DESCRIPTION
## Description
Came here via https://www.infoq.com/news/2022/02/differential-privacy-python/ and noticed a tiny grammar error int he README

## Affected Dependencies
N/A

## How has this been tested?
Double-checked in MS Word.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests

Unsure how to add the label, but it's type: Documentation.