### PR TITLE
DP percentiles

### DIFF
--- a/examples/movie_view_ratings/run_without_frameworks.py
+++ b/examples/movie_view_ratings/run_without_frameworks.py
@@ -49,7 +49,8 @@ def main(unused_argv):
             pipeline_dp.Metrics.SUM,
             pipeline_dp.Metrics.PRIVACY_ID_COUNT,
             pipeline_dp.Metrics.PERCENTILE(50),
-            pipeline_dp.Metrics.PERCENTILE(90)
+            pipeline_dp.Metrics.PERCENTILE(90),
+            pipeline_dp.Metrics.PERCENTILE(99)
         ],
         # Limits to how much one user can contribute:
         # .. at most two movies rated per user

--- a/examples/movie_view_ratings/run_without_frameworks.py
+++ b/examples/movie_view_ratings/run_without_frameworks.py
@@ -47,7 +47,9 @@ def main(unused_argv):
             # we can compute multiple metrics at once.
             pipeline_dp.Metrics.COUNT,
             pipeline_dp.Metrics.SUM,
-            pipeline_dp.Metrics.PRIVACY_ID_COUNT
+            pipeline_dp.Metrics.PRIVACY_ID_COUNT,
+            pipeline_dp.Metrics.PERCENTILE(50),
+            pipeline_dp.Metrics.PERCENTILE(90)
         ],
         # Limits to how much one user can contribute:
         # .. at most two movies rated per user

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -37,6 +37,9 @@ class Metric:
     def __repr__(self):
         return self.__str__()
 
+    def __hash__(self):
+        return hash(str(self))
+
     @property
     def is_percentile(self):
         return self.name == 'PERCENTILE'

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -20,13 +20,39 @@ import math
 import logging
 
 
-class Metrics(Enum):
-    COUNT = 'count'
-    PRIVACY_ID_COUNT = 'privacy_id_count'
-    SUM = 'sum'
-    MEAN = 'mean'
-    VARIANCE = 'variance'
-    VECTOR_SUM = 'vector_sum'
+class Metric:
+
+    def __init__(self, name: str, parameter: Optional[Any] = None):
+        self.name = name
+        self.parameter = parameter
+
+    def __eq__(self, other: 'Metric') -> bool:
+        return self.name == other.name and self.parameter == other.parameter
+
+    def __str__(self):
+        if self.parameter is None:
+            return self.name
+        return f'{self.name}({self.parameter})'
+
+    def __repr__(self):
+        return self.__str__()
+
+    @property
+    def is_percentile(self):
+        return self.name == 'PERCENTILE'
+
+
+class Metrics:
+    COUNT = Metric('COUNT')
+    PRIVACY_ID_COUNT = Metric('PRIVACY_ID_COUNT')
+    SUM = Metric('SUM')
+    MEAN = Metric('MEAN')
+    VARIANCE = Metric('VARIANCE')
+    VECTOR_SUM = Metric('VECTOR_SUM')
+
+    @classmethod
+    def PERCENTILE(cls, value: float):
+        return Metric('PERCENTILE', value)
 
 
 class NoiseKind(Enum):

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -20,11 +20,17 @@ import math
 import logging
 
 
+@dataclass
 class Metric:
+    """Represents DP metrics.
 
-    def __init__(self, name: str, parameter: Optional[Any] = None):
-        self.name = name
-        self.parameter = parameter
+    Attributes:
+        name: the name of the metric, like 'COUNT', 'PERCENTILE'.
+        parameter: parameter of the metric, e.g. for 90th percentile,
+          parameter = 90.
+    """
+    name: str
+    parameter: Optional[float] = None
 
     def __eq__(self, other: 'Metric') -> bool:
         return self.name == other.name and self.parameter == other.parameter
@@ -46,6 +52,7 @@ class Metric:
 
 
 class Metrics:
+    """Contains all supported DP metrics."""
     COUNT = Metric('COUNT')
     PRIVACY_ID_COUNT = Metric('PRIVACY_ID_COUNT')
     SUM = Metric('SUM')

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -158,7 +158,7 @@ class AggregateParams:
     def metrics_str(self) -> str:
         if self.custom_combiners:
             return f"custom combiners={[c.metrics_names() for c in self.custom_combiners]}"
