### PR TITLE
Sampling per partitions

### DIFF
--- a/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
+++ b/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
@@ -38,6 +38,8 @@ flags.DEFINE_boolean(
 flags.DEFINE_boolean(
     'multi_parameters', False, 'Whether utility analysis is performed for '
     'multiple parameters simultaneously')
+flags.DEFINE_float('partition_sampling_probability', 1.0,
+                   'Partition sampling probability')
 
 
 def write_to_file(col, filename):
@@ -110,11 +112,10 @@ def per_partition_utility_analysis():
     data_extractors = get_data_extractors()
     public_partitions = list(range(1, 8)) if FLAGS.public_partitions else None
 
-    result = utility_analysis_engine.aggregate(restaurant_visits_rows,
-                                               aggregate_params,
-                                               data_extractors,
-                                               public_partitions,
-                                               get_multi_params())
+    result = utility_analysis_engine.aggregate(
+        restaurant_visits_rows, aggregate_params, data_extractors,
+        public_partitions, get_multi_params(),
+        FLAGS.partition_sampling_probability)
 
     budget_accountant.compute_budgets()
 

--- a/pipeline_dp/sampling_utils.py
+++ b/pipeline_dp/sampling_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import numpy as np
+import hashlib
 
 
 def choose_from_list_without_replacement(a: list, size: int) -> list:
@@ -26,3 +27,25 @@ def choose_from_list_without_replacement(a: list, size: int) -> list:
     sampled_indices = np.random.choice(np.arange(len(a)), size, replace=False)
 
     return [a[i] for i in sampled_indices]
+
+
+def _compute_64bit_hash(v) -> int:
+    m = hashlib.sha1()
+    m.update(repr(v).encode())
+    return int(m.hexdigest()[:16], 16)
+
+
+class DeterministicSampler:
+    """Hash based sampler.
+
+    For a value it returns whether this value should be kept. The keeping
+    decision is deterministic for fixed value. On average the decision to keep
+    happens in sampling_rate cases.
+    """
+
+    def __init__(self, sampling_rate: float):
+        self._sample_bound = int(round(2**64 * sampling_rate))
+
+    def keep(self, value) -> bool:
+        """Returns true if the value should be kept."""
+        return _compute_64bit_hash(value) < self._sample_bound

--- a/pipeline_dp/sampling_utils.py
+++ b/pipeline_dp/sampling_utils.py
@@ -39,7 +39,7 @@ class ValueSampler:
     """Deterministic value sampler.
 
     For a value it returns whether this value should be kept. The keeping
-    decision is deterministic for a fixed value. For randomly chosen value the
+    decision is deterministic for a fixed value. For a randomly chosen value the
     decision to keep happens with probability sampling_rate.
     """
 

--- a/pipeline_dp/sampling_utils.py
+++ b/pipeline_dp/sampling_utils.py
@@ -36,10 +36,10 @@ def _compute_64bit_hash(v) -> int:
 
 
 class DeterministicSampler:
-    """Hash based sampler.
+    """Deterministic value sampler.
 
     For a value it returns whether this value should be kept. The keeping
-    decision is deterministic for fixed value. On average the decision to keep
+    decision is deterministic for a fixed value. On average the decision to keep
     happens in sampling_rate cases.
     """
 

--- a/pipeline_dp/sampling_utils.py
+++ b/pipeline_dp/sampling_utils.py
@@ -35,7 +35,7 @@ def _compute_64bit_hash(v) -> int:
     return int(m.hexdigest()[:16], 16)
 
 
-class DeterministicSampler:
+class ValueSampler:
     """Deterministic value sampler.
 
     For a value it returns whether this value should be kept. The keeping

--- a/pipeline_dp/sampling_utils.py
+++ b/pipeline_dp/sampling_utils.py
@@ -39,8 +39,8 @@ class ValueSampler:
     """Deterministic value sampler.
 
     For a value it returns whether this value should be kept. The keeping
-    decision is deterministic for a fixed value. On average the decision to keep
-    happens in sampling_rate cases.
+    decision is deterministic for a fixed value. For randomly chosen value the
+    decision to keep happens with probability sampling_rate.
     """
 
     def __init__(self, sampling_rate: float):

--- a/tests/sampling_utils_test.py
+++ b/tests/sampling_utils_test.py
@@ -51,6 +51,33 @@ class SamplingUtilsTest(parameterized.TestCase):
                 a, sample_size)
             self.assertTrue(self._check_is_subset(sample, a))
 
