### PR TITLE
Setting 0 for relative errors when actual value = 0

### DIFF
--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -609,9 +609,9 @@ class CountAggregateErrorMetricsCombiner(pipeline_dp.Combiner):
 
         # Relative error metrics
         if metrics.count == 0:  # For empty public partitions, to avoid division by 0
-            rel_error_expected = float('inf')
-            rel_error_variance = float('inf')
-            rel_error_quantiles = [float('inf')] * len(self._error_quantiles)
+            rel_error_expected = 0
+            rel_error_variance = 0
+            rel_error_quantiles = [0] * len(self._error_quantiles)
         else:
             rel_error_expected = abs_error_expected / metrics.count
             rel_error_variance = abs_error_variance / (metrics.count**2)

--- a/utility_analysis_new/tests/utility_analysis_test.py
+++ b/utility_analysis_new/tests/utility_analysis_test.py
@@ -120,8 +120,8 @@ class UtilityAnalysis(parameterized.TestCase):
         # Relative errors are infinity due to the empty partition.
         self.assertAlmostEqual(col[0][0].abs_error_expected, 0, delta=1e-2)
         self.assertAlmostEqual(col[0][0].abs_error_variance, 9.1648, delta=1e-2)
-        self.assertEqual(col[0][0].rel_error_expected, float('inf'))
-        self.assertEqual(col[0][0].rel_error_variance, float('inf'))
+        self.assertEqual(col[0][0].rel_error_expected, 0)
+        self.assertEqual(col[0][0].rel_error_variance, 6.109873453776042)
 
     def test_multi_parameters(self):
         # Arrange


### PR DESCRIPTION
Setting errors to inf, make the result inf, i.e. for any public partitions the result is inf. While it's a good question how to count relative error for added empty partitions, returning inf doesn't sound as a good option 