### PR TITLE
Use float instead of np.float64

### DIFF
--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -243,7 +243,7 @@ class CountCombiner(UtilityAnalysisCombiner):
             count=count,
             per_partition_error=per_partition_error,
             expected_cross_partition_error=expected_cross_partition_error,
-            std_cross_partition_error=np.sqrt(var_cross_partition_error),
+            std_cross_partition_error=math.sqrt(var_cross_partition_error),
             std_noise=std_noise,
             noise_kind=self._params.aggregate_params.noise_kind)
 
@@ -297,7 +297,7 @@ class SumCombiner(UtilityAnalysisCombiner):
             per_partition_error_min=per_partition_error_min,
             per_partition_error_max=per_partition_error_max,
             expected_cross_partition_error=expected_cross_partition_error,
-            std_cross_partition_error=np.sqrt(var_cross_partition_error),
+            std_cross_partition_error=math.sqrt(var_cross_partition_error),
             std_noise=std_noise,
             noise_kind=self._params.aggregate_params.noise_kind)
 
@@ -508,13 +508,13 @@ class CountAggregateErrorMetricsCombiner(pipeline_dp.Combiner):
                 q=self._error_quantiles, loc=loc_cpe_ne, scale=std_cpe_ne)
         else:
             error_distribution_quantiles = probability_computations.compute_sum_laplace_gaussian_quantiles(
-                laplace_b=metrics.std_noise / np.sqrt(2),
+                laplace_b=metrics.std_noise / math.sqrt(2),
                 gaussian_sigma=metrics.std_cross_partition_error,
                 quantiles=self._error_quantiles,
                 num_samples=10**3)
         for quantile in error_distribution_quantiles:
             error_at_quantile = probability_to_keep * (
-                quantile + metrics.per_partition_error)
+                float(quantile) + metrics.per_partition_error)
             abs_error_quantiles.append(error_at_quantile)
 
         # Relative error metrics

--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -271,7 +271,7 @@ class SumCombiner(UtilityAnalysisCombiner):
                                   n_partitions) if n_partitions > 0 else 0
         per_partition_contribution = np.clip(
             partition_sum, self._params.aggregate_params.min_sum_per_partition,
-            self._params.aggregate_params.max_sum_per_partition)
+            self._params.aggregate_params.max_sum_per_partition).item()
         per_partition_error_min = 0
         per_partition_error_max = 0
         per_partition_error = partition_sum - per_partition_contribution


### PR DESCRIPTION
float takes less space when serializing, leading to performance improvements as data is passed around workers.