### PR TITLE
Computing partition count histograms

### DIFF
--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -302,7 +302,7 @@ class DPEngine:
             (partition_key, aggregator_fn([])), "Build empty accumulators")
 
         return self._backend.flatten(
-            col, empty_accumulators,
+            (col, empty_accumulators),
             "Join public partitions with partitions from data")
 
     def _select_private_partitions_internal(

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -355,7 +355,7 @@ class SparkRDDBackendTest(parameterized.TestCase):
         dist_data2 = self.sc.parallelize(data2)
 
         self.assertEqual(
-            self.backend.flatten(dist_data1, dist_data2).collect(),
+            self.backend.flatten((dist_data1, dist_data2)).collect(),
             [1, 2, 3, 4, 5, 6, 7, 8])
 
     def test_distinct(self):
@@ -570,6 +570,12 @@ class LocalBackendTest(unittest.TestCase):
         self.assertEqual(list(self.backend.group_by_key(some_dict)),
                          [("cheese", ["brie", "swiss"]),
                           ("bread", ["sourdough"])])
+
+    def test_flatten(self):
+        data1, data2, data3 = [1, 2, 3, 4], [5, 6, 7, 8], [9, 10]
+
+        self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                         list(self.backend.flatten((data1, data2, data3))))
 
     def test_distinct(self):
         input = [3, 2, 1, 3, 5, 4, 1, 1, 2]

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -121,6 +121,13 @@ class BeamBackendTest(parameterized.TestCase):
             col = self.backend.to_list(data, "To list")
             beam_util.assert_that(col, beam_util.equal_to([[1, 2, 3, 4, 5]]))
 
+    def test_flatten(self):
+        with test_pipeline.TestPipeline() as p:
+            data1 = p | "data1" >> beam.Create([1, 2, 3, 4])
+            data2 = p | "data2" >> beam.Create([5, 6, 7, 8])
+            col = self.backend.flatten((data1, data2), "flatten")
+            beam_util.assert_that(col, beam_util.equal_to([1, 2, 3, 4, 5, 6, 7, 8]))
+
     def test_distinct(self):
         with test_pipeline.TestPipeline() as p:
             input = p | beam.Create([3, 2, 1, 3, 5, 4, 1, 1, 2])
@@ -349,13 +356,11 @@ class SparkRDDBackendTest(parameterized.TestCase):
                                                                  ("b", 8)])
 
     def test_flatten(self):
-        data1 = [1, 2, 3, 4]
-        dist_data1 = self.sc.parallelize(data1)
-        data2 = [5, 6, 7, 8]
-        dist_data2 = self.sc.parallelize(data2)
+        data1 = self.sc.parallelize( [1, 2, 3, 4])
+        data2 = self.sc.parallelize([5, 6, 7, 8])
 
         self.assertEqual(
-            self.backend.flatten((dist_data1, dist_data2)).collect(),
+            self.backend.flatten((data1, data2)).collect(),
             [1, 2, 3, 4, 5, 6, 7, 8])
 
     def test_distinct(self):

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -126,7 +126,8 @@ class BeamBackendTest(parameterized.TestCase):
             data1 = p | "data1" >> beam.Create([1, 2, 3, 4])
             data2 = p | "data2" >> beam.Create([5, 6, 7, 8])
             col = self.backend.flatten((data1, data2), "flatten")
-            beam_util.assert_that(col, beam_util.equal_to([1, 2, 3, 4, 5, 6, 7, 8]))
+            beam_util.assert_that(col,
+                                  beam_util.equal_to([1, 2, 3, 4, 5, 6, 7, 8]))
 
     def test_distinct(self):
         with test_pipeline.TestPipeline() as p:
@@ -356,7 +357,7 @@ class SparkRDDBackendTest(parameterized.TestCase):
                                                                  ("b", 8)])
 
     def test_flatten(self):
