### PR TITLE
Convert public partitions to PCollection

### DIFF
--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -292,6 +292,8 @@ class DPEngine:
         self._add_report_stage(
             "Adding empty partitions for public partitions that are missing in "
             "data")
+        public_partitions = self._backend.to_collection(
+            public_partitions, col, "Public partitions to collection")
         empty_accumulators = self._backend.map(
             public_partitions, lambda partition_key:
             (partition_key, aggregator_fn([])), "Build empty accumulators")

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -28,10 +28,6 @@ from pipeline_dp.pipeline_backend import BeamBackend
 import pipeline_dp.combiners as dp_combiners
 
 
-class PipelineBackendTest(unittest.TestCase):
-    pass
-
-
 class BeamBackendTest(parameterized.TestCase):
 
     @classmethod
@@ -42,14 +38,21 @@ class BeamBackendTest(parameterized.TestCase):
             privacy_id_extractor=lambda x: x[0],
             value_extractor=lambda x: x[2])
 
+    def test_to_collection(self):
+        with test_pipeline.TestPipeline() as p:
+            input = [1, 3, 5]
+            col = p | beam.Create([])
+            output = self.backend.to_collection(input, col, "to_collection")
+            self.assertIsInstance(output, beam.PCollection)
+            beam_util.assert_that(output, beam_util.equal_to(input))
+
     def test_filter_by_key_must_not_be_none(self):
         with test_pipeline.TestPipeline() as p:
             data = [(7, 1), (2, 1), (3, 9), (4, 1), (9, 10)]
             col = p | "Create PCollection" >> beam.Create(data)
             key_to_keep = None
             with self.assertRaises(TypeError):
-                result = self.backend.filter_by_key(col, key_to_keep,
-                                                    "filter_by_key")
+                self.backend.filter_by_key(col, key_to_keep, "filter_by_key")
 
     @parameterized.parameters(
         {'in_memory': True},


### PR DESCRIPTION
This PR fixes intricated problem inside Beam code. The idea is that Beam PTransforms should be applied to beam PCollection. While applying them to Python list is possible, it might lead to exceptions in complicated pipelines.