### PR TITLE
Expose vector_sum computation to high-level Beam API

### DIFF
--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -257,30 +257,24 @@ class VectorSumParams:
         max_contributions_per_partition: A bound on the number of times one unit of
           privacy (e.g. a user) can contribute to a partition.
               min_value: Lower bound on each value.
-        min_value: Lower bound on each value.
-        max_value: Upper bound on each value.
         budget_weight: Relative weight of the privacy budget allocated to this
           aggregation.
-        vector_norm_kind: The type of norm. Used only for VECTOR_SUM metric
+        vector_norm_kind: The type of norm.
         calculations.
-        vector_max_norm: Bound on each value of a vector. Used only for
-         VECTOR_SUM metric calculations.
-        vector_size: Number of coordinates in a vector. Used only for VECTOR_SUM
-         metric calculations.
+        vector_max_norm: Bound on each value of a vector.
+        vector_size: Number of coordinates in a vector.
         partition_extractor: A function which, given an input element, will return its partition id.
         value_extractor: A function which, given an input element, will return its value.
     """
     partition_extractor: Callable
     value_extractor: Callable
+    vector_norm_kind: NormKind
+    vector_max_norm: float
+    vector_size: int
     noise_kind: NoiseKind = NoiseKind.LAPLACE
     max_partitions_contributed: Optional[int] = None
     max_contributions_per_partition: Optional[int] = None
-    min_value: float = None
-    max_value: float = None
     budget_weight: float = 1
-    vector_norm_kind: NormKind = NormKind.Linf
-    vector_max_norm: float = None
-    vector_size: int = None
 
 
 @dataclass

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -245,6 +245,42 @@ class SumParams:
                 "SumParams.public_partitions is deprecated. Please read API documentation for anonymous Sum transform."
             )
 
+@dataclass
+class VectorSumParams:
+    """Specifies parameters for differentially-private vector summation calculation.
+
+    Args:
+        noise_kind: The type of noise to use for the DP calculations.
+        max_partitions_contributed: A bound on the number of partitions to which one
+          unit of privacy (e.g., a user) can contribute.
+        max_contributions_per_partition: A bound on the number of times one unit of
+          privacy (e.g. a user) can contribute to a partition.
+              min_value: Lower bound on each value.
+        min_value: Lower bound on each value.
+        max_value: Upper bound on each value.
+        budget_weight: Relative weight of the privacy budget allocated to this
+          aggregation.
+        vector_norm_kind: The type of norm. Used only for VECTOR_SUM metric
+        calculations.
+        vector_max_norm: Bound on each value of a vector. Used only for
+         VECTOR_SUM metric calculations.
+        vector_size: Number of coordinates in a vector. Used only for VECTOR_SUM
+         metric calculations.
+        partition_extractor: A function which, given an input element, will return its partition id.
+        value_extractor: A function which, given an input element, will return its value.
+    """
+    partition_extractor: Callable
+    value_extractor: Callable
+    noise_kind: NoiseKind = NoiseKind.LAPLACE
+    max_partitions_contributed: Optional[int] = None
+    max_contributions_per_partition: Optional[int] = None
+    min_value: float = None
+    max_value: float = None
+    budget_weight: float = 1
+    vector_norm_kind: NormKind = NormKind.Linf
+    vector_max_norm: float = None
+    vector_size: int = None
+
 
 @dataclass
 class VarianceParams:

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -245,6 +245,7 @@ class SumParams:
                 "SumParams.public_partitions is deprecated. Please read API documentation for anonymous Sum transform."
             )
 
+
 @dataclass
 class VectorSumParams:
     """Specifies parameters for differentially-private vector summation calculation.

--- a/pipeline_dp/private_beam.py
+++ b/pipeline_dp/private_beam.py
@@ -115,8 +115,6 @@ class VectorSum(PrivatePTransform):
             max_partitions_contributed,
             max_contributions_per_partition=self._vector_sum_params.
             max_contributions_per_partition,
-            min_value=self._vector_sum_params.min_value,
-            max_value=self._vector_sum_params.max_value,
             vector_norm_kind=self._vector_sum_params.vector_norm_kind,
             vector_max_norm=self._vector_sum_params.vector_max_norm,
             vector_size=self._vector_sum_params.vector_size,

