### PR TITLE
Implementation of partition selection accumulator

### DIFF
--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -98,20 +98,21 @@ class PartitionSelectionAccumulator:
             None), "Only one of probabilities and moments must be set."
 
     def __add__(self, other):
-        probs1 = self.probabilities
-        probs2 = other.probabilities
-        if probs1 and probs2 and len(probs1) + len(
-                probs2) <= MAX_PROBABILITIES_IN_ACCUMULATOR:
-            return PartitionSelectionAccumulator(probs1 + probs2)
-        moments1 = self.moments
-        if moments1 is None:
-            moments1 = _probabilities_to_moments(probs1)
+        probs_self = self.probabilities
+        probs_other = other.probabilities
+        if probs_self and probs_other and len(probs_self) + len(
+                probs_other) <= MAX_PROBABILITIES_IN_ACCUMULATOR:
+            return PartitionSelectionAccumulator(probs_self + probs_other)
+        moments_self = self.moments
+        if moments_self is None:
+            moments_self = _probabilities_to_moments(probs_self)
 
-        moments2 = other.moments
-        if moments2 is None:
-            moments2 = _probabilities_to_moments(probs2)
+        moments_other = other.moments
+        if moments_other is None:
+            moments_other = _probabilities_to_moments(probs_other)
 
-        return PartitionSelectionAccumulator(moments=moments1 + moments2)
+        return PartitionSelectionAccumulator(moments=moments_self +
+                                             moments_other)
 
 
 @dataclass
@@ -156,7 +157,7 @@ class UtilityAnalysisCountCombiner(pipeline_dp.Combiner):
             An accumulator with the count of contributions and the contribution error.
         """
         if not data:
-            return UtilityAnalysisCountAccumulator(0, 0, 0, 0)
+            return UtilityAnalysisCountAccumulator(0, 0, 0, 0, None)
         values, n_partitions = data
         count = len(values)
         max_per_partition = self._params.aggregate_params.max_contributions_per_partition

--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -77,22 +77,29 @@ class PartitionSelectionAccumulator:
     """Stores data needed for computing probability of keeping the partition.
 
     Args:
-        probabities_to_contribute: probabilities that each specific user contributes to the partition after contribution bounding.
-        moments: contains some moments of the sum of independent random variables, which represent whether user contributes to the partition.
+        probabilities: probabilities that each specific user contributes to the
+        partition after contribution bounding.
+        moments: contains moments of the sum of independent random
+        variables, which represent whether user contributes to the partition.
 
