### PR TITLE
Add variance calculations in PipelineDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ sample of it. Here's how to take a subset of the data in bash:
 
    `head -10000 combined_data_1.txt > data.txt`
 
-3. Run `python movie_view_ratings.py --input_file=<path to data.txt from 2> --output_file=<...>`
+3. Run `python run_all_frameworks.py --input_file=<path to data.txt from 2> --output_file=<...>`
 
 ## Support and Community on Slack
 

--- a/examples/movie_view_ratings/run_all_frameworks.py
+++ b/examples/movie_view_ratings/run_all_frameworks.py
@@ -71,7 +71,8 @@ def calc_dp_rating_metrics(movie_views, backend, public_partitions):
         noise_kind=pipeline_dp.NoiseKind.LAPLACE,
         metrics=[
             pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.SUM,
-            pipeline_dp.Metrics.PRIVACY_ID_COUNT, pipeline_dp.Metrics.MEAN
+            pipeline_dp.Metrics.PRIVACY_ID_COUNT, pipeline_dp.Metrics.MEAN,
+            pipeline_dp.Metrics.VARIANCE
         ],
         max_partitions_contributed=2,
         max_contributions_per_partition=1,

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -25,6 +25,7 @@ class Metrics(Enum):
     PRIVACY_ID_COUNT = 'privacy_id_count'
     SUM = 'sum'
     MEAN = 'mean'
+    VARIANCE = 'variance'
 
 
 class NoiseKind(Enum):
@@ -94,7 +95,8 @@ class AggregateParams:
                 "AggregateParams: please use max_value instead of high")
         if self.metrics:
             needs_min_max_value = Metrics.SUM in self.metrics \
