### PR TITLE
Test fix

### DIFF
--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -30,7 +30,8 @@ def _create_mechanism_spec(no_noise):
     else:
         eps, delta = 10, 1e-5
 
-    return ba.MechanismSpec(ba.MechanismType.GAUSSIAN, None, eps, delta)
+    return ba.MechanismSpec(pipeline_dp.MechanismType.GAUSSIAN, None, eps,
+                            delta)
 
 
 def _create_aggregate_params(max_value: float = 1,


### PR DESCRIPTION
It's broken because on [PR](https://github.com/OpenMined/PipelineDP/commit/90bb18c8c65e5bb220c2f1131bd2d34902c72b46) it was remove direct import of `MechanismType` class in `budget_accounting.py`