-    Those variables are set mutually exclusive. Until len(probabities_to_contribute) <= MAX_PROBABILITIES_IN_ACCUMULATOR then 'probabilities' are used otherwiser 'moments'. The idea is that when the number of the contribution are small the sum of the random variables is far from Normal, exact computations are performed, otherwise an approximataion based on moments.
+    Those variables are set mutually exclusive. If len(probabilities) <= 
+    MAX_PROBABILITIES_IN_ACCUMULATOR then 'probabilities' are used otherwise
+    'moments'. The idea is that when the number of the contributions are small
+    the sum of the random variables is far from Normal distribution and exact
+    computations are performed, otherwise a Normal approximation based on
+    moments is used.
     """
-    probabities_to_contribute: Optional[List[float]] = None
+    probabilities: Optional[List[float]] = None
     moments: Optional[SumOfRandomVariablesMoments] = None
 
     def __post_init__(self):
-        assert (self.probabities_to_contribute is None) != (self.moments is
-                                                            None), "todo"
+        assert (self.probabilities is None) != (self.moments is None), "todo"
 
     def __add__(self, other):
-        probs1 = self.probabities_to_contribute
-        probs2 = other.probabities_to_contribute
-        if probs1 and probs2 and len(probs1) + len(probs2) <= MAX_PROBABILITIES_IN_ACCUMULATOR:
+        probs1 = self.probabilities
+        probs2 = other.probabilities
+        if probs1 and probs2 and len(probs1) + len(
+                probs2) <= MAX_PROBABILITIES_IN_ACCUMULATOR:
             return PartitionSelectionAccumulator(probs1 + probs2)
         moments1 = self.moments
         if moments1 is None:
@@ -164,7 +171,7 @@ class UtilityAnalysisCountCombiner(pipeline_dp.Combiner):
         ps_accumulator = None
         if not self._is_public_partitions:
             ps_accumulator = PartitionSelectionAccumulator(
-                probabities_to_contribute=[prob_keep_partition])
+                probabilities=[prob_keep_partition])
 
         return UtilityAnalysisCountAccumulator(
             count, per_partition_contribution_error,

--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -93,7 +93,9 @@ class PartitionSelectionAccumulator:
     moments: Optional[SumOfRandomVariablesMoments] = None
 
     def __post_init__(self):
-        assert (self.probabilities is None) != (self.moments is None), "todo"
+        assert (self.probabilities is None) != (
+            self.moments is
+            None), "Only one of probabilities and moments must be set."
 
     def __add__(self, other):
         probs1 = self.probabilities

--- a/utility_analysis_new/tests/combiners_test.py
+++ b/utility_analysis_new/tests/combiners_test.py
@@ -74,7 +74,7 @@ class UtilityAnalysisCountCombinerTest(parameterized.TestCase):
     def test_compute_metrics(self, num_partitions, contribution_values, params,
                              expected_metrics):
         utility_analysis_combiner = combiners.UtilityAnalysisCountCombiner(
-            params)
+            params, is_public_partitions=True)
         test_acc = utility_analysis_combiner.create_accumulator(
             (contribution_values, num_partitions))
         self.assertEqual(expected_metrics,
@@ -82,7 +82,7 @@ class UtilityAnalysisCountCombinerTest(parameterized.TestCase):
 
     def test_merge(self):
         utility_analysis_combiner = combiners.UtilityAnalysisCountCombiner(
-            _create_combiner_params())
+            _create_combiner_params(), is_public_partitions=True)
         test_acc1 = utility_analysis_combiner.create_accumulator(((2, 3, 4), 1))
         test_acc2 = utility_analysis_combiner.create_accumulator(((6, 7, 8), 5))
         merged_acc = utility_analysis_combiner.merge_accumulators(
@@ -101,3 +101,46 @@ class UtilityAnalysisCountCombinerTest(parameterized.TestCase):
             test_acc1.var_cross_partition_error +
             test_acc2.var_cross_partition_error,
             merged_acc.var_cross_partition_error)
+
+
+class PartitionSelectionAccumulatorTest(parameterized.TestCase):
+    def test_probabilities_to_moments(self):
+        probabilities = [0.1, 0.5, 0.5, 0.2]
+        moments = combiners._probabilities_to_moments(probabilities)
+        self.assertAlmostEqual(4, moments.count)
+        self.assertAlmostEqual(1.3, moments.expectation)
+        self.assertAlmostEqual(0.75, moments.variance)
+        self.assertAlmostEqual(0.168, moments.third_central_moment)
+
+    def test_add_accumulators_both_probabilities(self):
+        acc1 = combiners.PartitionSelectionAccumulator([0.1, 0.2])
+        acc2 = combiners.PartitionSelectionAccumulator([0.3])
+        acc = acc1 + acc2
+        self.assertSequenceEqual([0.1, 0.2, 0.3], acc.probabities_to_contribute)
+        self.assertIsNone(acc.moments)
+
+        acc3 = combiners.PartitionSelectionAccumulator([0.5]*99)
+        acc = acc1 + acc3
+        self.assertIsNone(acc.probabities_to_contribute)
+        self.assertEqual(101, acc.moments.count)
+
+    def test_add_accumulators_probabilities_moments(self):
+        acc1 = combiners.PartitionSelectionAccumulator([0.1, 0.2])
+        moments = combiners.SumOfRandomVariablesMoments(count=10, expectation=5, variance=50, third_central_moment=1)
+        acc2 = combiners.PartitionSelectionAccumulator(moments=moments)
+        acc = acc1 + acc2
+
+        self.assertIsNone(acc.probabities_to_contribute)
+        self.assertEqual(12, acc.moments.count)
+
+    def test_add_accumulators_moments(self):
+        moments = combiners.SumOfRandomVariablesMoments(count=10, expectation=5, variance=50, third_central_moment=1)
+        acc1 = combiners.PartitionSelectionAccumulator(moments=moments)
+        acc2 = combiners.PartitionSelectionAccumulator(moments=moments)
+        acc = acc1 + acc2
+
+        self.assertIsNone(acc.probabities_to_contribute)
+        self.assertEqual(20, acc.moments.count)
+        self.assertEqual(10, acc.moments.expectation)
+        self.assertEqual(100, acc.moments.variance)
+        self.assertEqual(2, acc.moments.third_central_moment)


### PR DESCRIPTION
This accumulator is needed for computation of probability that the partition is kept. Computations of that probability will be in the subsequent PRs.