-                                  or Metrics.MEAN in self.metrics
+                                  or Metrics.MEAN in self.metrics \
+                                  or Metrics.VARIANCE in self.metrics
             if not isinstance(self.max_partitions_contributed,
                               int) or self.max_partitions_contributed <= 0:
                 raise ValueError(
@@ -191,6 +193,36 @@ class SumParams:
 
         if self.high is not None:
             raise ValueError("SumParams: please use max_value instead of high")
+
+
+@dataclass
+class VarianceParams:
+    """Specifies parameters for differentially-private variance calculation.
+
+    Args:
+        noise_kind: Kind of noise to use for the DP calculations.
+        max_partitions_contributed: Bounds the number of partitions in which one
+            unit of privacy (e.g., a user) can participate.
+        max_contributions_per_partition: Bounds the number of times one unit of
+            privacy (e.g. a user) can contribute to a partition.
+        min_value: Lower bound on a value contributed by a unit of privacy in a partition.
+        max_value: Upper bound on a value contributed by a unit of privacy in a
+            partition.
+        public_partitions: A collection of partition keys that will be present in
+            the result.
+        partition_extractor: A function for partition id extraction from a collection record.
+        value_extractor: A function for extraction of value
+            for which the sum will be calculated.
+  """
+    max_partitions_contributed: int
+    max_contributions_per_partition: int
+    min_value: float
+    max_value: float
+    partition_extractor: Callable
+    value_extractor: Callable
+    budget_weight: float = 1
+    noise_kind: NoiseKind = NoiseKind.LAPLACE
+    public_partitions: Union[Iterable, 'PCollection', 'RDD'] = None
 
 
 @dataclass

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -373,7 +373,8 @@ class CompoundCombiner(Combiner):
 
     In case one the of combiners is MeanCombiner, which computes count and sum
     in addition to mean, output_count and output_sum should be set to True if
-    they are to be outputted from MeanCombiner. For VarianceCombiner you can additionally set output_mean to True.
+    they are to be outputted from MeanCombiner. For VarianceCombiner you can
+    additionally set output_mean to True.
 
     The type of the accumulator is a tuple of int and an iterable.
     The first int represents the privacy id count. The second iterable

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -284,7 +284,7 @@ class MeanCombiner(Combiner):
         return self._metrics_to_compute
 
 
-# Cache for namedtuple types. It is should be used only in
+# Cache for namedtuple types. It should be used only in
 # '_get_or_create_named_tuple()' function.
 _named_tuple_cache = {}
 

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -389,7 +389,7 @@ def compute_dp_var(count: int, sum: float, sum_squares: float,
         ValueError: The noise kind is invalid.
 
     Returns:
-        The tuple of anonymized count, sum, sum_squares and variance.
+        The tuple of anonymized count, sum, mean and variance.
     """
     # Splits the budget equally between the three mechanisms.
     (
@@ -433,4 +433,4 @@ def compute_dp_var(count: int, sum: float, sum_squares: float,
                                     dp_params.noise_kind)
 
     dp_var = dp_mean_squares - dp_mean**2
-    return dp_count, dp_mean * dp_count, dp_mean_squares * dp_count, dp_var
+    return dp_count, dp_mean * dp_count, dp_mean, dp_var

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -61,13 +61,14 @@ class DPEngine:
         """
         _check_aggregate_params(col, params, data_extractors)
 
-        with self._budget_accountant.scope(
-                weight=params.budget_weight) as scope:
+        with self._budget_accountant.scope(weight=params.budget_weight):
             col = self._aggregate(col, params, data_extractors)
+            budget = self._budget_accountant._compute_budget_for_aggregation(
+                params.budget_weight)
             return self._backend.annotate(col,
                                           "annotation",
                                           params=params,
-                                          budget=scope)
+                                          budget=budget)
 
     def _aggregate(self, col, params: pipeline_dp.AggregateParams,
                    data_extractors: DataExtractors):
@@ -162,7 +163,13 @@ class DPEngine:
         self._check_select_private_partitions(col, params, data_extractors)
 
         with self._budget_accountant.scope(weight=params.budget_weight):
-            return self._select_partitions(col, params, data_extractors)
+            col = self._select_partitions(col, params, data_extractors)
+            budget = self._budget_accountant._compute_budget_for_aggregation(
+                params.budget_weight)
+            return self._backend.annotate(col,
+                                          "annotation",
+                                          params=params,
+                                          budget=budget)
 
     def _select_partitions(self, col,
                            params: pipeline_dp.SelectPartitionsParams,

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -433,7 +433,7 @@ class LocalBackend(PipelineBackend):
         keys_to_keep,
         stage_name: typing.Optional[str] = None,
     ):
-        return [kv for kv in col if kv[0] in keys_to_keep]
+        return (kv for kv in col if kv[0] in keys_to_keep)
 
     def keys(self, col, stage_name: typing.Optional[str] = None):
         return (k for k, v in col)

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -20,10 +20,11 @@ from pipeline_dp.budget_accounting import MechanismSpec
 from pipeline_dp.aggregate_params import MechanismType
 from pipeline_dp.budget_accounting import NaiveBudgetAccountant
 from pipeline_dp.budget_accounting import PLDBudgetAccountant
+from absl.testing import parameterized
 
 
 # pylint: disable=protected-access
-class NaiveBudgetAccountantTest(unittest.TestCase):
+class NaiveBudgetAccountantTest(parameterized.TestCase):
 
     def test_validation(self):
         NaiveBudgetAccountant(total_epsilon=1,
@@ -142,6 +143,56 @@ class NaiveBudgetAccountantTest(unittest.TestCase):
             # Budget can not be requested after it has been already computed.
             budget_accountant.request_budget(
                 mechanism_type=MechanismType.LAPLACE)
+
+    @parameterized.parameters(1, 2, 10)
+    def test_num_aggregations(self, num_aggregations):
+        total_epsilon, total_delta = 1, 1e-6
+        budget_accountant = NaiveBudgetAccountant(
+            total_epsilon=total_epsilon,
+            total_delta=total_delta,
+            num_aggregations=num_aggregations)
+        for _ in range(num_aggregations):
+            budget = budget_accountant._compute_budget_for_aggregation(1)
+            expected_epsilon = total_epsilon / num_aggregations
+            expected_delta = total_delta / num_aggregations
+            self.assertAlmostEqual(expected_epsilon, budget.epsilon)
+            self.assertAlmostEqual(expected_delta, budget.delta)
+
+        budget_accountant.compute_budgets()
+
+    def test_aggregation_weights(self):
+
+        total_epsilon, total_delta = 1, 1e-6
+        weights = [1, 2, 5]
+        budget_accountant = NaiveBudgetAccountant(total_epsilon=total_epsilon,
+                                                  total_delta=total_delta,
+                                                  aggregation_weights=weights)
+        for weight in weights:
+            budget = budget_accountant._compute_budget_for_aggregation(weight)
+            expected_epsilon = total_epsilon * weight / sum(weights)
+            expected_delta = total_delta * weight / sum(weights)
+            self.assertAlmostEqual(expected_epsilon, budget.epsilon)
+            self.assertAlmostEqual(expected_delta, budget.delta)
+
+        budget_accountant.compute_budgets()
+
+    @parameterized.parameters(True, False)
+    def test_not_enough_aggregations(self, use_num_aggregations):
+        weights = num_aggregations = None
+        if use_num_aggregations:
+            num_aggregations = 2
+        else:
+            weights = [1, 1]  # 2 aggregations
+        budget_accountant = NaiveBudgetAccountant(
+            total_epsilon=1,
+            total_delta=1e-6,
+            num_aggregations=num_aggregations,
+            aggregation_weights=weights)
+
+        budget_accountant._compute_budget_for_aggregation(1)
+        with self.assertRaises(ValueError):
+            # num_aggregations = 2, but only 1 aggregation_scope was created
+            budget_accountant.compute_budgets()
 
 
 class PLDBudgetAccountantTest(unittest.TestCase):

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -74,6 +74,18 @@ class CreateCompoundCombinersTest(parameterized.TestCase):
                  dp_combiners.CountCombiner, dp_combiners.SumCombiner,
                  dp_combiners.PrivacyIdCountCombiner
              ]),
