### PR TITLE
Refactoring: Using tuples instead of dataclasses for Utility Analysis accumulators.

### DIFF
--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Combiners for computing DP aggregations."""
+
 import abc
 import copy
 from typing import Callable, Iterable, Sized, Tuple, List, Union
@@ -109,7 +111,7 @@ class CustomCombiner(Combiner, abc.ABC):
 
     def set_aggregate_params(self,
                              aggregate_params: pipeline_dp.AggregateParams):
-        """Sets aggregate parameters
+        """Sets aggregate parameters.
 
         The custom combiner can optionally use it for own DP parameter
         computations.
@@ -117,9 +119,9 @@ class CustomCombiner(Combiner, abc.ABC):
         self._aggregate_params = aggregate_params
 
     def metrics_names(self) -> List[str]:
-        """Metrics that self computes.
+        """Metrics that 'self' computes.
 
-        By default returns class name.
+        It returns the class name by default.
         """
         return self.__class__.__name__
 

--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -203,7 +203,7 @@ class PartitionSelectionCombiner(pipeline_dp.Combiner):
 
 
 @dataclass
-class CountUtilityAnalysisMetrics:
+class CountMetrics:
     """Stores metrics for the count utility analysis.
 
     Args:
@@ -225,7 +225,7 @@ class CountUtilityAnalysisMetrics:
     noise_kind: pipeline_dp.NoiseKind
 
 
-class UtilityAnalysisCountCombiner(UtilityAnalysisCombiner):
+class CountCombiner(UtilityAnalysisCombiner):
     """A combiner for utility analysis counts."""
     # (count, per_partition_error, expected_cross_partition_error,
     # var_cross_partition_error)
@@ -258,12 +258,11 @@ class UtilityAnalysisCountCombiner(UtilityAnalysisCombiner):
         return (count, per_partition_error, expected_cross_partition_error,
                 var_cross_partition_error)
 
-    def compute_metrics(self,
-                        acc: AccumulatorType) -> CountUtilityAnalysisMetrics:
+    def compute_metrics(self, acc: AccumulatorType) -> CountMetrics:
         count, per_partition_error, expected_cross_partition_error, var_cross_partition_error = acc
         std_noise = dp_computations.compute_dp_count_noise_std(
             self._params.scalar_noise_params)
-        return CountUtilityAnalysisMetrics(
+        return CountMetrics(
             count=count,
             per_partition_error=per_partition_error,
             expected_cross_partition_error=expected_cross_partition_error,
@@ -279,7 +278,7 @@ class UtilityAnalysisCountCombiner(UtilityAnalysisCombiner):
 
 
 @dataclass
-class SumUtilityAnalysisMetrics:
+class SumMetrics:
     """Stores metrics for the sum utility analysis.
 
     Args:
@@ -300,7 +299,7 @@ class SumUtilityAnalysisMetrics:
     noise_kind: pipeline_dp.NoiseKind
 
 
-class UtilityAnalysisSumCombiner(UtilityAnalysisCombiner):
+class SumCombiner(UtilityAnalysisCombiner):
     """A combiner for utility analysis sums."""
     # (partition_sum, per_partition_error_min, per_partition_error_max,
     # expected_cross_partition_error, var_cross_partition_error)
@@ -335,13 +334,12 @@ class UtilityAnalysisSumCombiner(UtilityAnalysisCombiner):
         return (partition_sum, per_partition_error_min, per_partition_error_max,
                 expected_cross_partition_error, var_cross_partition_error)
 
-    def compute_metrics(self,
-                        acc: AccumulatorType) -> SumUtilityAnalysisMetrics:
+    def compute_metrics(self, acc: AccumulatorType) -> SumMetrics:
         """Computes metrics based on the accumulator properties."""
         partition_sum, per_partition_error_min, per_partition_error_max, expected_cross_partition_error, var_cross_partition_error = acc
         std_noise = dp_computations.compute_dp_count_noise_std(
             self._params.scalar_noise_params)
