### PR TITLE
Sparse mode for utility analysis accumulators

### DIFF
--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -176,7 +176,8 @@ class PartitionSelectionCombiner(UtilityAnalysisCombiner):
         self._params = params
 
     def create_accumulator(
-            self, data: Tuple[int, float, int]) -> PartitionSelectionAccumulator:
+            self, data: Tuple[int, float,
+                              int]) -> PartitionSelectionAccumulator:
         count, sum_, n_partitions = data
         max_partitions = self._params.aggregate_params.max_partitions_contributed
         prob_keep_contribution = min(1, max_partitions /
@@ -239,7 +240,8 @@ class CountCombiner(UtilityAnalysisCombiner):
     def _is_public_partitions(self):
         return self._partition_selection_budget is None
 
-    def create_accumulator(self, data: Tuple[int, float, int]) -> AccumulatorType:
+    def create_accumulator(self, data: Tuple[int, float,
+                                             int]) -> AccumulatorType:
         """Creates an accumulator for data."""
         if not data:
             return (0, 0, 0, 0)
@@ -308,7 +310,8 @@ class SumCombiner(UtilityAnalysisCombiner):
     def __init__(self, params: pipeline_dp.combiners.CombinerParams):
         self._params = params
 
-    def create_accumulator(self, data: Tuple[int, float, int]) -> AccumulatorType:
+    def create_accumulator(self, data: Tuple[int, float,
+                                             int]) -> AccumulatorType:
         if not data or not data[0]:
             return (0, 0, 0, 0, 0)
         count, partition_sum, n_partitions = data
@@ -382,7 +385,8 @@ class PrivacyIdCountCombiner(UtilityAnalysisCombiner):
     def __init__(self, params: pipeline_dp.combiners.CombinerParams):
         self._params = params
 
-    def create_accumulator(self, data: Tuple[int, float, int]) -> AccumulatorType:
+    def create_accumulator(self, data: Tuple[int, float,
+                                             int]) -> AccumulatorType:
         if not data:
             return (0, 0, 0)
         count, sum_, n_partitions = data

--- a/utility_analysis_new/contribution_bounders.py
+++ b/utility_analysis_new/contribution_bounders.py
@@ -48,7 +48,7 @@ class SamplingCrossAndPerPartitionContributionBounder(
             privacy_id, partition_values = pid_pk_v_values
             num_partitions_contributed = len(partition_values)
             for partition_key, values in partition_values:
-                yield (privacy_id, partition_key), (values,
+                yield (privacy_id, partition_key), (len(values), sum(values),
                                                     num_partitions_contributed)
 
         # Unnest the list per privacy id.

--- a/utility_analysis_new/contribution_bounders.py
+++ b/utility_analysis_new/contribution_bounders.py
@@ -48,7 +48,7 @@ class SamplingCrossAndPerPartitionContributionBounder(
             privacy_id, partition_values = pid_pk_v_values
             num_partitions_contributed = len(partition_values)
             for partition_key, values in partition_values:
-                yield (privacy_id, partition_key), (len(values), sum(values),
+                yield (privacy_id, partition_key), (values,
                                                     num_partitions_contributed)
 
         # Unnest the list per privacy id.

--- a/utility_analysis_new/dp_engine.py
+++ b/utility_analysis_new/dp_engine.py
@@ -14,7 +14,7 @@
 """DPEngine for utility analysis."""
 import copy
 import dataclasses
-from typing import Any, Iterable, List, Optional, Sequence, Tuple
+from typing import Iterable, Optional, Sequence
 
 import pipeline_dp
 from pipeline_dp import budget_accounting
@@ -173,8 +173,8 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
                 internal_combiners.append(
                     utility_analysis_combiners.PrivacyIdCountCombiner(
                         combiners.CombinerParams(budget, params)))
-        return UtilityAnalysisCompoundCombiner(internal_combiners,
-                                               return_named_tuple=False)
+        return utility_analysis_combiners.CompoundCombiner(
+            internal_combiners, return_named_tuple=False)
 
     def _get_aggregate_params(
         self, params: pipeline_dp.AggregateParams
@@ -215,44 +215,3 @@ def _check_utility_analysis_params(params: pipeline_dp.AggregateParams,
         raise NotImplementedError(
             "utility analysis when contribution bounds are already enforced is "
             "not supported")
-
-
-class UtilityAnalysisCompoundCombiner(pipeline_dp.combiners.CompoundCombiner):
-    AccumulatorType = Tuple[List[Tuple], List[Any]]
-
-    def create_accumulator(self, data) -> AccumulatorType:
-        values, n_partitions = data
-        return ([(len(values), sum(values), n_partitions)], None)
-
-    def to_dense(self, sparse_acc):
-        # compound_acc = (1, [combiner.create_accumulator([None, n_partitions, count, sum_]) for combiner in self._combiners])
-        result = None
-        for count_sum_n_partitions in sparse_acc:
-            compound_acc = (1, [
-                combiner.create_accumulator(count_sum_n_partitions)
-                for combiner in self._combiners
-            ])
-            if result is None:
-                result = compound_acc
-            else:
-                result = super().merge_accumulators(result, compound_acc)
-        return result
-
-    def merge_accumulators(self, acc1: AccumulatorType, acc2: AccumulatorType):
-        sparse1, dense1 = acc1
-        sparse2, dense2 = acc2
-        if sparse1 and sparse2:
-            sparse1.extend(sparse2)
-            if len(sparse1) <= 5 * len(self._combiners):
-                return (sparse1, None)
-            return (None, self.to_dense(sparse1))
-        dense1 = self.to_dense(sparse1) if sparse1 else dense1
-        dense2 = self.to_dense(sparse2) if sparse2 else dense2
-        merged_dense = super().merge_accumulators(dense1, dense2)
-        return (None, merged_dense)
-
-    def compute_metrics(self, acc: AccumulatorType):
-        sparse, dense = acc
-        if sparse:
-            dense = self.to_dense(dense)
-        return super().compute_metrics(dense)

--- a/utility_analysis_new/tests/combiners_test.py
+++ b/utility_analysis_new/tests/combiners_test.py
@@ -384,5 +384,105 @@ class UtilityAnalysisPrivacyIdCountCombinerTest(parameterized.TestCase):
         self.assertSequenceEqual((6, 12, -2), merged_acc)
 
 
+class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
+
+    def _create_combiner(self) -> combiners.CompoundCombiner:
+        count_combiner = combiners.CountCombiner(
+            _create_combiner_params_for_count())
+        return combiners.CompoundCombiner([count_combiner],
+                                          return_named_tuple=False)
+
+    def test_create_accumulator(self):
+        combiner = self._create_combiner()
+        data = [1, 2, 3]
+        n_partitions = 500
+        sparse, dense = combiner.create_accumulator((data, n_partitions))
+        self.assertEqual(sparse, [(len(data), sum(data), n_partitions)])
+        self.assertIsNone(dense)
+
+    def test_to_dense(self):
+        combiner = self._create_combiner()
+        sparse_acc = [(1, 10, 100), (3, 20, 200)]
+        dense = combiner._to_dense(sparse_acc)
+        num_privacy_ids, (count_acc,) = dense
+        self.assertEqual(2, num_privacy_ids)
+        self.assertSequenceEqual(count_acc, (4, -1, -2.98, 0.0298))
+
+    def test_merge_sparse(self):
+        combiner = self._create_combiner()
+        sparse_acc1 = [(1, 10, 100), (3, 20, 200)]
+        acc1 = (sparse_acc1, None)
+        sparse_acc2 = [(11, 2, 300)]
+        acc2 = (sparse_acc2, None)
+        sparse, dense = combiner.merge_accumulators(acc1, acc2)
+        self.assertSequenceEqual(sparse, [(1, 10, 100), (3, 20, 200),
+                                          (11, 2, 300)])
+        self.assertIsNone(dense)
+
+    def test_merge_dense(self):
+        combiner = self._create_combiner()
+        dense_count_acc1 = (0, 1, 2, 3)
+        acc1 = (None, (1, (dense_count_acc1,)))
+        dense_count_acc2 = (0.5, 0.5, 0, -4)
+        acc2 = (None, (3, (dense_count_acc2,)))
+        sparse, dense = combiner.merge_accumulators(acc1, acc2)
+
+        self.assertIsNone(sparse)
+        self.assertEqual(dense, (4, ((0.5, 1.5, 2, -1),)))
+
+    @parameterized.named_parameters(
+        dict(testcase_name='empty',
+             num_partitions=0,
+             contribution_values=(),
+             expected_metrics=combiners.CountMetrics(
+                 count=0,
+                 per_partition_error=0,
+                 expected_cross_partition_error=0,
+                 std_cross_partition_error=0,
+                 std_noise=7.46484375,
+                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)),
+        dict(testcase_name='one_partition_zero_error',
+             num_partitions=1,
+             contribution_values=(1, 2),
+             expected_metrics=combiners.CountMetrics(
+                 count=2,
+                 per_partition_error=0,
+                 expected_cross_partition_error=0,
+                 std_cross_partition_error=0,
+                 std_noise=7.46484375,
+                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)),
+        dict(testcase_name='4_partitions_4_contributions_keep_half',
+             num_partitions=4,
+             contribution_values=(1, 2, 3, 4),
+             expected_metrics=combiners.CountMetrics(
+                 count=4,
+                 per_partition_error=-2,
+                 expected_cross_partition_error=-1.5,
+                 std_cross_partition_error=0.8660254037844386,
+                 std_noise=7.46484375,
+                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)))
+    def test_compute_metrics(self, num_partitions, contribution_values,
+                             expected_metrics):
+        combiner = self._create_combiner()
+        acc = combiner.create_accumulator((contribution_values, num_partitions))
+        self.assertEqual(expected_metrics, combiner.compute_metrics(acc)[0])
+
+    def test_two_internal_combiner(self):
+        count_combiner = combiners.CountCombiner(
+            _create_combiner_params_for_count())
+        sum_combiner = combiners.SumCombiner(
+            _create_combiner_params_for_sum(0, 5))
+        combiner = combiners.CompoundCombiner([count_combiner, sum_combiner],
+                                              return_named_tuple=False)
+
+        data, n_partitions = [1, 2, 3], 100
+        acc = combiner.create_accumulator((data, n_partitions))
+
+        acc = combiner.merge_accumulators(acc, acc)
+
+        metrics = combiner.compute_metrics(acc)
+        # self.assertIsInstance(metrics[0], )
+
+
 if __name__ == '__main__':
     absltest.main()

--- a/utility_analysis_new/tests/combiners_test.py
+++ b/utility_analysis_new/tests/combiners_test.py
@@ -78,7 +78,7 @@ class UtilityAnalysisCountCombinerTest(parameterized.TestCase):
                              expected_metrics):
         utility_analysis_combiner = combiners.CountCombiner(params)
         test_acc = utility_analysis_combiner.create_accumulator(
-            (contribution_values, num_partitions))
+            (len(contribution_values), 0, num_partitions))
         self.assertEqual(expected_metrics,
                          utility_analysis_combiner.compute_metrics(test_acc))
 
@@ -189,7 +189,8 @@ class PartitionSelectionTest(parameterized.TestCase):
                                           mock_compute_probability_to_keep):
         params = _create_combiner_params_for_count()
         combiner = combiners.PartitionSelectionCombiner(params)
-        acc = combiner.create_accumulator(([1, 2, 3], 8))
+        data = [1, 2, 3]
+        acc = combiner.create_accumulator((len(data), sum(data), 8))
         probabilities, moments = acc
         self.assertLen(probabilities, 1)
         self.assertEqual(1 / 8, probabilities[0])
@@ -272,7 +273,8 @@ class UtilityAnalysisSumCombinerTest(parameterized.TestCase):
                              expected_metrics):
         utility_analysis_combiner = combiners.SumCombiner(params)
         test_acc = utility_analysis_combiner.create_accumulator(
-            (contribution_values, num_partitions))
+            (len(contribution_values), sum(contribution_values),
+             num_partitions))
         actual_metrics = utility_analysis_combiner.compute_metrics(test_acc)
         self.assertAlmostEqual(expected_metrics.sum, actual_metrics.sum)
         self.assertAlmostEqual(expected_metrics.per_partition_error_min,
@@ -327,7 +329,7 @@ class UtilityAnalysisPrivacyIdCountCombinerTest(parameterized.TestCase):
                  noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)),
         dict(testcase_name='single_contribution_keep_half',
              num_partitions=4,
-             contribution_values=(2),
+             contribution_values=(2,),
              params=_create_combiner_params_for_privacy_id_count(),
              expected_metrics=combiners.PrivacyIdCountMetrics(
                  privacy_id_count=1,
@@ -359,7 +361,8 @@ class UtilityAnalysisPrivacyIdCountCombinerTest(parameterized.TestCase):
                              expected_metrics):
         utility_analysis_combiner = combiners.PrivacyIdCountCombiner(params)
         test_acc = utility_analysis_combiner.create_accumulator(
-            (contribution_values, num_partitions))
+            (len(contribution_values), sum(contribution_values),
+             num_partitions))
         actual_metrics = utility_analysis_combiner.compute_metrics(test_acc)
         self.assertAlmostEqual(expected_metrics.privacy_id_count,
                                actual_metrics.privacy_id_count)

--- a/utility_analysis_new/tests/combiners_test.py
+++ b/utility_analysis_new/tests/combiners_test.py
@@ -410,14 +410,24 @@ class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
 
     def test_merge_sparse(self):
         combiner = self._create_combiner()
+        sparse_acc1 = [(1, 10, 100)]
+        acc1 = (sparse_acc1, None)
+        sparse_acc2 = [(11, 2, 300)]
+        acc2 = (sparse_acc2, None)
+        sparse, dense = combiner.merge_accumulators(acc1, acc2)
+        self.assertSequenceEqual(sparse, [(1, 10, 100), (11, 2, 300)])
+        self.assertIsNone(dense)
+
+    def test_merge_sparse_result_dense(self):
+        combiner = self._create_combiner()
         sparse_acc1 = [(1, 10, 100), (3, 20, 200)]
         acc1 = (sparse_acc1, None)
         sparse_acc2 = [(11, 2, 300)]
         acc2 = (sparse_acc2, None)
         sparse, dense = combiner.merge_accumulators(acc1, acc2)
-        self.assertSequenceEqual(sparse, [(1, 10, 100), (3, 20, 200),
-                                          (11, 2, 300)])
-        self.assertIsNone(dense)
+        self.assertIsNone(sparse)
+        self.assertEqual(
+            dense, (3, ((15, -10, -4.973333333333334, 0.04308888888888889),)))
 
     def test_merge_dense(self):
         combiner = self._create_combiner()

--- a/utility_analysis_new/tests/combiners_test.py
+++ b/utility_analysis_new/tests/combiners_test.py
@@ -392,6 +392,12 @@ class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
         return combiners.CompoundCombiner([count_combiner],
                                           return_named_tuple=False)
 
+    def test_create_accumulator_empty_data(self):
+        combiner = self._create_combiner()
+        sparse, dense = self._create_combiner().create_accumulator(())
+        self.assertEqual(sparse, [(0, 0, 0)])
+        self.assertIsNone(dense)
+
     def test_create_accumulator(self):
         combiner = self._create_combiner()
         data = [1, 2, 3]

--- a/utility_analysis_new/tests/combiners_test.py
+++ b/utility_analysis_new/tests/combiners_test.py
@@ -434,7 +434,7 @@ class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
         dict(testcase_name='empty',
              num_partitions=0,
              contribution_values=(),
-             expected_metrics=combiners.CountMetrics(
+             expected_metrics=metrics.CountMetrics(
                  count=0,
                  per_partition_error=0,
                  expected_cross_partition_error=0,
@@ -444,7 +444,7 @@ class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
         dict(testcase_name='one_partition_zero_error',
              num_partitions=1,
              contribution_values=(1, 2),
-             expected_metrics=combiners.CountMetrics(
+             expected_metrics=metrics.CountMetrics(
                  count=2,
                  per_partition_error=0,
                  expected_cross_partition_error=0,
@@ -454,7 +454,7 @@ class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
         dict(testcase_name='4_partitions_4_contributions_keep_half',
              num_partitions=4,
              contribution_values=(1, 2, 3, 4),
-             expected_metrics=combiners.CountMetrics(
+             expected_metrics=metrics.CountMetrics(
                  count=4,
                  per_partition_error=-2,
                  expected_cross_partition_error=-1.5,
@@ -467,7 +467,7 @@ class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
         acc = combiner.create_accumulator((contribution_values, num_partitions))
         self.assertEqual(expected_metrics, combiner.compute_metrics(acc)[0])
 
-    def test_two_internal_combiner(self):
+    def test_two_internal_combiners(self):
         count_combiner = combiners.CountCombiner(
             _create_combiner_params_for_count())
         sum_combiner = combiners.SumCombiner(
@@ -479,9 +479,11 @@ class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
         acc = combiner.create_accumulator((data, n_partitions))
 
         acc = combiner.merge_accumulators(acc, acc)
+        self.assertEqual(([(3, 6, 100), (3, 6, 100)], None), acc)
 
-        metrics = combiner.compute_metrics(acc)
-        # self.assertIsInstance(metrics[0], )
+        utility_metrics = combiner.compute_metrics(acc)
+        self.assertIsInstance(utility_metrics[0], metrics.CountMetrics)
+        self.assertIsInstance(utility_metrics[1], metrics.SumMetrics)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR is huge performance improvements, especially in case when Utility Analysis runs for many parameters:

It introduces a sparse mode for UtilityAnalysis accumulators, namely instead of creating many accumulators for each privacy id contribution (which can be 100s times larger than the original data), it keeps counts/sums of the original data in UtilityAnalalysisCompoundAccumulator , until there are many data points and only then the internal accumulators are created.