+        dict(testcase_name='mean',
+             metrics=[
+                 pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.SUM,
+                 pipeline_dp.Metrics.MEAN
+             ],
+             expected_combiner_types=[dp_combiners.MeanCombiner]),
+        dict(testcase_name='variance',
+             metrics=[
+                 pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.SUM,
+                 pipeline_dp.Metrics.MEAN, pipeline_dp.Metrics.VARIANCE
+             ],
+             expected_combiner_types=[dp_combiners.VarianceCombiner]),
     )
     def test_create_compound_combiner(self, metrics, expected_combiner_types):
         # Arrange.

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -430,7 +430,7 @@ class DPComputationsTest(unittest.TestCase):
                                            dp_params=params)
             for _ in range(N_ITERATIONS)
         ]
-        count_values, sum_values, sum_squares_values, var_values = zip(*results)
+        count_values, sum_values, mean_values, var_values = zip(*results)
         self._test_laplace_noise(
             results=count_values,
             num_trials=N_ITERATIONS,
@@ -439,7 +439,7 @@ class DPComputationsTest(unittest.TestCase):
             l1_sensitivity=dp_computations.compute_l1_sensitivity(
                 l0_sensitivity, count_linf_sensitivity))
         self.assertAlmostEqual(np.mean(sum_values), 1000000, delta=1)
-        self.assertAlmostEqual(np.mean(sum_squares_values), 20000000, delta=2)
+        self.assertAlmostEqual(np.mean(mean_values), 10, delta=0.00003)
         self.assertAlmostEqual(np.mean(var_values), 100, delta=0.1)
 
         # Gaussian Mechanism
@@ -451,7 +451,7 @@ class DPComputationsTest(unittest.TestCase):
                                            dp_params=params)
             for _ in range(N_ITERATIONS)
         ]
-        count_values, sum_values, sum_squares_values, var_values = zip(*results)
+        count_values, sum_values, mean_values, var_values = zip(*results)
 
         self._test_gaussian_noise(
             results=count_values,
@@ -462,7 +462,7 @@ class DPComputationsTest(unittest.TestCase):
             l2_sensitivity=dp_computations.compute_l2_sensitivity(
                 l0_sensitivity, count_linf_sensitivity))
         self.assertAlmostEqual(np.mean(sum_values), 1000000, delta=5)
-        self.assertAlmostEqual(np.mean(sum_squares_values), 20000000, delta=5)
+        self.assertAlmostEqual(np.mean(mean_values), 10, delta=0.0002)
         self.assertAlmostEqual(np.mean(var_values), 100, delta=0.5)
 
 

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -720,8 +720,8 @@ class DpEngineTest(parameterized.TestCase):
         self.assertAlmostEqual(0, col[1][1][1])  # "pk10" SUM ≈ 0
         self.assertAlmostEqual(0, col[1][1][2])  # "pk10" PRIVACY_ID_COUNT ≈ 0
 
