### PR TITLE
Return per partition utility analysis

### DIFF
--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -30,11 +30,11 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string('input_file', 'restaurants_week_data.csv',
                     'The file with the restaurant visits data')
 flags.DEFINE_string('output_file', None, 'Output file')
-flags.DEFINE_string('output_file_per_partition_analysis', None,
-                    'Output file for per partition example')
+flags.DEFINE_string(
+    'output_file_per_partition_analysis', None,
+    'If set, partition utility analysis is output to this file')
 flags.DEFINE_boolean('public_partitions', False,
                      'Whether public partitions are used')
-flags.DEFINE_boolean('return_utility_analysis_per_partition', False, 'If true')
 
 
 def write_to_file(col, filename):
@@ -98,7 +98,7 @@ def tune_parameters():
         aggregate_params=aggregate_params,
         function_to_minimize=minimizing_function,
         parameters_to_tune=parameters_to_tune)
-    if FLAGS.return_utility_analysis_per_partition:
+    if FLAGS.output_file_per_partition_analysis:
         result, per_partition = parameter_tuning.tune(restaurant_visits_rows,
                                                       backend, hist,
                                                       tune_options,

--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -30,8 +30,11 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string('input_file', 'restaurants_week_data.csv',
                     'The file with the restaurant visits data')
 flags.DEFINE_string('output_file', None, 'Output file')
+flags.DEFINE_string('output_file_per_partition_analysis', None,
+                    'Output file for per partition example')
 flags.DEFINE_boolean('public_partitions', False,
                      'Whether public partitions are used')
+flags.DEFINE_boolean('return_utility_analysis_per_partition', False, 'If true')
 
 
 def write_to_file(col, filename):
@@ -95,9 +98,17 @@ def tune_parameters():
         aggregate_params=aggregate_params,
         function_to_minimize=minimizing_function,
         parameters_to_tune=parameters_to_tune)
-    result = parameter_tuning.tune(restaurant_visits_rows, backend, hist,
-                                   tune_options, data_extractors,
-                                   public_partitions)
+    if FLAGS.return_utility_analysis_per_partition:
+        result, per_partition = parameter_tuning.tune(restaurant_visits_rows,
+                                                      backend, hist,
+                                                      tune_options,
+                                                      data_extractors,
+                                                      public_partitions, True)
+        write_to_file(per_partition, FLAGS.output_file_per_partition_analysis)
+    else:
+        result = parameter_tuning.tune(restaurant_visits_rows, backend, hist,
+                                       tune_options, data_extractors,
+                                       public_partitions, False)
 
     # Here's where the lazy iterator initiates computations and gets transformed
     # into actual results

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -171,7 +171,8 @@ def tune(col,
          contribution_histograms: histograms.ContributionHistograms,
          options: TuneOptions,
          data_extractors: pipeline_dp.DataExtractors,
-         public_partitions=None) -> TuneResult:
+         public_partitions=None,
+         return_utility_analysis_per_partition: bool = False) -> TuneResult:
     """Tunes parameters.
 
     It works in the following way:
@@ -196,6 +197,7 @@ def tune(col,
         public_partitions: A collection of partition keys that will be present
           in the result. If not provided, tuning will be performed assuming
           private partition selection is used.
+        return_utility_analysis_per_partition: todo
     Returns:
         1 element collection which contains TuneResult.
     """
@@ -209,15 +211,22 @@ def tune(col,
         options.delta,
         options.aggregate_params,
         multi_param_configuration=candidates)
-    utility_analysis_result = utility_analysis.perform_utility_analysis(
+    result = utility_analysis.perform_utility_analysis(
         col, backend, utility_analysis_options, data_extractors,
-        public_partitions)
+        public_partitions, return_utility_analysis_per_partition)
+    if return_utility_analysis_per_partition:
+        utility_analysis_result, utility_analysis_result_per_partition = result
+    else:
+        utility_analysis_result = result
     use_public_partitions = public_partitions is not None
-    return backend.map(
+    utility_analysis_result = backend.map(
         utility_analysis_result,
         lambda result: _convert_utility_analysis_to_tune_result(
             result, options, candidates, use_public_partitions,
             contribution_histograms), "To Tune result")
+    if return_utility_analysis_per_partition:
+        return utility_analysis_result, utility_analysis_result_per_partition
+    return utility_analysis_result
 
 
 def _check_tune_args(options: TuneOptions):

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -197,7 +197,8 @@ def tune(col,
         public_partitions: A collection of partition keys that will be present
           in the result. If not provided, tuning will be performed assuming
           private partition selection is used.
-        return_utility_analysis_per_partition: todo
+        return_per_partition: if true, it returns tuple, with the 2nd element
+          utility analysis per partitions.
     Returns:
         1 element collection which contains TuneResult.
     """

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -57,11 +57,12 @@ def perform_utility_analysis(col,
       backend: PipelineBackend with which the utility analysis will be run.
       options: options for utility analysis.
       data_extractors: functions that extract needed pieces of information
-            from elements of 'col'.
+        from elements of 'col'.
       public_partitions: A collection of partition keys that will be present
-            in the result. If not provided, the utility analysis with private
-            partition selection will be performed.
-      return_per_partition: todo
+        in the result. If not provided, the utility analysis with private
+        partition selection will be performed.
+      return_per_partition: if true, it returns tuple, with the 2nd element
+        utility analysis per partitions.
     Returns:
       1 element collection which contains utility analysis metrics.
     """


### PR DESCRIPTION
**Context:**
[`perform_utility_analysis`](https://github.com/OpenMined/PipelineDP/blob/b186cbdd2d7cc1794afe1b50be2f46a8cbdf8b12/utility_analysis_new/utility_analysis.py#L47)  the following way:
1. Errors per partitions are computed
2. Aggregated metrics from all partitions are computed

Now it returns only aggregated metrics. But sometimes errors per partitions are useful, for example for computing another aggregated metrics. This PR implements that