-        return SumUtilityAnalysisMetrics(
+        return SumMetrics(
             sum=partition_sum,
             per_partition_error_min=per_partition_error_min,
             per_partition_error_max=per_partition_error_max,
@@ -359,7 +357,7 @@ class UtilityAnalysisSumCombiner(UtilityAnalysisCombiner):
 
 
 @dataclass
-class PrivacyIdCountUtilityAnalysisMetrics:
+class PrivacyIdCountMetrics:
     """Stores metrics for the privacy ID count utility analysis.
 
     Args:
@@ -376,7 +374,7 @@ class PrivacyIdCountUtilityAnalysisMetrics:
     noise_kind: pipeline_dp.NoiseKind
 
 
-class UtilityAnalysisPrivacyIdCountCombiner(UtilityAnalysisCombiner):
+class PrivacyIdCountCombiner(UtilityAnalysisCombiner):
     """A combiner for utility analysis privacy ID counts."""
     # (privacy_id_count, expected_cross_partition_error,
     # var_cross_partition_error)
@@ -400,13 +398,12 @@ class UtilityAnalysisPrivacyIdCountCombiner(UtilityAnalysisCombiner):
         return (privacy_id_count, expected_cross_partition_error,
                 var_cross_partition_error)
 
-    def compute_metrics(
-            self, acc: AccumulatorType) -> PrivacyIdCountUtilityAnalysisMetrics:
+    def compute_metrics(self, acc: AccumulatorType) -> PrivacyIdCountMetrics:
         """Computes metrics based on the accumulator properties."""
         privacy_id_count, expected_cross_partition_error, var_cross_partition_error = acc
         std_noise = dp_computations.compute_dp_count_noise_std(
             self._params.scalar_noise_params)
-        return PrivacyIdCountUtilityAnalysisMetrics(
+        return PrivacyIdCountMetrics(
             privacy_id_count=privacy_id_count,
             expected_cross_partition_error=expected_cross_partition_error,
             std_cross_partition_error=np.sqrt(var_cross_partition_error),
@@ -518,7 +515,7 @@ class CountAggregateErrorMetricsCombiner(pipeline_dp.Combiner):
         self._error_quantiles = error_quantiles
 
     def create_accumulator(self,
-                           metrics: CountUtilityAnalysisMetrics,
+                           metrics: CountMetrics,
                            probability_to_keep: float = 1) -> AccumulatorType:
         """Creates an accumulator for metrics."""
         # Absolute error metrics

--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -41,7 +41,7 @@ class UtilityAnalysisCombiner(pipeline_dp.Combiner):
               2) the total number of partitions a user contributed to.
 
         Returns:
-            A tuple which is accumulator.
+            A tuple which is an accumulator.
         """
 
     def merge_accumulators(self, acc1: Tuple, acc2: Tuple):
@@ -227,6 +227,8 @@ class CountUtilityAnalysisMetrics:
 
 class UtilityAnalysisCountCombiner(UtilityAnalysisCombiner):
     """A combiner for utility analysis counts."""
+    # (count, per_partition_error, expected_cross_partition_error,
+    # var_cross_partition_error)
     AccumulatorType = Tuple[int, int, float, float]
 
     def __init__(self, params: pipeline_dp.combiners.CombinerParams):
@@ -300,6 +302,8 @@ class SumUtilityAnalysisMetrics:
 
 class UtilityAnalysisSumCombiner(UtilityAnalysisCombiner):
     """A combiner for utility analysis sums."""
+    # (partition_sum, per_partition_error_min, per_partition_error_max,
+    # expected_cross_partition_error, var_cross_partition_error)
     AccumulatorType = Tuple[float, float, float, float, float]
 
     def __init__(self, params: pipeline_dp.combiners.CombinerParams):
@@ -374,6 +378,8 @@ class PrivacyIdCountUtilityAnalysisMetrics:
 
 class UtilityAnalysisPrivacyIdCountCombiner(UtilityAnalysisCombiner):
     """A combiner for utility analysis privacy ID counts."""
+    # (privacy_id_count, expected_cross_partition_error,
+    # var_cross_partition_error)
     AccumulatorType = Tuple[int, float, float]
 
     def __init__(self, params: pipeline_dp.combiners.CombinerParams):

--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -237,15 +237,7 @@ class UtilityAnalysisCountCombiner(UtilityAnalysisCombiner):
         return self._partition_selection_budget is None
 
     def create_accumulator(self, data: Tuple[Sized, int]) -> AccumulatorType:
-        """Creates an accumulator for data.
-
-        Args:
-            data is a Tuple containing; 1) a list of the user's contributions for a single partition, and 2) the total
-            number of partitions a user contributed to.
-
-        Returns:
-            An accumulator with the count of contributions and the contribution error.
-        """
+        """Creates an accumulator for data."""
         if not data:
             return (0, 0, 0, 0)
         values, n_partitions = data

--- a/utility_analysis_new/dp_engine.py
+++ b/utility_analysis_new/dp_engine.py
@@ -159,20 +159,19 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
                 budget = self._budget_accountant.request_budget(
                     mechanism_type, weight=aggregate_params.budget_weight)
                 internal_combiners.append(
-                    utility_analysis_combiners.UtilityAnalysisCountCombiner(
+                    utility_analysis_combiners.CountCombiner(
                         combiners.CombinerParams(budget, params)))
             if pipeline_dp.Metrics.SUM in aggregate_params.metrics:
                 budget = self._budget_accountant.request_budget(
                     mechanism_type, weight=aggregate_params.budget_weight)
                 internal_combiners.append(
-                    utility_analysis_combiners.UtilityAnalysisSumCombiner(
+                    utility_analysis_combiners.SumCombiner(
                         combiners.CombinerParams(budget, params)))
             if pipeline_dp.Metrics.PRIVACY_ID_COUNT in aggregate_params.metrics:
                 budget = self._budget_accountant.request_budget(
                     mechanism_type, weight=aggregate_params.budget_weight)
                 internal_combiners.append(
-                    utility_analysis_combiners.
-                    UtilityAnalysisPrivacyIdCountCombiner(
+                    utility_analysis_combiners.PrivacyIdCountCombiner(
                         combiners.CombinerParams(budget, params)))
         return combiners.CompoundCombiner(internal_combiners,
                                           return_named_tuple=False)

--- a/utility_analysis_new/tests/combiners_test.py
+++ b/utility_analysis_new/tests/combiners_test.py
@@ -283,30 +283,11 @@ class UtilityAnalysisSumCombinerTest(parameterized.TestCase):
     def test_merge(self):
         utility_analysis_combiner = combiners.UtilityAnalysisSumCombiner(
             _create_combiner_params_for_sum(0, 20))
-        test_acc1 = utility_analysis_combiner.create_accumulator(
-            ((2.2, 3.3, 4.4), 1))
-        test_acc2 = utility_analysis_combiner.create_accumulator(
-            ((6.6, 7.7, 8.8), 5))
+        test_acc1 = (0.125, 1.5, -2, -3.5, 1000)
+        test_acc2 = (1, 0, -20, 3.5, 1)
         merged_acc = utility_analysis_combiner.merge_accumulators(
             test_acc1, test_acc2)
-
-        self.assertEqual(test_acc1.sum + test_acc2.sum, merged_acc.sum)
-        self.assertEqual(
-            test_acc1.per_partition_error_min +
-            test_acc2.per_partition_error_min,
-            merged_acc.per_partition_error_min)
-        self.assertEqual(
-            test_acc1.per_partition_error_max +
-            test_acc2.per_partition_error_max,
-            merged_acc.per_partition_error_max)
-        self.assertEqual(
-            test_acc1.expected_cross_partition_error +
-            test_acc2.expected_cross_partition_error,
-            merged_acc.expected_cross_partition_error)
-        self.assertEqual(
-            test_acc1.var_cross_partition_error +
-            test_acc2.var_cross_partition_error,
-            merged_acc.var_cross_partition_error)
+        self.assertSequenceEqual((1.125, 1.5, -22, 0, 1001), merged_acc)
 
 
 def _create_combiner_params_for_privacy_id_count(
@@ -387,21 +368,11 @@ class UtilityAnalysisPrivacyIdCountCombinerTest(parameterized.TestCase):
     def test_merge(self):
         utility_analysis_combiner = combiners.UtilityAnalysisPrivacyIdCountCombiner(
             _create_combiner_params_for_count())
-        test_acc1 = utility_analysis_combiner.create_accumulator(((1, 1, 1), 2))
-        test_acc2 = utility_analysis_combiner.create_accumulator(((2, 2, 2), 2))
+        test_acc1 = [1, 2, 3]
+        test_acc2 = [5, 10, -5]
         merged_acc = utility_analysis_combiner.merge_accumulators(
             test_acc1, test_acc2)
-        self.assertEqual(
-            test_acc1.privacy_id_count + test_acc2.privacy_id_count,
-            merged_acc.privacy_id_count)
-        self.assertAlmostEqual(
-            test_acc1.expected_cross_partition_error +
-            test_acc2.expected_cross_partition_error,
-            merged_acc.expected_cross_partition_error)
-        self.assertAlmostEqual(
-            test_acc1.var_cross_partition_error +
-            test_acc2.var_cross_partition_error,
-            merged_acc.var_cross_partition_error)
+        self.assertSequenceEqual((6, 12, -2), merged_acc)
 
 
 if __name__ == '__main__':

--- a/utility_analysis_new/tests/combiners_test.py
+++ b/utility_analysis_new/tests/combiners_test.py
@@ -45,7 +45,7 @@ class UtilityAnalysisCountCombinerTest(parameterized.TestCase):
              num_partitions=0,
              contribution_values=(),
              params=_create_combiner_params_for_count(),
-             expected_metrics=combiners.CountUtilityAnalysisMetrics(
+             expected_metrics=combiners.CountMetrics(
                  count=0,
                  per_partition_error=0,
                  expected_cross_partition_error=0,
@@ -56,7 +56,7 @@ class UtilityAnalysisCountCombinerTest(parameterized.TestCase):
              num_partitions=1,
              contribution_values=(1, 2),
              params=_create_combiner_params_for_count(),
-             expected_metrics=combiners.CountUtilityAnalysisMetrics(
+             expected_metrics=combiners.CountMetrics(
                  count=2,
                  per_partition_error=0,
                  expected_cross_partition_error=0,
@@ -67,7 +67,7 @@ class UtilityAnalysisCountCombinerTest(parameterized.TestCase):
              num_partitions=4,
              contribution_values=(1, 2, 3, 4),
              params=_create_combiner_params_for_count(),
-             expected_metrics=combiners.CountUtilityAnalysisMetrics(
+             expected_metrics=combiners.CountMetrics(
                  count=4,
                  per_partition_error=-2,
                  expected_cross_partition_error=-1.5,
@@ -76,15 +76,14 @@ class UtilityAnalysisCountCombinerTest(parameterized.TestCase):
                  noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)))
     def test_compute_metrics(self, num_partitions, contribution_values, params,
                              expected_metrics):
-        utility_analysis_combiner = combiners.UtilityAnalysisCountCombiner(
-            params)
+        utility_analysis_combiner = combiners.CountCombiner(params)
         test_acc = utility_analysis_combiner.create_accumulator(
             (contribution_values, num_partitions))
         self.assertEqual(expected_metrics,
                          utility_analysis_combiner.compute_metrics(test_acc))
 
     def test_merge(self):
-        utility_analysis_combiner = combiners.UtilityAnalysisCountCombiner(
+        utility_analysis_combiner = combiners.CountCombiner(
             _create_combiner_params_for_count())
         test_acc1 = [1, 2, 3, -4]
         test_acc2 = [5, 10, -5, 100]
@@ -217,7 +216,7 @@ class UtilityAnalysisSumCombinerTest(parameterized.TestCase):
              num_partitions=0,
              contribution_values=(),
              params=_create_combiner_params_for_sum(0, 0),
-             expected_metrics=combiners.SumUtilityAnalysisMetrics(
+             expected_metrics=combiners.SumMetrics(
                  sum=0,
                  per_partition_error_min=0,
                  per_partition_error_max=0,
@@ -229,7 +228,7 @@ class UtilityAnalysisSumCombinerTest(parameterized.TestCase):
              num_partitions=1,
              contribution_values=(1.1, 2.2),
              params=_create_combiner_params_for_sum(0, 3.4),
-             expected_metrics=combiners.SumUtilityAnalysisMetrics(
+             expected_metrics=combiners.SumMetrics(
                  sum=3.3,
                  per_partition_error_min=0,
                  per_partition_error_max=0,
@@ -241,7 +240,7 @@ class UtilityAnalysisSumCombinerTest(parameterized.TestCase):
              num_partitions=4,
              contribution_values=(1.1, 2.2, 3.3, 4.4),
              params=_create_combiner_params_for_sum(0, 5.5),
-             expected_metrics=combiners.SumUtilityAnalysisMetrics(
+             expected_metrics=combiners.SumMetrics(
                  sum=11.0,
                  per_partition_error_min=0,
                  per_partition_error_max=5.5,
@@ -253,7 +252,7 @@ class UtilityAnalysisSumCombinerTest(parameterized.TestCase):
              num_partitions=4,
              contribution_values=(0.1, 0.2, 0.3, 0.4),
              params=_create_combiner_params_for_sum(2, 20),
-             expected_metrics=combiners.SumUtilityAnalysisMetrics(
+             expected_metrics=combiners.SumMetrics(
                  sum=1.0,
                  per_partition_error_min=-1,
                  per_partition_error_max=0,
@@ -263,7 +262,7 @@ class UtilityAnalysisSumCombinerTest(parameterized.TestCase):
                  noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)))
     def test_compute_metrics(self, num_partitions, contribution_values, params,
                              expected_metrics):
-        utility_analysis_combiner = combiners.UtilityAnalysisSumCombiner(params)
+        utility_analysis_combiner = combiners.SumCombiner(params)
         test_acc = utility_analysis_combiner.create_accumulator(
             (contribution_values, num_partitions))
         actual_metrics = utility_analysis_combiner.compute_metrics(test_acc)
@@ -281,7 +280,7 @@ class UtilityAnalysisSumCombinerTest(parameterized.TestCase):
         self.assertEqual(expected_metrics.noise_kind, actual_metrics.noise_kind)
 
     def test_merge(self):
-        utility_analysis_combiner = combiners.UtilityAnalysisSumCombiner(
+        utility_analysis_combiner = combiners.SumCombiner(
             _create_combiner_params_for_sum(0, 20))
         test_acc1 = (0.125, 1.5, -2, -3.5, 1000)
         test_acc2 = (1, 0, -20, 3.5, 1)
@@ -312,7 +311,7 @@ class UtilityAnalysisPrivacyIdCountCombinerTest(parameterized.TestCase):
              num_partitions=0,
              contribution_values=(),
              params=_create_combiner_params_for_privacy_id_count(),
-             expected_metrics=combiners.PrivacyIdCountUtilityAnalysisMetrics(
+             expected_metrics=combiners.PrivacyIdCountMetrics(
                  privacy_id_count=0,
                  std_noise=10.556883272246033,
                  expected_cross_partition_error=-1,
@@ -322,7 +321,7 @@ class UtilityAnalysisPrivacyIdCountCombinerTest(parameterized.TestCase):
              num_partitions=4,
              contribution_values=(2),
              params=_create_combiner_params_for_privacy_id_count(),
-             expected_metrics=combiners.PrivacyIdCountUtilityAnalysisMetrics(
+             expected_metrics=combiners.PrivacyIdCountMetrics(
                  privacy_id_count=1,
                  expected_cross_partition_error=-0.5,
                  std_cross_partition_error=0.5,
@@ -332,7 +331,7 @@ class UtilityAnalysisPrivacyIdCountCombinerTest(parameterized.TestCase):
              num_partitions=4,
              contribution_values=(2, 2, 2, 2),
              params=_create_combiner_params_for_privacy_id_count(),
-             expected_metrics=combiners.PrivacyIdCountUtilityAnalysisMetrics(
+             expected_metrics=combiners.PrivacyIdCountMetrics(
                  privacy_id_count=1,
                  expected_cross_partition_error=-0.5,
                  std_cross_partition_error=0.5,
@@ -342,7 +341,7 @@ class UtilityAnalysisPrivacyIdCountCombinerTest(parameterized.TestCase):
              num_partitions=1,
              contribution_values=(2, 2),
              params=_create_combiner_params_for_privacy_id_count(),
-             expected_metrics=combiners.PrivacyIdCountUtilityAnalysisMetrics(
+             expected_metrics=combiners.PrivacyIdCountMetrics(
                  privacy_id_count=1,
                  expected_cross_partition_error=0,
                  std_cross_partition_error=0,
@@ -350,8 +349,7 @@ class UtilityAnalysisPrivacyIdCountCombinerTest(parameterized.TestCase):
                  noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)))
     def test_compute_metrics(self, num_partitions, contribution_values, params,
                              expected_metrics):
-        utility_analysis_combiner = combiners.UtilityAnalysisPrivacyIdCountCombiner(
-            params)
+        utility_analysis_combiner = combiners.PrivacyIdCountCombiner(params)
         test_acc = utility_analysis_combiner.create_accumulator(
             (contribution_values, num_partitions))
         actual_metrics = utility_analysis_combiner.compute_metrics(test_acc)
@@ -366,7 +364,7 @@ class UtilityAnalysisPrivacyIdCountCombinerTest(parameterized.TestCase):
         self.assertEqual(expected_metrics.noise_kind, actual_metrics.noise_kind)
 
     def test_merge(self):
-        utility_analysis_combiner = combiners.UtilityAnalysisPrivacyIdCountCombiner(
+        utility_analysis_combiner = combiners.PrivacyIdCountCombiner(
             _create_combiner_params_for_count())
         test_acc1 = [1, 2, 3]
         test_acc2 = [5, 10, -5]

--- a/utility_analysis_new/tests/combiners_test.py
+++ b/utility_analysis_new/tests/combiners_test.py
@@ -86,23 +86,12 @@ class UtilityAnalysisCountCombinerTest(parameterized.TestCase):
     def test_merge(self):
         utility_analysis_combiner = combiners.UtilityAnalysisCountCombiner(
             _create_combiner_params_for_count())
-        test_acc1 = utility_analysis_combiner.create_accumulator(((2, 3, 4), 1))
-        test_acc2 = utility_analysis_combiner.create_accumulator(((6, 7, 8), 5))
+        test_acc1 = [1, 2, 3, -4]
+        test_acc2 = [5, 10, -5, 100]
         merged_acc = utility_analysis_combiner.merge_accumulators(
             test_acc1, test_acc2)
 
-        self.assertEqual(test_acc1.count + test_acc2.count, merged_acc.count)
-        self.assertEqual(
-            test_acc1.per_partition_error + test_acc2.per_partition_error,
-            merged_acc.per_partition_error)
-        self.assertEqual(
-            test_acc1.expected_cross_partition_error +
-            test_acc2.expected_cross_partition_error,
-            merged_acc.expected_cross_partition_error)
-        self.assertEqual(
-            test_acc1.var_cross_partition_error +
-            test_acc2.var_cross_partition_error,
-            merged_acc.var_cross_partition_error)
+        self.assertSequenceEqual((6, 12, -2, 96), merged_acc)
 
 
 class PartitionSelectionTest(parameterized.TestCase):

--- a/utility_analysis_new/tests/dp_engine_test.py
+++ b/utility_analysis_new/tests/dp_engine_test.py
@@ -19,7 +19,7 @@ import copy
 import pipeline_dp
 from pipeline_dp import budget_accounting
 from utility_analysis_new import dp_engine
-from utility_analysis_new.combiners import CountUtilityAnalysisMetrics
+from utility_analysis_new.combiners import CountMetrics
 import utility_analysis_new
 
 
@@ -270,36 +270,32 @@ class DpEngine(parameterized.TestCase):
         [self.assertLen(partition_metrics, 2) for partition_metrics in output]
 
         expected_pk0 = [
-            CountUtilityAnalysisMetrics(
-                count=1,
-                per_partition_error=0,
-                expected_cross_partition_error=-0.5,
-                std_cross_partition_error=0.5,
-                std_noise=11.6640625,
-                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN),
-            CountUtilityAnalysisMetrics(
-                count=1,
-                per_partition_error=0,
-                expected_cross_partition_error=0,
-                std_cross_partition_error=0.0,
-                std_noise=32.99095075973487,
-                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
+            CountMetrics(count=1,
+                         per_partition_error=0,
+                         expected_cross_partition_error=-0.5,
+                         std_cross_partition_error=0.5,
+                         std_noise=11.6640625,
+                         noise_kind=pipeline_dp.NoiseKind.GAUSSIAN),
+            CountMetrics(count=1,
+                         per_partition_error=0,
+                         expected_cross_partition_error=0,
+                         std_cross_partition_error=0.0,
+                         std_noise=32.99095075973487,
+                         noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
         ]
         expected_pk1 = [
-            CountUtilityAnalysisMetrics(
-                count=2,
-                per_partition_error=-1,
-                expected_cross_partition_error=-0.5,
-                std_cross_partition_error=0.5,
-                std_noise=11.6640625,
-                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN),
-            CountUtilityAnalysisMetrics(
-                count=2,
-                per_partition_error=0,
-                expected_cross_partition_error=0,
-                std_cross_partition_error=0.0,
-                std_noise=32.99095075973487,
-                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
+            CountMetrics(count=2,
+                         per_partition_error=-1,
+                         expected_cross_partition_error=-0.5,
+                         std_cross_partition_error=0.5,
+                         std_noise=11.6640625,
+                         noise_kind=pipeline_dp.NoiseKind.GAUSSIAN),
+            CountMetrics(count=2,
+                         per_partition_error=0,
+                         expected_cross_partition_error=0,
+                         std_cross_partition_error=0.0,
+                         std_noise=32.99095075973487,
+                         noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
         ]
 
         self.assertSequenceEqual(expected_pk0, output[0][1])


### PR DESCRIPTION
This is done for performance reasons - it's much faster to work with tuples and serialized size of tuples is ~10 times smaller.

It turned out that the changes are pretty small and the resulting code structuring is nice:

1. Before:
```
def create_accumulators():
  ...
  return Accumulator(...)

```
After
```
def create_accumulators():
  ...
  return (...)  # the same code, just Accumulator name dropped

```

2. Before
```
  def compute_metrics(acc)
      # using acc.field1, acc.field2 etc
```
After
```
  def compute_metrics(acc)
     field1, field2.. = acc 
     # replace acc.field1 -> field1 ...
```

Also, it's introduced a base class for UtilityAnalysisCombiners.