-    @staticmethod
-    def create_dp_engine_default(accountant: NaiveBudgetAccountant = None,
+    def create_dp_engine_default(self,
+                                 accountant: NaiveBudgetAccountant = None,
                                  backend: PipelineBackend = None):
         if not accountant:
             accountant = NaiveBudgetAccountant(total_epsilon=1,
@@ -738,8 +738,19 @@ class DpEngineTest(parameterized.TestCase):
         dp_engine._add_report_stage("DP Engine Test")
         return dp_engine
 
-    @staticmethod
-    def run_e2e_private_partition_selection_large_budget(col, backend):
+    def create_params_default(self):
+        return pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            metrics=[
+                agg.Metrics.COUNT, agg.Metrics.SUM, agg.Metrics.PRIVACY_ID_COUNT
+            ],
+            min_value=0,
+            max_value=1,
+            max_partitions_contributed=1,
+            max_contributions_per_partition=1,
+            public_partitions=["pk0", "pk10", "pk11"])
+
+    def run_e2e_private_partition_selection_large_budget(self, col, backend):
         # Arrange
         aggregator_params = pipeline_dp.AggregateParams(
             noise_kind=pipeline_dp.NoiseKind.LAPLACE,
@@ -827,6 +838,32 @@ class DpEngineTest(parameterized.TestCase):
         engine.aggregate(col, params, data_extractors)
         mock_create_custom_combiners.assert_called_once()
         mock_create_standard_combiners.assert_not_called()
+
+    @patch('pipeline_dp.pipeline_backend.PipelineBackend.annotate')
+    def test_annotate_call(self, mock_annotate_fn):
+        # Arrange
+        total_epsilon, total_delta = 3, 0.0001
+        budget_accountant = NaiveBudgetAccountant(total_epsilon,
+                                                  total_delta,
+                                                  num_aggregations=3)
+        dp_engine = self.create_dp_engine_default(budget_accountant)
+        aggregate_params = self.create_params_default()
+        select_partition_params = SelectPartitionsParams(2)
+        extractors = pipeline_dp.DataExtractors(None, None, None)
+        input = [1, 2, 3]
+
+        # Act and assert
+        dp_engine.select_partitions(input, select_partition_params, extractors)
+        dp_engine.aggregate(input, aggregate_params, extractors)
+        dp_engine.aggregate(input, aggregate_params, extractors)
+        budget_accountant.compute_budgets()
+
+        # Assert
+        self.assertEqual(3, mock_annotate_fn.call_count)
+        for i_call in range(3):
+            budget = mock_annotate_fn.call_args_list[i_call][1]['budget']
+            self.assertEqual(total_epsilon / 3, budget.epsilon)
+            self.assertEqual(total_delta / 3, budget.delta)
 
 
 if __name__ == '__main__':

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -436,13 +436,13 @@ class LocalBackendTest(unittest.TestCase):
         col = [(7, 1), (2, 1), (3, 9), (4, 1), (9, 10)]
         keys_to_keep = []
         result = self.backend.filter_by_key(col, keys_to_keep, "filter_by_key")
-        self.assertEqual(result, [])
+        self.assertEqual(list(result), [])
 
     def test_local_filter_by_key_remove(self):
         col = [(7, 1), (2, 1), (3, 9), (4, 1), (9, 10)]
         keys_to_keep = [7, 9]
         result = self.backend.filter_by_key(col, keys_to_keep, "filter_by_key")
-        self.assertEqual(result, [(7, 1), (9, 10)])
+        self.assertEqual(list(result), [(7, 1), (9, 10)])
 
     def test_local_keys(self):
         self.assertEqual(list(self.backend.keys([])), [])
@@ -515,6 +515,7 @@ class LocalBackendTest(unittest.TestCase):
         assert_laziness(self.backend.flat_map, str)
         assert_laziness(self.backend.sample_fixed_per_key, int)
         assert_laziness(self.backend.reduce_accumulators_per_key)
+        assert_laziness(self.backend.filter_by_key, list)
 
     def test_local_sample_fixed_per_key_requires_no_discarding(self):
         input_col = [("pid1", ('pk1', 1)), ("pid1", ('pk2', 1)),

--- a/tests/private_beam_test.py
+++ b/tests/private_beam_test.py
@@ -129,6 +129,134 @@ class PrivateBeamTest(unittest.TestCase):
             self.assertIsInstance(transformed, pvalue.PCollection)
 
     @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
+    def test_variance_calls_aggregate_with_params(self, mock_aggregate):
+        runner = fn_api_runner.FnApiRunner()
+        with beam.Pipeline(runner=runner) as pipeline:
+            # Arrange
+            pcol = pipeline | 'Create produce' >> beam.Create(
+                [1, 2, 3, 4, 5, 6])
+            budget_accountant = budget_accounting.NaiveBudgetAccountant(
+                total_epsilon=1, total_delta=0.01)
+            private_collection = (
+                pcol | 'Create private collection' >> private_beam.MakePrivate(
+                    budget_accountant=budget_accountant,
+                    privacy_id_extractor=PrivateBeamTest.privacy_id_extractor))
+
+            variance_params = aggregate_params.VarianceParams(
+                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+                max_partitions_contributed=2,
+                max_contributions_per_partition=3,
+                min_value=1,
+                max_value=5,
+                budget_weight=1,
+                public_partitions=[],
+                partition_extractor=lambda x: f"pk:{x // 10}",
+                value_extractor=lambda x: x)
+
+            # Act
+            transformer = private_beam.Variance(variance_params=variance_params)
+            private_collection | transformer
+
+            # Assert
+            self.assertEqual(transformer._budget_accountant, budget_accountant)
+            mock_aggregate.assert_called_once()
+
+            args = mock_aggregate.call_args[0]
+
+            params = pipeline_dp.AggregateParams(
+                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+                metrics=[pipeline_dp.Metrics.VARIANCE],
+                max_partitions_contributed=variance_params.
+                max_partitions_contributed,
+                max_contributions_per_partition=variance_params.
+                max_contributions_per_partition,
+                min_value=variance_params.min_value,
+                max_value=variance_params.max_value,
+                public_partitions=variance_params.public_partitions)
+            self.assertEqual(params, args[1])
+
+    def test_variance_returns_sensible_result(self):
+        with TestPipeline() as pipeline:
+            # Arrange
+            col = [(f"{u}", "pk1", -100.0) for u in range(30)]
+            col += [(f"{u + 30}", "pk1", 100.0) for u in range(10)]
+            pcol = pipeline | 'Create produce' >> beam.Create(col)
+            # Use very high epsilon and delta to minimize noise and test
+            # flakiness.
+            budget_accountant = budget_accounting.NaiveBudgetAccountant(
+                total_epsilon=800, total_delta=0.999)
+            private_collection = (
+                pcol | 'Create private collection' >> private_beam.MakePrivate(
+                    budget_accountant=budget_accountant,
+                    privacy_id_extractor=lambda x: x[0]))
+
+            variance_params = aggregate_params.VarianceParams(
+                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+                max_partitions_contributed=1,
+                max_contributions_per_partition=1,
+                min_value=1.55,  # -100 should be clipped to this value
+                max_value=2.7889,  # 100 should be clipped to this value
+                budget_weight=1,
+                partition_extractor=lambda x: x[1],
+                value_extractor=lambda x: x[2])
+
+            # Act
+            result = private_collection | private_beam.Variance(
+                variance_params=variance_params)
+            budget_accountant.compute_budgets()
+
+            # Assert
+            # This is a health check to validate that the result is sensible.
+            # Hence, we use a very large tolerance to reduce test flakiness.
+            beam_util.assert_that(
+                result,
+                beam_util.equal_to([("pk1", 0.288)],
+                                   equals_fn=lambda e, a: PrivateBeamTest.
+                                   value_per_key_within_tolerance(e, a, 0.1)))
+
+    def test_variance_with_public_partitions_returns_sensible_result(self):
+        with TestPipeline() as pipeline:
+            # Arrange
+            col = [(f"{u}", "pubK1", -100.0) for u in range(30)]
+            col += [(f"{u + 30}", "pubK1", 100.0) for u in range(10)]
+            col += [(f"{u + 40}", "privK1", 100.0) for u in range(30)]
+            pcol = pipeline | 'Create produce' >> beam.Create(col)
+            # Use very high epsilon and delta to minimize noise and test
+            # flakiness.
+            budget_accountant = budget_accounting.NaiveBudgetAccountant(
+                total_epsilon=8000, total_delta=0.9999999)
+            private_collection = (
+                pcol | 'Create private collection' >> private_beam.MakePrivate(
+                    budget_accountant=budget_accountant,
+                    privacy_id_extractor=lambda x: x[0]))
+
+            variance_params = aggregate_params.VarianceParams(
+                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+                max_partitions_contributed=1,
+                max_contributions_per_partition=1,
+                min_value=1.55,  # -100 should be clipped to this value
+                max_value=2.7889,  # 100 should be clipped to this value
+                budget_weight=1,
+                partition_extractor=lambda x: x[1],
+                value_extractor=lambda x: x[2],
+                public_partitions=["pubK1", "pubK2"])
+
+            # Act
+            result = private_collection | private_beam.Variance(
+                variance_params=variance_params)
+            budget_accountant.compute_budgets()
+
+            # Assert
+            # This is a health check to validate that the result is sensible.
+            # Hence, we use a very large tolerance to reduce test flakiness.
+            beam_util.assert_that(
+                result,
+                # pubK2 has no data points therefore the dataset is assumed to be {min_value, max_value}
+                beam_util.equal_to([("pubK1", 0.288), ("pubK2", 0.384)],
+                                   equals_fn=lambda e, a: PrivateBeamTest.
+                                   value_per_key_within_tolerance(e, a, 0.1)))
+
+    @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
     def test_mean_calls_aggregate_with_params(self, mock_aggregate):
         runner = fn_api_runner.FnApiRunner()
         with beam.Pipeline(runner=runner) as pipeline:
@@ -194,8 +322,8 @@ class PrivateBeamTest(unittest.TestCase):
                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
                 max_partitions_contributed=1,
                 max_contributions_per_partition=1,
-                min_value=1.55,
-                max_value=2.7889,
+                min_value=1.55,  # -100 should be clipped to this value
+                max_value=2.7889,  # 100 should be clipped to this value
                 budget_weight=1,
                 partition_extractor=lambda x: x[1],
                 value_extractor=lambda x: x[2])
@@ -234,8 +362,8 @@ class PrivateBeamTest(unittest.TestCase):
                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
                 max_partitions_contributed=1,
                 max_contributions_per_partition=1,
-                min_value=1.55,
-                max_value=2.7889,
+                min_value=1.55,  # -100 should be clipped to this value
+                max_value=2.7889,  # 100 should be clipped to this value
                 budget_weight=1,
                 partition_extractor=lambda x: x[1],
                 value_extractor=lambda x: x[2],
@@ -251,6 +379,7 @@ class PrivateBeamTest(unittest.TestCase):
             # Hence, we use a very large tolerance to reduce test flakiness.
             beam_util.assert_that(
                 result,
+                # pubK2 has no data points therefore the dataset is assumed to be {min_value, max_value}
                 beam_util.equal_to([("pubK1", 1.859), ("pubK2", 2.1695)],
                                    equals_fn=lambda e, a: PrivateBeamTest.
                                    value_per_key_within_tolerance(e, a, 0.1)))
@@ -684,7 +813,7 @@ class PrivateBeamTest(unittest.TestCase):
             select_partitions_params = \
                 aggregate_params.SelectPartitionsParams(
                     max_partitions_contributed=2,
-                    budget_weight=0.5,)
+                    budget_weight=0.5, )
             partition_extractor = lambda x: f"pk:{x // 10}"
 
             # Act

--- a/tests/private_spark_test.py
+++ b/tests/private_spark_test.py
@@ -79,6 +79,145 @@ class PrivateRDDTest(unittest.TestCase):
         self.assertEqual(result._budget_accountant, prdd._budget_accountant)
 
     @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
+    def test_variance_calls_aggregate_with_correct_params(self, mock_aggregate):
+        # Arrange
+        dist_data = PrivateRDDTest.sc.parallelize([(1, 0.0, "pk1"),
+                                                   (2, 10.0, "pk1")])
+        MetricsTuple = collections.namedtuple('MetricsTuple', ['variance'])
+        mock_aggregate.return_value = PrivateRDDTest.sc.parallelize([
+            ("pk1", MetricsTuple(variance=25.0))
+        ])
+        budget_accountant = budget_accounting.NaiveBudgetAccountant(1, 1e-10)
+
+        def privacy_id_extractor(x):
+            return x[1]
+
+        prdd = private_spark.make_private(dist_data, budget_accountant,
+                                          privacy_id_extractor)
+        variance_params = agg.VarianceParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            max_partitions_contributed=2,
+            max_contributions_per_partition=3,
+            min_value=1.5,
+            max_value=5.78,
+            budget_weight=1.1,
+            public_partitions=None,
+            partition_extractor=lambda x: x[0],
+            value_extractor=lambda x: x)
+
+        # Act
+        actual_result = prdd.variance(variance_params)
+
+        # Assert
+        mock_aggregate.assert_called_once()
+        args = mock_aggregate.call_args[0]
+
+        rdd = dist_data.map(lambda x: (privacy_id_extractor(x), x))
+        self.assertListEqual(args[0].collect(), rdd.collect())
+
+        params = pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            metrics=[pipeline_dp.Metrics.VARIANCE],
+            max_partitions_contributed=variance_params.
+            max_partitions_contributed,
+            max_contributions_per_partition=variance_params.
+            max_contributions_per_partition,
+            min_value=variance_params.min_value,
+            max_value=variance_params.max_value,
+            budget_weight=variance_params.budget_weight,
+            public_partitions=variance_params.public_partitions)
+        self.assertEqual(args[1], params)
+
+        self.assertEqual(actual_result.collect(), [("pk1", 25.0)])
+
+    def test_variance_returns_sensible_result(self):
+        # Arrange
+        col = [(u, "pk1", -100) for u in range(30)]
+        col += [(u + 30, "pk1", 100) for u in range(10)]
+
+        dist_data = PrivateRDDTest.sc.parallelize(col)
+        # Use very high epsilon and delta to minimize noise and test
+        # flakiness.
+        budget_accountant = budget_accounting.NaiveBudgetAccountant(
+            total_epsilon=800, total_delta=0.999)
+
+        def privacy_id_extractor(x):
+            return x[0]
+
+        prdd = private_spark.make_private(dist_data, budget_accountant,
+                                          privacy_id_extractor)
+        variance_params = agg.VarianceParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            max_partitions_contributed=2,
+            max_contributions_per_partition=3,
+            min_value=1.55,  # -100 should be clipped to this value
+            max_value=2.7889,  # 100 should be clipped to this value
+            budget_weight=1,
+            public_partitions=None,
+            partition_extractor=lambda x: x[1],
+            value_extractor=lambda x: x[2])
+
+        # Act
+        actual_result = prdd.variance(variance_params)
+        budget_accountant.compute_budgets()
+
+        # Assert
+        # This is a health check to validate that the result is sensible.
+        # Hence, we use a very large tolerance to reduce test flakiness.
+        expected_result_dict = {"pk1": 0.288}
+        actual_result_dict = self.to_dict(actual_result.collect())
+
+        for pk, variance in actual_result_dict.items():
+            self.assertTrue(
+                self.value_per_key_within_tolerance(variance,
+                                                    expected_result_dict[pk],
+                                                    0.1))
+
+    def test_variance_with_public_partitions_returns_sensible_result(self):
+        # Arrange
+        col = [(u, "pubK1", -100) for u in range(30)]
+        col += [(u + 30, "pubK1", 100) for u in range(10)]
+        col += [(u + 40, "privK1", 100) for u in range(30)]
+
+        dist_data = PrivateRDDTest.sc.parallelize(col)
+        # Use very high epsilon and delta to minimize noise and test
+        # flakiness.
+        budget_accountant = budget_accounting.NaiveBudgetAccountant(
+            total_epsilon=8000, total_delta=0.9999999)
+
+        def privacy_id_extractor(x):
+            return x[0]
+
+        prdd = private_spark.make_private(dist_data, budget_accountant,
+                                          privacy_id_extractor)
+        variance_params = agg.VarianceParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            max_partitions_contributed=2,
+            max_contributions_per_partition=3,
+            min_value=1.55,  # -100 should be clipped to this value
+            max_value=2.7889,  # 100 should be clipped to this value
+            budget_weight=1,
+            partition_extractor=lambda x: x[1],
+            value_extractor=lambda x: x[2],
+            public_partitions=["pubK1", "pubK2"])
+
+        # Act
+        actual_result = prdd.variance(variance_params)
+        budget_accountant.compute_budgets()
+
+        # Assert
+        # This is a health check to validate that the result is sensible.
+        # Hence, we use a very large tolerance to reduce test flakiness.
+        expected_result_dict = {"pubK1": 0.288, "pubK2": 0.384}
+        actual_result_dict = self.to_dict(actual_result.collect())
+
+        for pk, variance in actual_result_dict.items():
+            self.assertTrue(
+                self.value_per_key_within_tolerance(variance,
+                                                    expected_result_dict[pk],
+                                                    0.1))
+
+    @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
     def test_mean_calls_aggregate_with_correct_params(self, mock_aggregate):
         # Arrange
         dist_data = PrivateRDDTest.sc.parallelize([(1, 2.0, "pk1"),
@@ -168,7 +307,7 @@ class PrivateRDDTest(unittest.TestCase):
             self.assertTrue(
                 self.value_per_key_within_tolerance(mean,
                                                     expected_result_dict[pk],
-                                                    5.0))
+                                                    0.1))
 
     def test_mean_with_public_partitions_returns_sensible_result(self):
         # Arrange