+    @parameterized.parameters(
+        {
+            "p": 0.5,
+            "values": list(range(1000)),
+            "expected_kept": 481
+        },
+        {
+            "p": 0.3,
+            "values": list(range(1000)),
+            "expected_kept": 298
+        },
+        {
+            "p": 0.8,
+            "values": list(range(10000)),
+            "expected_kept": 8074
+        },
+        {
+            "p": 0.5,
+            "values": list(map(str, range(1000))),  # strings
+            "expected_kept": 497
+        },
+    )
+    def test_deterministic_sampler(self, p, values, expected_kept):
+        sampler = sampling_utils.DeterministicSampler(p)
+        kept = sum([sampler.keep(v) for v in values])
+        self.assertEqual(expected_kept, kept)
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/tests/sampling_utils_test.py
+++ b/tests/sampling_utils_test.py
@@ -74,7 +74,7 @@ class SamplingUtilsTest(parameterized.TestCase):
         },
     )
     def test_deterministic_sampler(self, p, values, expected_kept):
-        sampler = sampling_utils.DeterministicSampler(p)
+        sampler = sampling_utils.ValueSampler(p)
         kept = sum([sampler.keep(v) for v in values])
         self.assertEqual(expected_kept, kept)
 

--- a/utility_analysis_new/contribution_bounders.py
+++ b/utility_analysis_new/contribution_bounders.py
@@ -14,6 +14,14 @@
 """ContributionBounder for utility analysis."""
 from pipeline_dp import contribution_bounders
 
+import hashlib
+
+
+def _compute_64bit_hach(v) -> int:
+    m = hashlib.sha1()
+    m.update(repr(v).encode())
+    return int(m.hexdigest()[:16], 16)
+
 
 class SamplingCrossAndPerPartitionContributionBounder(
         contribution_bounders.ContributionBounder):