-        return f"metrics={[m.value for m in self.metrics]}"
+        return f"metrics={[str(m) for m in self.metrics]}"
 
     @property
     def bounds_per_contribution_are_set(self) -> bool:

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -22,12 +22,12 @@ import logging
 
 @dataclass
 class Metric:
-    """Represents DP metrics.
+    """Represents a DP metric.
 
     Attributes:
         name: the name of the metric, like 'COUNT', 'PERCENTILE'.
-        parameter: parameter of the metric, e.g. for 90th percentile,
-          parameter = 90.
+        parameter: an optional parameter of the metric, e.g. for 90th
+        percentile, parameter = 90.
     """
     name: str
     parameter: Optional[float] = None
@@ -61,8 +61,8 @@ class Metrics:
     VECTOR_SUM = Metric('VECTOR_SUM')
 
     @classmethod
-    def PERCENTILE(cls, value: float):
-        return Metric('PERCENTILE', value)
+    def PERCENTILE(cls, percentile_to_compute: float):
+        return Metric('PERCENTILE', percentile_to_compute)
 
 
 class NoiseKind(Enum):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,4 +11,4 @@ pytest-timeout
 pylint
 yapf
 git+https://github.com/google/differential-privacy.git@327972c1ae710e8cd0a4754fffdd78c3500272ee#subdirectory=python
-python-dp==1.1.2rc3
+python-dp==1.1.3rc2

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -454,7 +454,8 @@ class QuantileCombinerTest(parameterized.TestCase):
         mechanism_spec = _create_mechanism_spec(no_noise)
         aggregate_params = _create_aggregate_params(max_value=1000)
         params = dp_combiners.CombinerParams(mechanism_spec, aggregate_params)
-        return dp_combiners.QuantileCombiner(params, percentiles=percentiles)
+        return dp_combiners.QuantileCombiner(params,
+                                             percentiles_to_compute=percentiles)
 
     def test_create_accumulator(self):
         combiner = self._create_combiner(no_noise=False)

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -95,6 +95,12 @@ class CreateCompoundCombinersTest(parameterized.TestCase):
         dict(testcase_name='vector_sum',
              metrics=[pipeline_dp.Metrics.VECTOR_SUM],
              expected_combiner_types=[dp_combiners.VectorSumCombiner]),
+        dict(testcase_name='percentiles',
+             metrics=[
+                 pipeline_dp.Metrics.PERCENTILE(10),
+                 pipeline_dp.Metrics.PERCENTILE(90)
+             ],
+             expected_combiner_types=[dp_combiners.QuantileCombiner]),
     )
     def test_create_compound_combiner(self, metrics, expected_combiner_types):
         # Arrange.
@@ -438,6 +444,64 @@ class VarianceCombinerTest(parameterized.TestCase):
         self.assertAlmostEqual(variance, np.mean(noisy_variances), delta=20)
         self.assertGreater(np.var(noisy_variances),
                            1)  # check that noise is added
+
+
+class QuantileCombinerTest(parameterized.TestCase):
+
+    def _create_combiner(self,
+                         no_noise: bool,
+                         percentiles: typing.List[int] = [10, 90]):
+        mechanism_spec = _create_mechanism_spec(no_noise)
+        aggregate_params = _create_aggregate_params(max_value=1000)
+        params = dp_combiners.CombinerParams(mechanism_spec, aggregate_params)
+        return dp_combiners.QuantileCombiner(params, percentiles=percentiles)
+
+    def test_create_accumulator(self):
+        combiner = self._create_combiner(no_noise=False)
+        quantile_tree = combiner._create_empty_quantile_tree()
+        self.assertEqual(16, quantile_tree.branching_factor)  # default value
+        self.assertEqual(4, quantile_tree.height)  # default value
+
+    def test_compute_metrics_without_merge(self):
+        # Arrange.
+        combiner = self._create_combiner(no_noise=True,
+                                         percentiles=[10, 50, 90])
+
+        # Act.
+        # Add values 0, ... 1000.
+        acc = combiner.create_accumulator(list(range(1001)))
+        metrics = combiner.compute_metrics(acc)
+
+        # Assert.
+        self.assertLen(metrics, 3)
+
+        # The budget is high, so computed percentiles should be close to actual.
+        self.assertAlmostEqual(100, metrics['percentile_10'], delta=1e-1)
+        self.assertAlmostEqual(500, metrics['percentile_50'], delta=1e-1)
+        self.assertAlmostEqual(900, metrics['percentile_90'], delta=1e-1)
+
+    def test_compute_metrics_with_merge(self):
+        # Arrange.
+        combiner = self._create_combiner(no_noise=True,
+                                         percentiles=[10, 50, 90])
+
+        # Act.
+        # Add values 0, ... 1000, each value for a separate acc and merge them.
+        result_acc = None
+        for i in range(1001):
+            acc = combiner.create_accumulator([i])
+            result_acc = acc if i == 0 else combiner.merge_accumulators(
+                acc, result_acc)
+
+        metrics = combiner.compute_metrics(result_acc)
+
+        # Assert.
+        self.assertLen(metrics, 3)
+
+        # The budget is high, so computed percentiles should be close to actual.
+        self.assertAlmostEqual(100, metrics['percentile_10'], delta=1e-1)
+        self.assertAlmostEqual(500, metrics['percentile_50'], delta=1e-1)
+        self.assertAlmostEqual(900, metrics['percentile_90'], delta=1e-1)
 
 
 class CompoundCombinerTest(parameterized.TestCase):

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -175,7 +175,7 @@ class DpEngineTest(parameterized.TestCase):
             engine._report_generators[0].report(),
             [
                 "DPEngine method: aggregate",
-                "metrics=['privacy_id_count', 'count', 'mean']",
+                "metrics=['PRIVACY_ID_COUNT', 'COUNT', 'MEAN']",
                 " noise_kind=gaussian", "max_value=5",
                 "Partition selection: private partitions",
                 "Cross-partition contribution bounding: for each privacy id randomly select max(actual_partition_contributed, 3)",
@@ -186,7 +186,7 @@ class DpEngineTest(parameterized.TestCase):
         self._check_string_contains_strings(
             engine._report_generators[1].report(),
             [
-                "metrics=['sum', 'mean']", " noise_kind=gaussian",
+                "metrics=['SUM', 'MEAN']", " noise_kind=gaussian",
                 "max_value=5", "Partition selection: public partitions",
                 "Per-partition contribution bounding: for each privacy_id and eachpartition, randomly select max(actual_contributions_per_partition, 3)",
                 "Adding empty partitions for public partitions that are missing in data"

--- a/tests/report_generator_test.py
+++ b/tests/report_generator_test.py
@@ -29,7 +29,7 @@ class ReportGeneratorTest(unittest.TestCase):
         expected_report = (
             "DPEngine method: test_method\n"
             "AggregateParams:\n"
-            " metrics=['privacy_id_count', 'count', 'mean', 'sum']\n"
+            " metrics=['PRIVACY_ID_COUNT', 'COUNT', 'MEAN', 'SUM']\n"
             " noise_kind=gaussian\n"
             " budget_weight=1\n"
             " Contribution bounding:\n"


### PR DESCRIPTION
This PR implements DP percentile computations.

API:
It adds metric `metrics.Percentile`, so now it's possible to compute percentiles with `DPEngine.aggregate`
   
`dp_engine.aggregate(... metrics=[metrics.Count, metrics.Percentile(50), metrics.Percentile(90)] ...)`

The result looks like:
(8, MetricsTuple(count=14532.95396910912, percentile_50=2.9999810443476416, percentile_90=4.99996013795033))

Implementation:
1. `Metrics`: previously it was `enum`, but metrics.Percentile(50) can't be implemented with enum, so `Metric` class was implemented.
2. `QuantileCombiner` is implemented. It uses `QuantileTree` object which is wrapper from PyDP for [the object](https://github.com/google/differential-privacy/blob/main/cc/algorithms/quantile-tree.h) from Google C++ building block library
