### PR TITLE
Fix to_collection

### DIFF
--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -219,6 +219,8 @@ class BeamBackend(PipelineBackend):
         self._ulg = UniqueLabelsGenerator(suffix)
 
     def to_collection(self, collection_or_iterable, col, stage_name: str):
+        if isinstance(collection_or_iterable, beam.PCollection):
+            return collection_or_iterable
         return col.pipeline | self._ulg.unique(stage_name) >> beam.Create(
             collection_or_iterable)
 

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -38,13 +38,16 @@ class BeamBackendTest(parameterized.TestCase):
             privacy_id_extractor=lambda x: x[0],
             value_extractor=lambda x: x[2])
 
-    def test_to_collection(self):
+    @parameterized.parameters(True, False)
+    def test_to_collection(self, input_is_pcollection):
         with test_pipeline.TestPipeline() as p:
             input = [1, 3, 5]
+            if input_is_pcollection:
+                input = p | "Creat input PCollection" >> beam.Create(input)
             col = p | beam.Create([])
             output = self.backend.to_collection(input, col, "to_collection")
             self.assertIsInstance(output, beam.PCollection)
-            beam_util.assert_that(output, beam_util.equal_to(input))
+            beam_util.assert_that(output, beam_util.equal_to([1, 3, 5]))
 
     def test_filter_by_key_must_not_be_none(self):
         with test_pipeline.TestPipeline() as p:


### PR DESCRIPTION
`to_collection` a function which converts to the framework collection. This PR fixes it for `BeamBackend`, namely if the input is already `PCollection`, then this function should be no-op.

This fixes using `PCollection` as `public_partitions`  for `BeamBackend`.