@@ -26,6 +34,10 @@ class SamplingCrossAndPerPartitionContributionBounder(
 
     Only works for count at the moment.
     """
+
+    def __init__(self, sampling_probability: float):
+        super().__init__()
+        self._sampling_probability = sampling_probability
 
     def bound_contributions(self, col, params, backend, report_generator,
                             aggregate_fn):
@@ -44,10 +56,17 @@ class SamplingCrossAndPerPartitionContributionBounder(
 
         # Rekey by (privacy_id, partition_key) and unnest values along with the
         # number of partitions contributed per privacy_id.
+        # Sample by partition key if sampling_prob != 1.
+        if self._sampling_probability < 1:
+            sample_bound = int(round(2**64 * self._sampling_probability))
+
         def rekey_per_privacy_id_per_partition_key_and_unnest(pid_pk_v_values):
             privacy_id, partition_values = pid_pk_v_values
             num_partitions_contributed = len(partition_values)
             for partition_key, values in partition_values:
+                if self._sampling_probability < 1:
+                    if _compute_64bit_hach(partition_key) >= sample_bound:
+                        continue
                 yield (privacy_id, partition_key), (values,
                                                     num_partitions_contributed)
 

--- a/utility_analysis_new/contribution_bounders.py
+++ b/utility_analysis_new/contribution_bounders.py
@@ -53,7 +53,7 @@ class SamplingL0LinfContributionBounder(
         # Rekey by (privacy_id, partition_key) and unnest val_coues along with the
         # number of partitions contributed per privacy_id.
         # Sample by partition key if sampling_prob < 1.
-        sampler = sampling_utils.DeterministicSampler(
+        sampler = sampling_utils.ValueSampler(
             self._sampling_probability
         ) if self._sampling_probability < 1 else None
 

--- a/utility_analysis_new/contribution_bounders.py
+++ b/utility_analysis_new/contribution_bounders.py
@@ -25,10 +25,8 @@ class SamplingL0LinfContributionBounder(
     different data points are kept under per-partition (Linf) and
     cross-partition (L0) contribution bounding.
 
-    If partitions_sampling_prob < 1.0, it samples partitions. The sampling is
-    performed by rule: keep partition_key iff
-      hash(partition_key) < partitions_sampling_prob*MAX_HASH_VALUE.
-
+    If partitions_sampling_prob < 1.0, partitions are subsampled. This sampling
+    is deterministic and depends on partition key.
 
     Only works for count at the moment.
     """

--- a/utility_analysis_new/contribution_bounders.py
+++ b/utility_analysis_new/contribution_bounders.py
@@ -50,7 +50,7 @@ class SamplingL0LinfContributionBounder(
 
         # (privacy_id, [(partition_key, [value])])
 
-        # Rekey by (privacy_id, partition_key) and unnest val_coues along with the
+        # Rekey by (privacy_id, partition_key) and unnest values along with the
         # number of partitions contributed per privacy_id.
         # Sample by partition key if sampling_prob < 1.
         sampler = sampling_utils.ValueSampler(

--- a/utility_analysis_new/dp_engine.py
+++ b/utility_analysis_new/dp_engine.py
@@ -108,7 +108,7 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
                   public_partitions=None,
                   multi_param_configuration: Optional[
                       MultiParameterConfiguration] = None,
-                  sampling_probability: float = 1.0):
+                  partitions_sampling_prob: float = 1.0):
         """Performs utility analysis for DP aggregations per partition.
 
         Args:
@@ -124,7 +124,7 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
             blue-print and non-None attributes from 'multi_param_configuration'
             are used for creating multiple AggregateParams. See docstring for
             MultiParameterConfiguration for more details.
-          sampling_probability: todo
+          partitions_sampling_prob: todo
 
         Returns:
             A collection with elements (pk, utility analysis metrics).
@@ -132,7 +132,7 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
         _check_utility_analysis_params(params, public_partitions)
         self._is_public_partitions = public_partitions is not None
         self._multi_run_configuration = multi_param_configuration
-        self._sampling_probability = sampling_probability
+        self._sampling_probability = partitions_sampling_prob
         result = super().aggregate(col, params, data_extractors,
                                    public_partitions)
         self._is_public_partitions = None
@@ -144,7 +144,7 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
         self, params: pipeline_dp.AggregateParams
     ) -> contribution_bounders.ContributionBounder:
         """Creates ContributionBounder for utility analysis."""
-        return utility_contribution_bounders.SamplingCrossAndPerPartitionContributionBounder(
+        return utility_contribution_bounders.SamplingL0LinfContributionBounder(
             self._sampling_probability)
 
     def _create_compound_combiner(

--- a/utility_analysis_new/dp_engine.py
+++ b/utility_analysis_new/dp_engine.py
@@ -99,15 +99,16 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
                  backend: pipeline_backend.PipelineBackend):
         super().__init__(budget_accountant, backend)
         self._is_public_partitions = None
+        self._sampling_probability = 1.0
 
-    def aggregate(
-        self,
-        col,
-        params: pipeline_dp.AggregateParams,
-        data_extractors: pipeline_dp.DataExtractors,
-        public_partitions=None,
-        multi_param_configuration: Optional[MultiParameterConfiguration] = None
-    ):
+    def aggregate(self,
+                  col,
+                  params: pipeline_dp.AggregateParams,
+                  data_extractors: pipeline_dp.DataExtractors,
+                  public_partitions=None,
+                  multi_param_configuration: Optional[
+                      MultiParameterConfiguration] = None,
+                  sampling_probability: float = 1.0):
         """Performs utility analysis for DP aggregations per partition.
 
         Args:
@@ -123,6 +124,7 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
             blue-print and non-None attributes from 'multi_param_configuration'
             are used for creating multiple AggregateParams. See docstring for
             MultiParameterConfiguration for more details.
+          sampling_probability: todo
 
         Returns:
             A collection with elements (pk, utility analysis metrics).
@@ -130,10 +132,12 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
         _check_utility_analysis_params(params, public_partitions)
         self._is_public_partitions = public_partitions is not None
         self._multi_run_configuration = multi_param_configuration
+        self._sampling_probability = sampling_probability
         result = super().aggregate(col, params, data_extractors,
                                    public_partitions)
         self._is_public_partitions = None
         self._multi_run_configuration = None
+        self._sampling_probability = 1.0
         return result
 
     def _create_contribution_bounder(
@@ -141,7 +145,7 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
     ) -> contribution_bounders.ContributionBounder:
         """Creates ContributionBounder for utility analysis."""
         return utility_contribution_bounders.SamplingCrossAndPerPartitionContributionBounder(
-        )
+            self._sampling_probability)
 
     def _create_compound_combiner(
         self, aggregate_params: pipeline_dp.AggregateParams

--- a/utility_analysis_new/tests/contribution_bounders_test.py
+++ b/utility_analysis_new/tests/contribution_bounders_test.py
@@ -37,13 +37,16 @@ def _create_report_generator():
 class SamplingCrossAndPerPartitionContributionBounderTest(
         parameterized.TestCase):
 
-    def _run_contribution_bounding(self, input, max_partitions_contributed,
-                                   max_contributions_per_partition):
+    def _run_contribution_bounding(self,
+                                   input,
+                                   max_partitions_contributed,
+                                   max_contributions_per_partition,
+                                   partitions_sampling_prob: float = 1.0):
         params = CrossAndPerPartitionContributionParams(
             max_partitions_contributed, max_contributions_per_partition)
 
-        bounder = contribution_bounders.SamplingCrossAndPerPartitionContributionBounder(
-        )
+        bounder = contribution_bounders.SamplingL0LinfContributionBounder(
+            partitions_sampling_prob)
         return list(
             bounder.bound_contributions(input, params,
                                         pipeline_dp.LocalBackend(),

--- a/utility_analysis_new/tests/contribution_bounders_test.py
+++ b/utility_analysis_new/tests/contribution_bounders_test.py
@@ -34,8 +34,7 @@ def _create_report_generator():
     return pipeline_dp.report_generator.ReportGenerator(None, "test")
 
 
-class SamplingCrossAndPerPartitionContributionBounderTest(
-        parameterized.TestCase):
+class SamplingL0LinfContributionBounderTest(parameterized.TestCase):
 
     def _run_contribution_bounding(self,
                                    input,
@@ -96,6 +95,25 @@ class SamplingCrossAndPerPartitionContributionBounderTest(
         expected_result = [(('pid1', 'pk1'), 2), (('pid1', 'pk2'), 3),
                            (('pid1', 'pk3'), 1), (('pid1', 'pk4'), 1),
                            (('pid2', 'pk4'), 1)]
+        # Check per- and cross-partition contribution limits are not enforced.
+        self.assertEqual(set(expected_result), set(bound_result))
+
+    def test_contribution_bounding_cross_partition_bounding_and_sampling(self):
+        input = [("pid1", 'pk1', 1), ("pid1", 'pk1', 2), ("pid1", 'pk2', 3),
+                 ("pid1", 'pk2', 4), ("pid1", 'pk2', 5), ("pid1", 'pk3', 6),
+                 ("pid1", 'pk4', 7), ("pid2", 'pk4', 8)]
+        max_partitions_contributed = 3
+        max_contributions_per_partition = 5
+
+        bound_result = self._run_contribution_bounding(
+            input,
+            max_partitions_contributed,
+            max_contributions_per_partition,
+            partitions_sampling_prob=0.7)
+
+        # 'pk1' and 'pk2' are dropped by subsampling.
+        expected_result = [(('pid2', 'pk4'), 1), (('pid1', 'pk3'), 1),
+                           (('pid1', 'pk4'), 1)]
         # Check per- and cross-partition contribution limits are not enforced.
         self.assertEqual(set(expected_result), set(bound_result))
 

--- a/utility_analysis_new/tests/dp_engine_test.py
+++ b/utility_analysis_new/tests/dp_engine_test.py
@@ -301,7 +301,7 @@ class DpEngine(parameterized.TestCase):
         self.assertSequenceEqual(expected_pk0, output[0][1])
         self.assertSequenceEqual(expected_pk1, output[1][1])
 
-    @patch('pipeline_dp.sampling_utils.DeterministicSampler.__init__')
+    @patch('pipeline_dp.sampling_utils.ValueSampler.__init__')
     def test_partition_sampling(self, mock_sampler_init):
         # Arrange
         mock_sampler_init.return_value = None

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -31,7 +31,7 @@ class UtilityAnalysisOptions:
     aggregate_params: pipeline_dp.AggregateParams
     multi_param_configuration: Optional[
         dp_engine.MultiParameterConfiguration] = None
-    sampling_probability: float = 1
+    partitions_sampling_prob: float = 1
 
     def __post_init__(self):
         input_validators.validate_epsilon_delta(self.epsilon, self.delta,

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -37,6 +37,10 @@ class UtilityAnalysisOptions:
     def __post_init__(self):
         input_validators.validate_epsilon_delta(self.epsilon, self.delta,
                                                 "UtilityAnalysisOptions")
+        if self.partitions_sampling_prob or self.partitions_sampling_prob > 1:
+            raise ValueError(
+                f"partitions_sampling_prob must be in the interval"
+                f" (0, 1], but {self.partitions_sampling_prob} given.")
 
     @property
     def n_parameters(self):

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -31,6 +31,7 @@ class UtilityAnalysisOptions:
     aggregate_params: pipeline_dp.AggregateParams
     multi_param_configuration: Optional[
         dp_engine.MultiParameterConfiguration] = None
+    sampling_probability: float = 1
 
     def __post_init__(self):
         input_validators.validate_epsilon_delta(self.epsilon, self.delta,

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -37,7 +37,7 @@ class UtilityAnalysisOptions:
     def __post_init__(self):
         input_validators.validate_epsilon_delta(self.epsilon, self.delta,
                                                 "UtilityAnalysisOptions")
-        if self.partitions_sampling_prob or self.partitions_sampling_prob > 1:
+        if self.partitions_sampling_prob <= 0 or self.partitions_sampling_prob > 1:
             raise ValueError(
                 f"partitions_sampling_prob must be in the interval"
                 f" (0, 1], but {self.partitions_sampling_prob} given.")

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -73,7 +73,8 @@ def perform_utility_analysis(col,
         params=options.aggregate_params,
         data_extractors=data_extractors,
         public_partitions=public_partitions,
-        multi_param_configuration=options.multi_param_configuration)
+        multi_param_configuration=options.multi_param_configuration,
+        partitions_sampling_prob=options.partitions_sampling_prob)
     budget_accountant.compute_budgets()
     # result : (partition_key, per_partition_metrics)
 


### PR DESCRIPTION
This PR implements sub-sampling of partitions for utility analysis.
It works the following:
1.`UtilityAnalysisEngine.aggregate` has sampling_probability
2. Utility analysis ContributionBounder can perform sub-sampling of partitions using `ValueSampler` if sampling probability < 1.0
3. `ValueSampler` computes hash of partition key and if the hash (which is assumed to return uniform values) is less than sampling_rate*max_hash_value, the partition_key is kept.