### PR TITLE
Improvement: numerical stability of DP mean and variance computations as per #287

### DIFF
--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -253,8 +253,8 @@ class SumCombiner(Combiner):
 class MeanCombiner(Combiner):
     """Combiner for computing DP Mean. Also returns sum and count in addition to
     the mean.
-    The type of the accumulator is a tuple(count: int, sum: float) that holds
-    the count and sum of elements in the dataset for which this accumulator is
+    The type of the accumulator is a tuple(count: int, normalized_sum: float) that holds
+    the count and normalized sum of elements in the dataset for which this accumulator is
     computed.
     """
     AccumulatorType = Tuple[int, float]
@@ -274,9 +274,12 @@ class MeanCombiner(Combiner):
         self._metrics_to_compute = metrics_to_compute
 
     def create_accumulator(self, values: Iterable[float]) -> AccumulatorType:
-        return len(values), np.clip(
-            values, self._params.aggregate_params.min_value,
-            self._params.aggregate_params.max_value).sum()
+        min_value = self._params.aggregate_params.min_value
+        max_value = self._params.aggregate_params.max_value
+        middle = dp_computations.compute_middle(min_value, max_value)
+        normalized_values = np.clip(values, min_value, max_value) - middle
+
+        return len(values), normalized_values.sum()
 
     def merge_accumulators(self, accum1: AccumulatorType,
                            accum2: AccumulatorType):
@@ -285,9 +288,9 @@ class MeanCombiner(Combiner):
         return count1 + count2, sum1 + sum2
 
     def compute_metrics(self, accum: AccumulatorType) -> dict:
-        total_count, total_sum = accum
+        total_count, total_normalized_sum = accum
         noisy_count, noisy_sum, noisy_mean = dp_computations.compute_dp_mean(
-            total_count, total_sum, self._params.mean_var_params)
+            total_count, total_normalized_sum, self._params.mean_var_params)
         mean_dict = {'mean': noisy_mean}
         if 'count' in self._metrics_to_compute:
             mean_dict['count'] = noisy_count
@@ -302,8 +305,8 @@ class MeanCombiner(Combiner):
 class VarianceCombiner(Combiner):
     """Combiner for computing DP Variance. Also returns mean, sum and count in addition to
     the variance.
-    The type of the accumulator is a tuple(count: int, sum: float, sum_of_squares: float) that holds
-    the count, sum and sum of squares of elements in the dataset for which this accumulator is
+    The type of the accumulator is a tuple(count: int, normalized_sum: float, normalized_sum_of_squares: float) that holds
+    the count, normalized sum and normalized sum of squares of elements in the dataset for which this accumulator is
     computed.
     """
     AccumulatorType = Tuple[int, float, float]
@@ -324,10 +327,15 @@ class VarianceCombiner(Combiner):
         self._metrics_to_compute = metrics_to_compute
 
     def create_accumulator(self, values: Iterable[float]) -> AccumulatorType:
-        clipped_values = np.clip(values,
-                                 self._params.aggregate_params.min_value,
-                                 self._params.aggregate_params.max_value)
-        return len(values), clipped_values.sum(), (clipped_values**2).sum()
+        min_value = self._params.aggregate_params.min_value
+        max_value = self._params.aggregate_params.max_value
+        middle = dp_computations.compute_middle(min_value, max_value)
+
+        clipped_values = np.clip(values, min_value, max_value)
+        normalized_values = clipped_values - middle
+
+        return len(values), normalized_values.sum(), (
+            normalized_values**2).sum()
 
     def merge_accumulators(self, accum1: AccumulatorType,
                            accum2: AccumulatorType):
@@ -336,9 +344,9 @@ class VarianceCombiner(Combiner):
         return count1 + count2, sum1 + sum2, sum_of_squares1 + sum_of_squares2
 
     def compute_metrics(self, accum: AccumulatorType) -> dict:
-        total_count, total_sum, total_sum_of_squares = accum
+        total_count, total_normalized_sum, total_normalized_sum_of_squares = accum
         noisy_count, noisy_sum, noisy_mean, noisy_variance = dp_computations.compute_dp_var(
-            total_count, total_sum, total_sum_of_squares,
+            total_count, total_normalized_sum, total_normalized_sum_of_squares,
             self._params.mean_var_params)
         variance_dict = {'variance': noisy_variance}
         if 'count' in self._metrics_to_compute:

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -296,7 +296,7 @@ class MeanCombinerTest(parameterized.TestCase):
         for no_noise in [False, True]:
             combiner = self._create_combiner(no_noise)
             self.assertEqual((0, 0), combiner.create_accumulator([]))
-            self.assertEqual((2, 3), combiner.create_accumulator([1, 2]))
+            self.assertEqual((2, 0), combiner.create_accumulator([1, 3]))
 
     def test_merge_accumulators(self):
         for no_noise in [False, True]:
@@ -310,16 +310,18 @@ class MeanCombinerTest(parameterized.TestCase):
         combiner = self._create_combiner(no_noise=True)
         res = combiner.compute_metrics((3, 3))
         self.assertAlmostEqual(3, res['count'], delta=1e-5)
-        self.assertAlmostEqual(3, res['sum'], delta=1e-5)
-        self.assertAlmostEqual(1, res['mean'], delta=1e-5)
+        self.assertAlmostEqual(9, res['sum'], delta=1e-5)
+        self.assertAlmostEqual(3, res['mean'], delta=1e-5)
 
     def test_compute_metrics_with_noise(self):
         combiner = self._create_combiner(no_noise=False)
         count = 5
         sum = 10
+        normalized_sum = 0
         mean = 2
         noisy_values = [
-            combiner.compute_metrics((count, sum)) for _ in range(1000)
+            combiner.compute_metrics((count, normalized_sum))
+            for _ in range(1000)
         ]
 
         noisy_counts = [noisy_value['count'] for noisy_value in noisy_values]
@@ -348,7 +350,7 @@ class VarianceCombinerTest(parameterized.TestCase):
         for no_noise in [False, True]:
             combiner = self._create_combiner(no_noise)
             self.assertEqual((0, 0, 0), combiner.create_accumulator([]))
-            self.assertEqual((2, 3, 5), combiner.create_accumulator([1, 2]))
+            self.assertEqual((2, -1, 1), combiner.create_accumulator([1, 2]))
 
     def test_merge_accumulators(self):
         for no_noise in [False, True]:
@@ -360,8 +362,8 @@ class VarianceCombinerTest(parameterized.TestCase):
 
     def test_compute_metrics_no_noise(self):
         combiner = self._create_combiner(no_noise=True)
-        # potential values: 1, 2, 2, 3
-        res = combiner.compute_metrics((4, 8, 18))
+        # potential values: 1, 2, 2, 3 | middle = 2
+        res = combiner.compute_metrics((4, 0, 2))
         self.assertAlmostEqual(4, res['count'], delta=1e-5)
         self.assertAlmostEqual(8, res['sum'], delta=1e-5)
         self.assertAlmostEqual(2, res['mean'], delta=1e-5)
@@ -369,14 +371,16 @@ class VarianceCombinerTest(parameterized.TestCase):
 
     def test_compute_metrics_with_noise(self):
         combiner = self._create_combiner(no_noise=False)
-        # potential values: 1, 1, 2, 3, 3
+        # potential values: 1, 1, 2, 3, 3 | middle = 2
         count = 5
         sum = 10
-        sum_of_squares = 24
+        normalized_sum = 0
+        normalized_sum_of_squares = 4
         mean = 2
         variance = 0.8
         noisy_values = [
-            combiner.compute_metrics((count, sum, sum_of_squares))
+            combiner.compute_metrics(
+                (count, normalized_sum, normalized_sum_of_squares))
             for _ in range(1000)
         ]
 

--- a/tests/private_beam_test.py
+++ b/tests/private_beam_test.py
@@ -251,7 +251,7 @@ class PrivateBeamTest(unittest.TestCase):
             beam_util.assert_that(
                 result,
                 # pubK2 has no data points therefore the dataset is assumed to be {min_value, max_value}
-                beam_util.equal_to([("pubK1", 0.288), ("pubK2", 0.384)],
+                beam_util.equal_to([("pubK1", 0.288), ("pubK2", 0.0)],
                                    equals_fn=lambda e, a: PrivateBeamTest.
                                    value_per_key_within_tolerance(e, a, 0.1)))
 

--- a/tests/private_spark_test.py
+++ b/tests/private_spark_test.py
@@ -206,7 +206,7 @@ class PrivateRDDTest(unittest.TestCase):
         # Assert
         # This is a health check to validate that the result is sensible.
         # Hence, we use a very large tolerance to reduce test flakiness.
-        expected_result_dict = {"pubK1": 0.288, "pubK2": 0.384}
+        expected_result_dict = {"pubK1": 0.288, "pubK2": 0.0}
         actual_result_dict = self.to_dict(actual_result.collect())
 
         for pk, variance in actual_result_dict.items():


### PR DESCRIPTION
# Description
This PR introduces an improvement for the numerical stability of DP mean and variance computations as per #287.
This is done by computing the normalized sum in the accumulator of the mean combiner.  
For computing variance the sum and the squares sum are both normalized in the accumulator of the variance combiner.

## Affected Dependencies
N/A

## How has this been tested?
- Existing tests for the mean and variance combiners where refactored to test the normalized sum instead of sum
- Existing tests in `dp_computations` were refactored to call `compute_dp_mean` and `compute_dp_var` methods correctly with normalized sum instead of total sum

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