-        data1 = self.sc.parallelize( [1, 2, 3, 4])
+        data1 = self.sc.parallelize([1, 2, 3, 4])
         data2 = self.sc.parallelize([5, 6, 7, 8])
 
         self.assertEqual(

--- a/utility_analysis_new/__init__.py
+++ b/utility_analysis_new/__init__.py
@@ -14,7 +14,7 @@
 
 from utility_analysis_new.dp_engine import MultiParameterConfiguration
 from utility_analysis_new.histograms import compute_contribution_histograms
-from utility_analysis_new.histograms import ContributionHistograms
+from utility_analysis_new.histograms import DatasetHistograms
 from utility_analysis_new.metrics import AggregateMetrics
 from utility_analysis_new.parameter_tuning import tune
 from utility_analysis_new.parameter_tuning import MinimizingFunction

--- a/utility_analysis_new/histograms.py
+++ b/utility_analysis_new/histograms.py
@@ -195,6 +195,9 @@ def _compute_l0_contributions_histogram(
     Returns:
       1 element collection, which contains the computed Histogram.
     """
+    col = backend.keys(col, "Drop partition id")
+    # col: (pid)
+
     col = backend.count_per_element(col, "Compute partitions per privacy id")
     # col: (pid, num_pk)
 

--- a/utility_analysis_new/histograms.py
+++ b/utility_analysis_new/histograms.py
@@ -101,15 +101,7 @@ class Histogram:
 
 @dataclass
 class DatasetHistograms:
-    """Contains histograms useful for parameter tuning.
-
-    Attributes:
-        l0_contributions_histogram:
-        linf_contributions_histogram:
-        count_per_partition_histogram:
-        count_privacy_id_per_partition
-
-    """
+    """Contains histograms useful for parameter tuning."""
     l0_contributions_histogram: Histogram
     linf_contributions_histogram: Histogram
     count_per_partition_histogram: Histogram
@@ -190,16 +182,16 @@ def _compute_l0_contributions_histogram(
         col, backend: pipeline_backend.PipelineBackend):
     """Computes histogram of cross partition privacy id contributions.
 
-  This histogram contains: number of privacy ids which contributes to 1 partition,
-  to 2 partitions etc.
+    This histogram contains: number of privacy ids which contributes to 1
+    partition, to 2 partitions etc.
 
-  Args:
+    Args:
       col: collection with elements (privacy_id, partition_key).
       backend: PipelineBackend to run operations on the collection.
 
-  Returns:
+    Returns:
       1 element collection, which contains the computed Histogram.
-  """
+    """
 
     col = backend.distinct(col, "Distinct (privacy_id, partition_key)")
     # col: (pid, pk)
@@ -221,16 +213,16 @@ def _compute_linf_contributions_histogram(
         col, backend: pipeline_backend.PipelineBackend):
     """Computes histogram of per partition privacy id contributions.
 
-  This histogram contains: number of tuple (privacy id, partition_key) which
-  have 1 row in datasets, 2 rows etc.
+    This histogram contains: number of tuple (privacy id, partition_key) which
+    have 1 row in datasets, 2 rows etc.
 
-  Args:
+    Args:
       col: collection with elements (privacy_id, partition_key).
       backend: PipelineBackend to run operations on the collection.
 
-  Returns:
+    Returns:
       1 element collection, which contains the computed Histogram.
-  """
+    """
     col = backend.count_per_element(
         col, "Contributions per (privacy_id, partition)")
     # col: ((pid, pk), n)

--- a/utility_analysis_new/histograms.py
+++ b/utility_analysis_new/histograms.py
@@ -277,9 +277,6 @@ def _compute_partition_privacy_id_count_histogram(
       1 element collection, which contains the computed Histogram.
     """
 
-    col = backend.distinct(col, "Distinct (privacy_id, partition_key)")
-    # col: (pid, pk)
-
     col = backend.values(col, "Drop privacy key")
     # col: (pk)
 

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -97,15 +97,14 @@ class TuneResult:
           were performed during the tuning process.
     """
     options: TuneOptions
-    contribution_histograms: histograms.ContributionHistograms
+    contribution_histograms: histograms.DatasetHistograms
     utility_analysis_parameters: utility_analysis_new.dp_engine.MultiParameterConfiguration
     index_best: int
     utility_analysis_results: List[metrics.AggregateErrorMetrics]
 
 
 def _find_candidate_parameters(
-    hist: histograms.ContributionHistograms,
-    parameters_to_tune: ParametersToTune
+    hist: histograms.DatasetHistograms, parameters_to_tune: ParametersToTune
 ) -> utility_analysis_new.dp_engine.MultiParameterConfiguration:
     """Uses some heuristics to find (hopefully) good enough parameters."""
     # TODO: decide where to put QUANTILES_TO_USE, maybe TuneOptions?
@@ -149,8 +148,7 @@ def _convert_utility_analysis_to_tune_result(
         utility_analysis_result: Tuple, tune_options: TuneOptions,
         run_configurations: utility_analysis_new.dp_engine.
     MultiParameterConfiguration, use_public_partitions: bool,
-        contribution_histograms: histograms.ContributionHistograms
-) -> TuneResult:
+        contribution_histograms: histograms.DatasetHistograms) -> TuneResult:
     assert len(utility_analysis_result) == run_configurations.size
     # TODO(dvadym): implement relative error.
     # TODO(dvadym): take into consideration partition selection from private
@@ -168,7 +166,7 @@ def _convert_utility_analysis_to_tune_result(
 
 def tune(col,
          backend: pipeline_backend.PipelineBackend,
-         contribution_histograms: histograms.ContributionHistograms,
+         contribution_histograms: histograms.DatasetHistograms,
          options: TuneOptions,
          data_extractors: pipeline_dp.DataExtractors,
          public_partitions=None) -> TuneResult:

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -120,10 +120,10 @@ def _find_candidate_parameters(
         return candidates
 
     if parameters_to_tune.max_partitions_contributed:
-        l0_candidates = _find_candidates(hist.cross_partition_histogram)
+        l0_candidates = _find_candidates(hist.l0_contributions_histogram)
 
     if parameters_to_tune.max_contributions_per_partition:
-        linf_candidates = _find_candidates(hist.per_partition_histogram)
+        linf_candidates = _find_candidates(hist.linf_contributions_histogram)
 
     l0_bounds = linf_bounds = None
 

--- a/utility_analysis_new/tests/histograms_test.py
+++ b/utility_analysis_new/tests/histograms_test.py
@@ -80,7 +80,7 @@ class ParameterTuning(parameterized.TestCase):
         dict(testcase_name='empty', input=[], expected=[]),
         dict(
             testcase_name='small_histogram',
-            input=[(1, 1), (1, 2), (2, 1), (1, 1)],  # (privacy_id, partition)
+            input=[(1, 1), (1, 2), (2, 1)],  # (privacy_id, partition)
             expected=[
                 FrequencyBin(lower=1, count=1, sum=1, max=1),
                 FrequencyBin(lower=2, count=1, sum=2, max=2)
@@ -93,7 +93,7 @@ class ParameterTuning(parameterized.TestCase):
             ]),
         dict(
             testcase_name='1 privacy id many contributions to 1 partition',
-            input=[(0, 0)] * 100,  # (privacy_id, partition)
+            input=[(0, 0)],  # (privacy_id, partition)
             expected=[
                 FrequencyBin(lower=1, count=1, sum=1, max=1),
             ]),
@@ -219,7 +219,7 @@ class ParameterTuning(parameterized.TestCase):
         dict(testcase_name='empty', input=[], expected=[]),
         dict(
             testcase_name='small_histogram',
-            input=[(1, 1), (1, 2), (2, 1), (1, 1)],  # (privacy_id, partition)
+            input=[(1, 1), (1, 2), (2, 1)],  # (privacy_id, partition)
             expected=[
                 FrequencyBin(lower=1, count=1, sum=1, max=1),
                 FrequencyBin(lower=2, count=1, sum=2, max=2)
@@ -232,7 +232,7 @@ class ParameterTuning(parameterized.TestCase):
             ]),
         dict(
             testcase_name='1 privacy id many contributions to 1 partition',
-            input=[(0, 0)] * 100,  # (privacy_id, partition)
+            input=[(0, 0)],  # (privacy_id, partition)
             expected=[
                 FrequencyBin(lower=1, count=1, sum=1, max=1),
             ]),

--- a/utility_analysis_new/tests/histograms_test.py
+++ b/utility_analysis_new/tests/histograms_test.py
@@ -63,12 +63,18 @@ class ParameterTuning(parameterized.TestCase):
         self.assertListEqual(expected, histogram.bins)
 
     def test_list_to_contribution_histograms(self):
-        histogram1 = hist.Histogram("CrossPartitionHistogram", None)
-        histogram2 = hist.Histogram("PerPartitionHistogram", None)
+        histogram1 = hist.Histogram(hist.HistogramType.L0_CONTRIBUTIONS, None)
+        histogram2 = hist.Histogram(hist.HistogramType.LINF_CONTRIBUTIONS, None)
+        histogram3 = hist.Histogram(hist.HistogramType.COUNT_PER_PARTITION,
+                                    None)
+        histogram4 = hist.Histogram(
+            hist.HistogramType.COUNT_PRIVACY_ID_PER_PARTITION, None)
         histograms = hist._list_to_contribution_histograms(
-            [histogram2, histogram1])
+            [histogram2, histogram1, histogram3, histogram4])
         self.assertEqual(histogram1, histograms.l0_contributions_histogram)
         self.assertEqual(histogram2, histograms.linf_contributions_histogram)
+        self.assertEqual(histogram3, histograms.count_per_partition_histogram)
+        self.assertEqual(histogram4, histograms.count_privacy_id_per_partition)
 
     @parameterized.named_parameters(
         dict(testcase_name='empty', input=[], expected=[]),
@@ -109,7 +115,7 @@ class ParameterTuning(parameterized.TestCase):
         histogram = hist._compute_cross_partition_histogram(
             input, pipeline_dp.LocalBackend())
         histogram = list(histogram)[0]
-        self.assertEqual("CrossPartitionHistogram", histogram.name)
+        self.assertEqual(hist.HistogramType.L0_CONTRIBUTIONS, histogram.name)
         self.assertListEqual(expected, histogram.bins)
 
     @parameterized.named_parameters(
@@ -163,7 +169,7 @@ class ParameterTuning(parameterized.TestCase):
         histogram = list(histogram)
         self.assertLen(histogram, 1)
         histogram = histogram[0]
-        self.assertEqual("PerPartitionHistogram", histogram.name)
+        self.assertEqual(hist.HistogramType.LINF_CONTRIBUTIONS, histogram.name)
         self.assertListEqual(expected, histogram.bins)
 
     @parameterized.named_parameters(
@@ -245,11 +251,11 @@ class ParameterTuning(parameterized.TestCase):
         self.assertLen(histograms, 1)
         histograms = histograms[0]
 
-        self.assertEqual("CrossPartitionHistogram",
+        self.assertEqual(hist.HistogramType.L0_CONTRIBUTIONS,
                          histograms.l0_contributions_histogram.name)
         self.assertListEqual(expected_cross_partition,
                              histograms.l0_contributions_histogram.bins)
-        self.assertEqual("PerPartitionHistogram",
+        self.assertEqual(hist.HistogramType.LINF_CONTRIBUTIONS,
                          histograms.linf_contributions_histogram.name)
         self.assertListEqual(expected_per_partition,
                              histograms.linf_contributions_histogram.bins)

--- a/utility_analysis_new/tests/histograms_test.py
+++ b/utility_analysis_new/tests/histograms_test.py
@@ -111,8 +111,8 @@ class ParameterTuning(parameterized.TestCase):
                 FrequencyBin(lower=15, count=2, sum=30, max=15),
             ]),
     )
-    def test_compute_cross_partition_histogram(self, input, expected):
-        histogram = hist._compute_cross_partition_histogram(
+    def test_compute_l0_contributions_histogram(self, input, expected):
+        histogram = hist._compute_l0_contributions_histogram(
             input, pipeline_dp.LocalBackend())
         histogram = list(histogram)[0]
         self.assertEqual(hist.HistogramType.L0_CONTRIBUTIONS, histogram.name)
@@ -162,8 +162,8 @@ class ParameterTuning(parameterized.TestCase):
                 FrequencyBin(lower=3, count=1, sum=3, max=3),
             ]),
     )
-    def test_compute_per_partition_histogram(self, input, expected):
-        histogram = hist._compute_per_partition_histogram(
+    def test_compute_linf_contributions_histogram(self, input, expected):
+        histogram = hist._compute_linf_contributions_histogram(
             input, pipeline_dp.LocalBackend())
 
         histogram = list(histogram)

--- a/utility_analysis_new/tests/histograms_test.py
+++ b/utility_analysis_new/tests/histograms_test.py
@@ -67,8 +67,8 @@ class ParameterTuning(parameterized.TestCase):
         histogram2 = hist.Histogram("PerPartitionHistogram", None)
         histograms = hist._list_to_contribution_histograms(
             [histogram2, histogram1])
-        self.assertEqual(histogram1, histograms.cross_partition_histogram)
-        self.assertEqual(histogram2, histograms.per_partition_histogram)
+        self.assertEqual(histogram1, histograms.l0_contributions_histogram)
+        self.assertEqual(histogram2, histograms.linf_contributions_histogram)
 
     @parameterized.named_parameters(
         dict(testcase_name='empty', input=[], expected=[]),
@@ -246,13 +246,13 @@ class ParameterTuning(parameterized.TestCase):
         histograms = histograms[0]
 
         self.assertEqual("CrossPartitionHistogram",
-                         histograms.cross_partition_histogram.name)
+                         histograms.l0_contributions_histogram.name)
         self.assertListEqual(expected_cross_partition,
-                             histograms.cross_partition_histogram.bins)
+                             histograms.l0_contributions_histogram.bins)
         self.assertEqual("PerPartitionHistogram",
-                         histograms.per_partition_histogram.name)
+                         histograms.linf_contributions_histogram.name)
         self.assertListEqual(expected_per_partition,
-                             histograms.per_partition_histogram.bins)
+                             histograms.linf_contributions_histogram.bins)
 
     @parameterized.named_parameters(
         dict(testcase_name='1 bins histogram',

--- a/utility_analysis_new/tests/histograms_test.py
+++ b/utility_analysis_new/tests/histograms_test.py
@@ -173,6 +173,94 @@ class ParameterTuning(parameterized.TestCase):
         self.assertListEqual(expected, histogram.bins)
 
     @parameterized.named_parameters(
+        dict(testcase_name='empty', input=[], expected=[]),
+        dict(
+            testcase_name='small_histogram',
+            input=[(1, 1), (1, 2), (2, 1), (1, 1)],  # (privacy_id, partition)
+            expected=[
+                FrequencyBin(lower=1, count=1, sum=1, max=1),
+                FrequencyBin(lower=3, count=1, sum=3, max=3)
+            ]),
+        dict(
+            testcase_name='Each privacy id, 1 contribution',
+            input=[(i, i) for i in range(100)],  # (privacy_id, partition)
+            expected=[
+                FrequencyBin(lower=1, count=100, sum=100, max=1),
+            ]),
+        dict(
+            testcase_name='1 privacy id many contributions to 1 partition',
+            input=[(0, 0)] * 100,  # (privacy_id, partition)
+            expected=[
+                FrequencyBin(lower=100, count=1, sum=100, max=100),
+            ]),
+        dict(
+            testcase_name='1 privacy id many contributions to many partitions',
+            input=[(0, i) for i in range(1234)],  # (privacy_id, partition)
+            expected=[
+                FrequencyBin(lower=1, count=1234, sum=1234, max=1),
+            ]),
+        dict(
+            testcase_name='2 privacy ids, same partitions contributed',
+            input=[(0, i) for i in range(15)] +
+            [(1, i) for i in range(10, 25)],  # (privacy_id, partition)
+            expected=[
+                FrequencyBin(lower=1, count=20, sum=20, max=1),
+                FrequencyBin(lower=2, count=5, sum=10, max=2),
+            ]),
+    )
+    def test_compute_partitions_count_histogram(self, input, expected):
+        histogram = hist._compute_partition_count_histogram(
+            input, pipeline_dp.LocalBackend())
+        histogram = list(histogram)[0]
+        self.assertEqual(hist.HistogramType.COUNT_PER_PARTITION, histogram.name)
+        self.assertListEqual(expected, histogram.bins)
+
+    @parameterized.named_parameters(
+        dict(testcase_name='empty', input=[], expected=[]),
+        dict(
+            testcase_name='small_histogram',
+            input=[(1, 1), (1, 2), (2, 1), (1, 1)],  # (privacy_id, partition)
+            expected=[
+                FrequencyBin(lower=1, count=1, sum=1, max=1),
+                FrequencyBin(lower=2, count=1, sum=2, max=2)
+            ]),
+        dict(
+            testcase_name='Each privacy id, 1 contribution',
+            input=[(i, i) for i in range(100)],  # (privacy_id, partition)
+            expected=[
+                FrequencyBin(lower=1, count=100, sum=100, max=1),
+            ]),
+        dict(
+            testcase_name='1 privacy id many contributions to 1 partition',
+            input=[(0, 0)] * 100,  # (privacy_id, partition)
+            expected=[
+                FrequencyBin(lower=1, count=1, sum=1, max=1),
+            ]),
+        dict(
+            testcase_name='1 privacy id many contributions to many partitions',
+            input=[(0, i) for i in range(1234)],  # (privacy_id, partition)
+            expected=[
+                FrequencyBin(lower=1, count=1234, sum=1234, max=1),
+            ]),
+        dict(
+            testcase_name='2 privacy ids, same partitions contributed',
+            input=[(0, i) for i in range(15)] +
+            [(1, i) for i in range(10, 25)],  # (privacy_id, partition)
+            expected=[
+                FrequencyBin(lower=1, count=20, sum=20, max=1),
+                FrequencyBin(lower=2, count=5, sum=10, max=2),
+            ]),
+    )
+    def test_compute_partitions_privacy_id_count_histogram(
+            self, input, expected):
+        histogram = hist._compute_partition_privacy_id_count_histogram(
+            input, pipeline_dp.LocalBackend())
+        histogram = list(histogram)[0]
+        self.assertEqual(hist.HistogramType.COUNT_PRIVACY_ID_PER_PARTITION,
+                         histogram.name)
+        self.assertListEqual(expected, histogram.bins)
+
+    @parameterized.named_parameters(
         dict(testcase_name='empty',
              input=[],
              expected_cross_partition=[],

--- a/utility_analysis_new/tests/parameter_tuning_test.py
+++ b/utility_analysis_new/tests/parameter_tuning_test.py
@@ -51,7 +51,7 @@ class ParameterTuning(parameterized.TestCase):
         mock_linf_histogram = histograms.Histogram(None, None)
         mock_linf_histogram.quantiles = mock.Mock(return_value=[3, 6, 6])
 
-        mock_histograms = histograms.ContributionHistograms(
+        mock_histograms = histograms.DatasetHistograms(
             mock_l0_histogram, mock_linf_histogram,
             histograms.Histogram(None, None), histograms.Histogram(None, None))
         parameters_to_tune = parameter_tuning.ParametersToTune(

--- a/utility_analysis_new/tests/parameter_tuning_test.py
+++ b/utility_analysis_new/tests/parameter_tuning_test.py
@@ -52,8 +52,7 @@ class ParameterTuning(parameterized.TestCase):
         mock_linf_histogram.quantiles = mock.Mock(return_value=[3, 6, 6])
 
         mock_histograms = histograms.DatasetHistograms(
-            mock_l0_histogram, mock_linf_histogram,
-            histograms.Histogram(None, None), histograms.Histogram(None, None))
+            mock_l0_histogram, mock_linf_histogram, None, None)
         parameters_to_tune = parameter_tuning.ParametersToTune(
             max_partitions_contributed=tune_max_partitions_contributed,
             max_contributions_per_partition=tune_max_contributions_per_partition

--- a/utility_analysis_new/tests/parameter_tuning_test.py
+++ b/utility_analysis_new/tests/parameter_tuning_test.py
@@ -51,8 +51,9 @@ class ParameterTuning(parameterized.TestCase):
         mock_linf_histogram = histograms.Histogram(None, None)
         mock_linf_histogram.quantiles = mock.Mock(return_value=[3, 6, 6])
 
-        mock_histograms = histograms.DatasetHistograms(
-            mock_l0_histogram, mock_linf_histogram, None, None)
+        mock_histograms = histograms.DatasetHistograms(mock_l0_histogram,
+                                                       mock_linf_histogram,
+                                                       None, None)
         parameters_to_tune = parameter_tuning.ParametersToTune(
             max_partitions_contributed=tune_max_partitions_contributed,
             max_contributions_per_partition=tune_max_contributions_per_partition

--- a/utility_analysis_new/tests/parameter_tuning_test.py
+++ b/utility_analysis_new/tests/parameter_tuning_test.py
@@ -52,7 +52,8 @@ class ParameterTuning(parameterized.TestCase):
         mock_linf_histogram.quantiles = mock.Mock(return_value=[3, 6, 6])
 
         mock_histograms = histograms.ContributionHistograms(
-            mock_l0_histogram, mock_linf_histogram)
+            mock_l0_histogram, mock_linf_histogram,
+            histograms.Histogram(None, None), histograms.Histogram(None, None))
         parameters_to_tune = parameter_tuning.ParametersToTune(
             max_partitions_contributed=tune_max_partitions_contributed,
             max_contributions_per_partition=tune_max_contributions_per_partition


### PR DESCRIPTION
This PR implements computing of histograms for `(partition_key, count)` (i.e. how many partitions have count=1, how many partitions have count=2, ... )   and `(partition_key, privacy_id_count)` (i.e. how many partitions have privacy_id_count=1, how many partitions have privacy_id_count=2, ... ).

Those are the same histograms which are used for computing cross and per partition contributions per privacy_id.

These histograms will be used in parameter tuning.