--- a/pipeline_dp/private_beam.py
+++ b/pipeline_dp/private_beam.py
@@ -99,7 +99,7 @@ class VectorSum(PrivatePTransform):
     def __init__(self,
                  vector_sum_params: aggregate_params.VectorSumParams,
                  label: Optional[str] = None,
-                 public_partitions = None):
+                 public_partitions=None):
         super().__init__(return_anonymized=True, label=label)
         self._vector_sum_params = vector_sum_params
         self._public_partitions = public_partitions
@@ -126,8 +126,8 @@ class VectorSum(PrivatePTransform):
             partition_extractor=lambda x: self._vector_sum_params.
             partition_extractor(x[1]),
             privacy_id_extractor=lambda x: x[0],
-            value_extractor=lambda x: self._vector_sum_params.value_extractor(x[1]
-                                                                           ))
+            value_extractor=lambda x: self._vector_sum_params.value_extractor(x[
+                1]))
 
         dp_result = dp_engine.aggregate(pcol, params, data_extractors,
                                         self._public_partitions)
@@ -140,6 +140,7 @@ class VectorSum(PrivatePTransform):
         # dp_result : (partition_key, dp_vector_sum)
 
         return dp_result
+
 
 class Variance(PrivatePTransform):
     """Transform class for performing DP Variance on PrivatePCollection."""

--- a/tests/private_beam_test.py
+++ b/tests/private_beam_test.py
@@ -135,8 +135,8 @@ class PrivateBeamTest(unittest.TestCase):
         runner = fn_api_runner.FnApiRunner()
         with beam.Pipeline(runner=runner) as pipeline:
             # Arrange
-            pcol = pipeline | 'Create produce' >> beam.Create(
-                [[1, 2, 3],[4, 5, 6]])
+            pcol = pipeline | 'Create produce' >> beam.Create([[1, 2, 3],
+                                                               [4, 5, 6]])
             budget_accountant = budget_accounting.NaiveBudgetAccountant(
                 total_epsilon=1, total_delta=0.01)
             private_collection = (
@@ -153,11 +153,12 @@ class PrivateBeamTest(unittest.TestCase):
                 vector_max_norm=5,
                 vector_size=3,
                 partition_extractor=lambda x: f"pk:{x // 10}",
-                value_extractor=lambda x: x,)
+                value_extractor=lambda x: x,
+            )
 
             # Act
-            transformer = private_beam.VectorSum(vector_sum_params=vector_sum_params,
-                                                public_partitions=[])
+            transformer = private_beam.VectorSum(
+                vector_sum_params=vector_sum_params, public_partitions=[])
             private_collection | transformer
 
             # Assert
@@ -175,13 +176,14 @@ class PrivateBeamTest(unittest.TestCase):
                 max_contributions_per_partition,
                 vector_norm_kind=aggregate_params.NormKind.Linf,
                 vector_max_norm=5,
-                vector_size=3,)
+                vector_size=3,
+            )
             self.assertEqual(params, args[1])
 
     def test_vector_sum_returns_sensible_result(self):
         with TestPipeline() as pipeline:
             # Arrange
-            col = [(f"{u}", "pk1",[-100.0]) for u in range(30)]
+            col = [(f"{u}", "pk1", [-100.0]) for u in range(30)]
             col += [(f"{u + 30}", "pk1", [100.0]) for u in range(30)]
             pcol = pipeline | 'Create produce' >> beam.Create(col)
             # Use very high epsilon and delta to minimize noise and test
@@ -192,7 +194,7 @@ class PrivateBeamTest(unittest.TestCase):
                 pcol | 'Create private collection' >> private_beam.MakePrivate(
                     budget_accountant=budget_accountant,
                     privacy_id_extractor=lambda x: x[0]))
-      
+
             vector_sum_params = aggregate_params.VectorSumParams(
                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
                 max_partitions_contributed=2,
@@ -202,7 +204,8 @@ class PrivateBeamTest(unittest.TestCase):
                 vector_max_norm=5,
                 vector_size=1,
                 partition_extractor=lambda x: x[1],
-                value_extractor=lambda x: x[2],)
+                value_extractor=lambda x: x[2],
+            )
 
             # Act
             result = private_collection | private_beam.VectorSum(


### PR DESCRIPTION
## Description
This PR continues the work started for #264 . An additional `PrivatePTransform` is added for vector summation in [private_beam.py](https://github.com/OpenMined/PipelineDP/blob/bb4046265e155f45cdd7b4ee91b8d595c1089c72/pipeline_dp/private_beam.py#L96).

## Affected Dependencies
* VectorSumParams class was added to `aggregate_params.py`
* VectorSum class was added to `private_beam.py`

## How has this been tested?
* Tests added to `private_beam_test.py`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
