### PR TITLE
Tuning polishings

### DIFF
--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -1,0 +1,117 @@
+# Copyright 2022 OpenMined.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Demo of running PipelineDP locally, without any external data processing framework.
+
+This demo outputs a utility analysis of errors and noise for each partition in the dataset.
+
+1. Install Python and run on the command line `pip install pipeline-dp absl-py`
+2. Run python python run_without_frameworks_utility_analysis.py --output_file=<...>
+"""
+from absl import app
+from absl import flags
+import pipeline_dp
+import pandas as pd
+
+from utility_analysis_new import parameter_tuning
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string('input_file', 'restaurants_week_data.csv',
+                    'The file with the restaurant visits data')
+flags.DEFINE_string('output_file', None, 'Output file')
+flags.DEFINE_boolean('public_partitions', False,
+                     'Whether public partitions are used')
+
+
+def write_to_file(col, filename):
+    with open(filename, 'w') as out:
+        out.write('\n'.join(map(str, col)))
+
+
+def load_data(input_file: str) -> list:
+    df = pd.read_csv(input_file)
+    df.rename(inplace=True,
+              columns={
+                  'VisitorId': 'user_id',
+                  'Time entered': 'enter_time',
+                  'Time spent (minutes)': 'spent_minutes',
+                  'Money spent (euros)': 'spent_money',
+                  'Day': 'day'
+              })
+    # Double the inputs so we have twice as many contributions per partition
+    df_double = pd.concat([df, df])
+    df_double.columns = df.columns
+    return [index_row[1] for index_row in df_double.iterrows()]
+
+
+def get_aggregate_params():
+    # Limit contributions to 1 per partition, contribution error will be half of the count.
+    return pipeline_dp.AggregateParams(
+        noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+        metrics=[pipeline_dp.Metrics.COUNT],
+        max_partitions_contributed=1,
+        max_contributions_per_partition=1)
+
+
+def get_data_extractors():
+    # Specify how to extract privacy_id, partition_key and value from an
+    # element of restaurant_visits_rows.
+    return pipeline_dp.DataExtractors(
+        partition_extractor=lambda row: row.day,
+        privacy_id_extractor=lambda row: row.user_id,
+        value_extractor=lambda row: row.spent_money)
+
+
+def tune_parameters():
+    # Load data
+    restaurant_visits_rows = load_data(FLAGS.input_file)
+    # Create aggregate_params, data_extractors and public partitions.
+    aggregate_params = get_aggregate_params()
+    data_extractors = get_data_extractors()
+    public_partitions = list(range(1, 8)) if FLAGS.public_partitions else None
+    backend = pipeline_dp.LocalBackend()
+
+    histograms = parameter_tuning.compute_contribution_histograms(
+        restaurant_visits_rows, data_extractors, backend)
+    histograms = list(histograms)[0]
+
+    minimizing_function = parameter_tuning.MinimizingFunction.ABSOLUTE_ERROR
+    parameters_to_tune = parameter_tuning.ParametersToTune(
+        tune_max_partitions_contributed=True,
+        tune_max_contributions_per_partition=True)
+    tune_options = parameter_tuning.TuneOptions(
+        epsilon=1,
+        delta=1e-5,
+        aggregate_params=aggregate_params,
+        function_to_minimize=minimizing_function,
+        parameters_to_tune=parameters_to_tune)
+    result = parameter_tuning.tune(restaurant_visits_rows, backend, histograms,
+                                   tune_options, data_extractors,
+                                   public_partitions)
+
+    # Here's where the lazy iterator initiates computations and gets transformed
+    # into actual results
+    result = list(result)
+
+    # Save the results
+    write_to_file(result, FLAGS.output_file)
+
+
+def main(unused_args):
+    tune_parameters()
+    return 0
+
+
+if __name__ == '__main__':
+    flags.mark_flag_as_required("output_file")
+    app.run(main)

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 from dataclasses import dataclass
 import pipeline_dp.aggregate_params as agg_params
+from pipeline_dp import input_validators
 
 try:
     from dp_accounting import privacy_loss_distribution as pldlib
@@ -116,7 +117,8 @@ class BudgetAccountant(abc.ABC):
                  num_aggregations: Optional[int],
                  aggregation_weights: Optional[list]):
 
-        _validate_epsilon_delta(total_epsilon, total_delta)
+        input_validators._validate_epsilon_delta(total_epsilon, total_delta,
+                                                 "BudgetAccountant")
         self._total_epsilon = total_epsilon
         self._total_delta = total_delta
 
@@ -596,19 +598,3 @@ class PLDBudgetAccountant(BudgetAccountant):
             composed = pld if composed is None else composed.compose(pld)
 
         return composed
-
-
-def _validate_epsilon_delta(epsilon: float, delta: float):
-    """Helper function to validate the epsilon and delta parameters.
-
-    Args:
-        epsilon: The epsilon value to validate.
-        delta: The delta value to validate.
-
-    Raises:
-        A ValueError if either epsilon or delta are out of range.
-    """
-    if epsilon <= 0:
-        raise ValueError(f"Epsilon must be positive, not {epsilon}.")
-    if delta < 0:
-        raise ValueError(f"Delta must be non-negative, not {delta}.")

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -117,8 +117,8 @@ class BudgetAccountant(abc.ABC):
                  num_aggregations: Optional[int],
                  aggregation_weights: Optional[list]):
 
-        input_validators._validate_epsilon_delta(total_epsilon, total_delta,
-                                                 "BudgetAccountant")
+        input_validators.validate_epsilon_delta(total_epsilon, total_delta,
+                                                "BudgetAccountant")
         self._total_epsilon = total_epsilon
         self._total_delta = total_delta
 

--- a/pipeline_dp/input_validators.py
+++ b/pipeline_dp/input_validators.py
@@ -1,0 +1,16 @@
+def validate_epsilon_delta(epsilon: float, delta: float, obj_name: str):
+    """Helper function to validate the epsilon and delta parameters.
+
+  Args:
+      epsilon: The epsilon value to validate.
+      delta: The delta value to validate.
+
+  Raises:
+      A ValueError if either epsilon or delta are out of range.
+  """
+    if epsilon <= 0:
+        raise ValueError(
+            f"{obj_name}: epsilon must be positive, not {epsilon}.")
+    if delta < 0:
+        raise ValueError(
+            f"{obj_name}: delta must be non-negative, not {delta}.")

--- a/pipeline_dp/input_validators.py
+++ b/pipeline_dp/input_validators.py
@@ -14,3 +14,6 @@ def validate_epsilon_delta(epsilon: float, delta: float, obj_name: str):
     if delta < 0:
         raise ValueError(
             f"{obj_name}: delta must be non-negative, not {delta}.")
+    if delta > 1:
+        raise ValueError(
+            f"{obj_name}: delta must be not bigger than 1, not {delta}.")

--- a/pipeline_dp/input_validators.py
+++ b/pipeline_dp/input_validators.py
@@ -14,6 +14,5 @@ def validate_epsilon_delta(epsilon: float, delta: float, obj_name: str):
     if delta < 0:
         raise ValueError(
             f"{obj_name}: delta must be non-negative, not {delta}.")
-    if delta > 1:
-        raise ValueError(
-            f"{obj_name}: delta must be not bigger than 1, not {delta}.")
+    if delta >= 1:
+        raise ValueError(f"{obj_name}: delta must be less than 1, not {delta}.")

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -683,7 +683,7 @@ class DpEngineTest(parameterized.TestCase):
         # Set a large budget for having the small noise and keeping all
         # partition keys.
         budget_accountant = NaiveBudgetAccountant(total_epsilon=100000,
-                                                  total_delta=1)
+                                                  total_delta=0.99)
 
         data_extractor = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x,

--- a/utility_analysis_new/__init__.py
+++ b/utility_analysis_new/__init__.py
@@ -14,4 +14,4 @@
 
 from utility_analysis_new.dp_engine import MultiParameterConfiguration
 from utility_analysis_new.utility_analysis import perform_utility_analysis
-from utility_analysis_new.parameter_tuning import tune_parameters
+from utility_analysis_new.parameter_tuning import tune

--- a/utility_analysis_new/tests/utility_analysis_test.py
+++ b/utility_analysis_new/tests/utility_analysis_test.py
@@ -49,7 +49,7 @@ class UtilityAnalysis(parameterized.TestCase):
             col=col,
             backend=pipeline_dp.LocalBackend(),
             options=utility_analysis.UtilityAnalysisOptions(
-                eps=2, delta=0.9, aggregate_params=aggregate_params),
+                epsilon=2, delta=0.9, aggregate_params=aggregate_params),
             data_extractors=data_extractors)
 
         col = list(col)
@@ -103,7 +103,7 @@ class UtilityAnalysis(parameterized.TestCase):
             col=col,
             backend=pipeline_dp.LocalBackend(),
             options=utility_analysis.UtilityAnalysisOptions(
-                eps=2, delta=1e-10, aggregate_params=aggregator_params),
+                epsilon=2, delta=1e-10, aggregate_params=aggregator_params),
             data_extractors=data_extractor,
             public_partitions=public_partitions)
 
@@ -149,7 +149,7 @@ class UtilityAnalysis(parameterized.TestCase):
             col=input,
             backend=pipeline_dp.LocalBackend(),
             options=utility_analysis.UtilityAnalysisOptions(
-                eps=2,
+                epsilon=2,
                 delta=1e-10,
                 aggregate_params=aggregate_params,
                 multi_param_configuration=multi_param),

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -18,6 +18,7 @@ from typing import List, Optional
 import pipeline_dp
 from pipeline_dp import combiners
 from pipeline_dp import pipeline_backend
+from pipeline_dp import input_validators
 from utility_analysis_new import dp_engine
 import utility_analysis_new.combiners as utility_analysis_combiners
 
@@ -25,11 +26,15 @@ import utility_analysis_new.combiners as utility_analysis_combiners
 @dataclass
 class UtilityAnalysisOptions:
     """Options for the utility analysis."""
-    eps: float
+    epsilon: float
     delta: float
     aggregate_params: pipeline_dp.AggregateParams
     multi_param_configuration: Optional[
         dp_engine.MultiParameterConfiguration] = None
+
+    def __post_init__(self):
+        input_validators._validate_epsilon_delta(self.epsilon, self.delta,
+                                                 "UtilityAnalysisOptions")
 
     @property
     def n_parameters(self):
@@ -54,6 +59,8 @@ def perform_utility_analysis(col,
       public_partitions: A collection of partition keys that will be present
             in the result. If not provided, the utility analysis with private
             partition selection will be performed.
+    Returns:
+      1 element collection which contains utility analysis metrics.
     """
     budget_accountant = pipeline_dp.NaiveBudgetAccountant(
         total_epsilon=options.eps, total_delta=options.delta)

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -33,8 +33,8 @@ class UtilityAnalysisOptions:
         dp_engine.MultiParameterConfiguration] = None
 
     def __post_init__(self):
-        input_validators._validate_epsilon_delta(self.epsilon, self.delta,
-                                                 "UtilityAnalysisOptions")
+        input_validators.validate_epsilon_delta(self.epsilon, self.delta,
+                                                "UtilityAnalysisOptions")
 
     @property
     def n_parameters(self):
@@ -63,7 +63,7 @@ def perform_utility_analysis(col,
       1 element collection which contains utility analysis metrics.
     """
     budget_accountant = pipeline_dp.NaiveBudgetAccountant(
-        total_epsilon=options.eps, total_delta=options.delta)
+        total_epsilon=options.epsilon, total_delta=options.delta)
     engine = dp_engine.UtilityAnalysisEngine(
         budget_accountant=budget_accountant, backend=backend)
     result = engine.aggregate(


### PR DESCRIPTION
This CL contains multiple minor improvements:
1. Renaming `tune_parameters()` -> `tune()` and added `backend` argument
2. Simplified tune API: `ParametersToTune` changed to bool arguments 
3. Added example of using tune API (which is mostly copy of utility_analysis example)
4. Validation for (eps, delta) extracted to separete file (and added in a few places)
5. Renaming `eps` -> `epsilon` in `UtilityAnalysisOptions`