@@ -180,7 +319,7 @@ class PrivateRDDTest(unittest.TestCase):
         # Use very high epsilon and delta to minimize noise and test
         # flakiness.
         budget_accountant = budget_accounting.NaiveBudgetAccountant(
-            total_epsilon=800, total_delta=0.999)
+            total_epsilon=8000, total_delta=0.999999)
 
         def privacy_id_extractor(x):
             return x[0]
@@ -211,7 +350,7 @@ class PrivateRDDTest(unittest.TestCase):
             self.assertTrue(
                 self.value_per_key_within_tolerance(mean,
                                                     expected_result_dict[pk],
-                                                    5.0))
+                                                    0.1))
 
     @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
     def test_sum_calls_aggregate_with_correct_params(self, mock_aggregate):

--- a/utility_analysis/non_private_combiners.py
+++ b/utility_analysis/non_private_combiners.py
@@ -120,6 +120,38 @@ class RawMeanCombiner(pipeline_dp.combiners.Combiner):
         return ['non_private_mean']
 
 
+VarianceTuple = namedtuple('VarianceTuple', ['count', 'sum', 'mean', 'variance'])
+
+
+class RawVarianceCombiner(pipeline_dp.combiners.Combiner):
+    """Combiner for computing DP Variance. Also returns sum, count and mean in addition to
+    the variance.
+    The type of the accumulator is a tuple(count: int, sum: float) that holds
+    the count and sum of elements in the dataset for which this accumulator is
+    computed.
+    """
+    AccumulatorType = Tuple[int, float, float]
+
+    def create_accumulator(self, values: Iterable[float]) -> AccumulatorType:
+        return len(values), sum(values), sum(value ** 2 for value in values)
+
+    def merge_accumulators(self, accum1: AccumulatorType,
+                           accum2: AccumulatorType):
+        count1, sum1, sum_of_squares1 = accum1
+        count2, sum2, sum_of_squares2 = accum2
+        return count1 + count2, sum1 + sum2, sum_of_squares1 + sum_of_squares2
+
+    def compute_metrics(self, accum: AccumulatorType) -> namedtuple:
+        count, sum, sum_of_squares = accum
+        return VarianceTuple(count=count,
+                             sum=sum,
+                             mean=sum / count if count else None,
+                             variance=sum_of_squares / count - sum / count if count else None)
+
+    def metrics_names(self) -> List[str]:
+        return ['non_private_mean']
+
+
 class CompoundCombiner(pipeline_dp.combiners.Combiner):
     """Combiner for computing a set of dp aggregations.
 
@@ -166,7 +198,7 @@ class CompoundCombiner(pipeline_dp.combiners.Combiner):
 
 
 def create_compound_combiner(
-    metrics: pipeline_dp.aggregate_params.Metrics,) -> CompoundCombiner:
+        metrics: pipeline_dp.aggregate_params.Metrics, ) -> CompoundCombiner:
     combiners = []
     if pipeline_dp.Metrics.COUNT in metrics:
         combiners.append(RawCountCombiner())
@@ -176,4 +208,6 @@ def create_compound_combiner(
         combiners.append(RawPrivacyIdCountCombiner())
     if pipeline_dp.Metrics.MEAN in metrics:
         combiners.append(RawMeanCombiner())
+    if pipeline_dp.Metrics.VARIANCE in metrics:
+        combiners.append(RawVarianceCombiner())
     return CompoundCombiner(combiners)

--- a/utility_analysis/non_private_combiners.py
+++ b/utility_analysis/non_private_combiners.py
@@ -198,7 +198,7 @@ class CompoundCombiner(pipeline_dp.combiners.Combiner):
 
 
 def create_compound_combiner(
-        metrics: pipeline_dp.aggregate_params.Metrics, ) -> CompoundCombiner:
+        metrics: pipeline_dp.aggregate_params.Metrics) -> CompoundCombiner:
     combiners = []
     if pipeline_dp.Metrics.COUNT in metrics:
         combiners.append(RawCountCombiner())


### PR DESCRIPTION
## Description
Closes #255
Adds support for the calculation of variance in PipelineDP. Changes cover all places where mean was used since variance and mean are very close to each other.

## Affected Dependencies
None

## How has this been tested?
It was tested by unit tests. If a unit test exists for the mean then similar test was added for variance.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
