### PR TITLE
Run utility analysis on pre-aggregated data

### DIFF
--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -23,7 +23,6 @@ from absl import flags
 import pipeline_dp
 import pandas as pd
 import collections
-import itertools
 
 import utility_analysis_new
 from utility_analysis_new import histograms
@@ -106,7 +105,6 @@ def preaggregate(col: list, data_extractors: pipeline_dp.DataExtractors):
     backend = pipeline_dp.LocalBackend()
     col = backend.map(col, lambda x: (key_fn(x), x))
     res = list(backend.map(backend.group_by_key(col), preaggregate))
-    # res = list(map(preaggregate, pipeline_dp.(col, key_fn)))
     return res
 
 
@@ -121,6 +119,7 @@ def tune_parameters():
 
     hist = histograms.compute_dataset_histograms(restaurant_visits_rows,
                                                  data_extractors, backend)
+    # Hist is 1-element iterable and the single element is a computed histogram.
     hist = list(hist)[0]
 
     minimizing_function = parameter_tuning.MinimizingFunction.ABSOLUTE_ERROR

--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -85,10 +85,10 @@ def preaggregate(col: list, data_extractors: pipeline_dp.DataExtractors):
 
     The output is a collection with elements
     (partition_key, (count, sum, n_partitions)).
-    Each element corresponds to each (privacy_key, partition_key) which is
-    present in dataset. count and sum correspond to count and sum of values
-    which correspoinds to (privacy_key, partition_key). n_partitions is the
-    number of partitions which privacy_key contributes.
+    Each element corresponds to each (privacy_id, partition_key) which is
+    present in the dataset. count and sum correspond to count and sum of values
+    contributed by the privacy_key to the partition_key. n_partitions is the
+    number of partitions which privacy_id contributes.
     """
     pid_pk = set((data_extractors.privacy_id_extractor(row),
                   data_extractors.partition_extractor(row)) for row in col)
@@ -97,8 +97,8 @@ def preaggregate(col: list, data_extractors: pipeline_dp.DataExtractors):
     # (pid,)
     pid_n_partitions = collections.Counter(pid)
 
-    def preaggregate(pk_pid_rows):
-        """Aggregates per (partition_key, privacy_id)."""
+    def preaggregate_fn(pk_pid_rows):
+        """Aggregates rows per (partition_key, privacy_id)."""
         (pk, pid), rows = pk_pid_rows
         c = s = 0
         for row in rows:
@@ -110,7 +110,7 @@ def preaggregate(col: list, data_extractors: pipeline_dp.DataExtractors):
     key_fn = lambda row: (data_extractors.partition_extractor(row),
                           data_extractors.privacy_id_extractor(row))
     col = backend.map(col, lambda x: (key_fn(x), x))
-    res = list(backend.map(backend.group_by_key(col), preaggregate))
+    res = list(backend.map(backend.group_by_key(col), preaggregate_fn))
     return res
 
 

--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -103,7 +103,10 @@ def preaggregate(col: list, data_extractors: pipeline_dp.DataExtractors):
             s += data_extractors.value_extractor(v)
         return (pk, (c, s, pid_n_partitions[pid]))
 
-    res = list(map(preaggregate, itertools.groupby(col, key_fn)))
+    backend = pipeline_dp.LocalBackend()
+    col = backend.map(col, lambda x: (key_fn(x), x))
+    res = list(backend.map(backend.group_by_key(col), preaggregate))
+    # res = list(map(preaggregate, pipeline_dp.(col, key_fn)))
     return res
 
 

--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -101,7 +101,7 @@ def preaggregate(col: list, data_extractors: pipeline_dp.DataExtractors):
         for v in values:
             c += 1
             s += data_extractors.value_extractor(v)
-        return (c, s, pid_n_partitions[pid])
+        return (pk, (c, s, pid_n_partitions[pid]))
 
     res = list(map(preaggregate, itertools.groupby(col, key_fn)))
     return res

--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -97,8 +97,9 @@ def preaggregate(col: list, data_extractors: pipeline_dp.DataExtractors):
     # (pid,)
     pid_n_partitions = collections.Counter(pid)
 
-    def preaggregate(kv):
-        (pk, pid), rows = kv
+    def preaggregate(pk_pid_rows):
+        """Aggregates per (partition_key, privacy_id)."""
+        (pk, pid), rows = pk_pid_rows
         c = s = 0
         for row in rows:
             c += 1

--- a/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
+++ b/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
@@ -112,7 +112,7 @@ def per_partition_utility_analysis():
     data_extractors = get_data_extractors()
     public_partitions = list(range(1, 8)) if FLAGS.public_partitions else None
 
-    result = utility_analysis_engine.aggregate(
+    result = utility_analysis_engine.analyze(
         restaurant_visits_rows, aggregate_params, data_extractors,
         public_partitions, get_multi_params(),
         FLAGS.partition_sampling_probability)

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -117,12 +117,7 @@ class DPEngine:
             col = self._drop_not_public_partitions(col, public_partitions,
                                                    data_extractors)
         if not params.contribution_bounds_already_enforced:
-            # Extract the columns.
-            col = self._backend.map(
-                col, lambda row: (data_extractors.privacy_id_extractor(row),
-                                  data_extractors.partition_extractor(row),
-                                  data_extractors.value_extractor(row)),
-                "Extract (privacy_id, partition_key, value))")
+            col = self._extract_columns(col, data_extractors)
             # col : (privacy_id, partition_key, value)
             contribution_bounder = self._create_contribution_bounder(params)
             col = contribution_bounder.bound_contributions(
@@ -374,6 +369,14 @@ class DPEngine:
         else:
             return contribution_bounders.SamplingCrossAndPerPartitionContributionBounder(
             )
+
+    def _extract_columns(self, col, data_extractors: DataExtractors):
+        """todo"""
+        return self._backend.map(
+            col, lambda row: (data_extractors.privacy_id_extractor(row),
+                              data_extractors.partition_extractor(row),
+                              data_extractors.value_extractor(row)),
+            "Extract (privacy_id, partition_key, value))")
 
 
 def _check_aggregate_params(col, params: pipeline_dp.AggregateParams,

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -405,5 +405,5 @@ class DPEngine:
                     "contribution_bounds_already_enforced is False")
             if pipeline_dp.Metrics.PRIVACY_ID_COUNT in params.metrics:
                 raise ValueError(
-                    "PRIVACY_ID_COUNT can not be computed when "
+                    "PRIVACY_ID_COUNT cannot be computed when "
                     "contribution_bounds_already_enforced is True.")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -85,7 +85,7 @@ class DPEngine:
           Keys of 'result_dictionary' correspond to computed metrics, e.g.
           'count' for COUNT metrics etc.
         """
-        _check_aggregate_params(col, params, data_extractors)
+        self._check_aggregate_params(col, params, data_extractors)
 
         with self._budget_accountant.scope(weight=params.budget_weight):
             self._report_generators.append(
@@ -378,25 +378,32 @@ class DPEngine:
                               data_extractors.value_extractor(row)),
             "Extract (privacy_id, partition_key, value))")
 
-
-def _check_aggregate_params(col, params: pipeline_dp.AggregateParams,
-                            data_extractors: DataExtractors):
-    if params.max_contributions is not None:
-        raise NotImplementedError("max_contributions is not supported yet.")
-    if col is None or not col:
-        raise ValueError("col must be non-empty")
-    if params is None:
-        raise ValueError("params must be set to a valid AggregateParams")
-    if not isinstance(params, pipeline_dp.AggregateParams):
-        raise TypeError("params must be set to a valid AggregateParams")
-    if data_extractors is None:
-        raise ValueError("data_extractors must be set to a DataExtractors")
-    # if not isinstance(data_extractors, pipeline_dp.DataExtractors): todo
-    #     raise TypeError("data_extractors must be set to a DataExtractors")
-    if params.contribution_bounds_already_enforced:
-        if data_extractors.privacy_id_extractor:
-            raise ValueError("privacy_id_extractor should be set iff "
-                             "contribution_bounds_already_enforced is False")
-        if pipeline_dp.Metrics.PRIVACY_ID_COUNT in params.metrics:
-            raise ValueError("PRIVACY_ID_COUNT can not be computed when "
-                             "contribution_bounds_already_enforced is True.")
+    def _check_aggregate_params(self,
+                                col,
+                                params: pipeline_dp.AggregateParams,
+                                data_extractors: DataExtractors,
+                                check_data_extractors: bool = True):
+        if params.max_contributions is not None:
+            raise NotImplementedError("max_contributions is not supported yet.")
+        if col is None or not col:
+            raise ValueError("col must be non-empty")
+        if params is None:
+            raise ValueError("params must be set to a valid AggregateParams")
+        if not isinstance(params, pipeline_dp.AggregateParams):
+            raise TypeError("params must be set to a valid AggregateParams")
+        if check_data_extractors:
+            if data_extractors is None:
+                raise ValueError(
+                    "data_extractors must be set to a DataExtractors")
+            if not isinstance(data_extractors, pipeline_dp.DataExtractors):
+                raise TypeError(
+                    "data_extractors must be set to a DataExtractors")
+        if params.contribution_bounds_already_enforced:
+            if data_extractors.privacy_id_extractor:
+                raise ValueError(
+                    "privacy_id_extractor should be set iff "
+                    "contribution_bounds_already_enforced is False")
+            if pipeline_dp.Metrics.PRIVACY_ID_COUNT in params.metrics:
+                raise ValueError(
+                    "PRIVACY_ID_COUNT can not be computed when "
+                    "contribution_bounds_already_enforced is True.")

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -388,8 +388,8 @@ def _check_aggregate_params(col, params: pipeline_dp.AggregateParams,
         raise TypeError("params must be set to a valid AggregateParams")
     if data_extractors is None:
         raise ValueError("data_extractors must be set to a DataExtractors")
-    if not isinstance(data_extractors, pipeline_dp.DataExtractors):
-        raise TypeError("data_extractors must be set to a DataExtractors")
+    # if not isinstance(data_extractors, pipeline_dp.DataExtractors): todo
+    #     raise TypeError("data_extractors must be set to a DataExtractors")
     if params.contribution_bounds_already_enforced:
         if data_extractors.privacy_id_extractor:
             raise ValueError("privacy_id_extractor should be set iff "

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -371,7 +371,7 @@ class DPEngine:
             )
 
     def _extract_columns(self, col, data_extractors: DataExtractors):
-        """todo"""
+        """Extract columns using data_extractors."""
         return self._backend.map(
             col, lambda row: (data_extractors.privacy_id_extractor(row),
                               data_extractors.partition_extractor(row),

--- a/utility_analysis_new/__init__.py
+++ b/utility_analysis_new/__init__.py
@@ -23,4 +23,5 @@ from utility_analysis_new.parameter_tuning import TuneOptions
 from utility_analysis_new.parameter_tuning import TuneResult
 from utility_analysis_new.parameter_tuning import UtilityAnalysisRun
 from utility_analysis_new.utility_analysis import perform_utility_analysis
+from utility_analysis_new.utility_analysis import PreAggregateExtractors
 from utility_analysis_new.utility_analysis import UtilityAnalysisOptions

--- a/utility_analysis_new/__init__.py
+++ b/utility_analysis_new/__init__.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from utility_analysis_new.dp_engine import MultiParameterConfiguration
+from utility_analysis_new.data_structures import MultiParameterConfiguration
+from utility_analysis_new.data_structures import PreAggregateExtractors
+from utility_analysis_new.data_structures import UtilityAnalysisOptions
 from utility_analysis_new.histograms import compute_dataset_histograms
 from utility_analysis_new.histograms import DatasetHistograms
 from utility_analysis_new.metrics import AggregateMetrics
@@ -23,5 +25,3 @@ from utility_analysis_new.parameter_tuning import TuneOptions
 from utility_analysis_new.parameter_tuning import TuneResult
 from utility_analysis_new.parameter_tuning import UtilityAnalysisRun
 from utility_analysis_new.utility_analysis import perform_utility_analysis
-from utility_analysis_new.utility_analysis import PreAggregateExtractors
-from utility_analysis_new.utility_analysis import UtilityAnalysisOptions

--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -344,11 +344,9 @@ class CompoundCombiner(pipeline_dp.combiners.CompoundCombiner):
 
     def create_accumulator(self, data: Tuple[Sequence, int]) -> AccumulatorType:
         if not data:
-            # This is empty partition, added because of public partitions.
+            # This is an empty partition, added because of public partitions.
             return ([(0, 0, 0)], None)
-        values, n_partitions = data
-        sum_ = sum((v for v in values if v is not None))
-        return ([(len(values), sum_, n_partitions)], None)
+        return ([data], None)
 
     def _to_dense(self,
                   sparse_acc: SparseAccumulatorType) -> DenseAccumulatorType:

--- a/utility_analysis_new/combiners.py
+++ b/utility_analysis_new/combiners.py
@@ -344,7 +344,8 @@ class CompoundCombiner(pipeline_dp.combiners.CompoundCombiner):
 
     def create_accumulator(self, data: Tuple[Sequence, int]) -> AccumulatorType:
         if not data:
-            # This is an empty partition, added because of public partitions.
+            # This is an empty partition, what is None assigned to. It was added
+            # because of public partitions.
             return ([(0, 0, 0)], None)
         return ([data], None)
 

--- a/utility_analysis_new/contribution_bounders.py
+++ b/utility_analysis_new/contribution_bounders.py
@@ -85,4 +85,4 @@ class NoOpContributionBounder(contribution_bounders.ContributionBounder):
         return backend.map_tuple(
             col, lambda pk, val: ((None, pk), aggregate_fn(val)),
             "Apply aggregate_fn")
-        # ((privacy_id, privacy_key), accumulator)
+        # ((privacy_id, partition_key), accumulator)

--- a/utility_analysis_new/contribution_bounders.py
+++ b/utility_analysis_new/contribution_bounders.py
@@ -81,7 +81,7 @@ class NoOpContributionBounder(contribution_bounders.ContributionBounder):
                             aggregate_fn):
         """Returns a collection with element in the correct format."""
         # Dummy privacy_id = None is added, since the caller code expects that
-        # privacy id is available. TODO, maybe better solution?
+        # privacy id is available.
         return backend.map_tuple(
             col, lambda pk, val: ((None, pk), aggregate_fn(val)),
             "Apply aggregate_fn")

--- a/utility_analysis_new/contribution_bounders.py
+++ b/utility_analysis_new/contribution_bounders.py
@@ -79,6 +79,7 @@ class NoOpContributionBounder(contribution_bounders.ContributionBounder):
 
     def bound_contributions(self, col, params, backend, report_generator,
                             aggregate_fn):
+        """Returns a collection with element in the correct format."""
         # Dummy privacy_id = None is added, since the caller code expects that
         # privacy id is available. TODO, maybe better solution?
         return backend.map_tuple(

--- a/utility_analysis_new/contribution_bounders.py
+++ b/utility_analysis_new/contribution_bounders.py
@@ -38,6 +38,7 @@ class SamplingL0LinfContributionBounder(
     def bound_contributions(self, col, params, backend, report_generator,
                             aggregate_fn):
         """See docstrings for this class and the base class."""
+
         col = backend.map_tuple(
             col, lambda pid, pk, v: (pid, (pk, v)),
             "Rekey to ((privacy_id), (partition_key, value))")
@@ -63,7 +64,7 @@ class SamplingL0LinfContributionBounder(
             for partition_key, values in partition_values:
                 if sampler is not None and not sampler.keep(partition_key):
                     continue
-                yield (privacy_id, partition_key), (values,
+                yield (privacy_id, partition_key), (len(values), sum(values),
                                                     num_partitions_contributed)
 
         # Unnest the list per privacy id.
@@ -71,6 +72,16 @@ class SamplingL0LinfContributionBounder(
             col, rekey_per_privacy_id_per_partition_key_and_unnest,
             "Unnest per-privacy_id")
 
-        return backend.map_values(
-            col, aggregate_fn,
-            "Apply aggregate_fn with num_partitions_contributed as input")
+        return backend.map_values(col, aggregate_fn, "Apply aggregate_fn")
+
+
+class NoOpContributionBounder(contribution_bounders.ContributionBounder):
+
+    def bound_contributions(self, col, params, backend, report_generator,
+                            aggregate_fn):
+        # Dummy privacy_id = None is added, since the caller code expects that
+        # privacy id is available. TODO, maybe better solution?
+        return backend.map_tuple(
+            col, lambda pk, val: ((None, pk), aggregate_fn(val)),
+            "Apply aggregate_fn")
+        # ((privacy_id, privacy_key), accumulator)

--- a/utility_analysis_new/data_structures.py
+++ b/utility_analysis_new/data_structures.py
@@ -1,0 +1,119 @@
+# Copyright 2022 OpenMined.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""todo"""
+
+import copy
+import dataclasses
+from typing import Callable, Optional, Sequence
+
+import pipeline_dp
+from pipeline_dp import input_validators
+
+
+@dataclasses.dataclass
+class PreAggregateExtractors:
+    partition_extractor: Callable
+    preaggregate_extractor: Callable
+
+
+@dataclasses.dataclass
+class MultiParameterConfiguration:
+    """Specifies parameters for multi-parameter Utility Analysis.
+
+    All MultiParameterConfiguration attributes corresponds to attributes in
+    pipeline_dp.AggregateParams.
+
+    UtilityAnalysisEngine can perform utility analysis for multiple sets of
+    parameters simultaneously. API for this is the following:
+    1. Specify blue-print AggregateParams instance.
+    2. Set MultiParameterConfiguration attributes (see the example below). Note
+    that each attribute is a sequence of parameter values for which the utility
+    analysis will be run. All attributes that have non-None values must have
+    the same length.
+    3. Pass the created objects to UtilityAnalysisEngine.aggregate().
+
+    Example:
+        max_partitions_contributed = [1, 2]
+        max_contributions_per_partition = [10, 11]
+
+        Then the utility analysis will be performed for
+          AggregateParams(max_partitions_contributed=1, max_contributions_per_partition=10)
+          AggregateParams(max_partitions_contributed=2, max_contributions_per_partition=11)
+    """
+    max_partitions_contributed: Sequence[int] = None
+    max_contributions_per_partition: Sequence[int] = None
+    min_sum_per_partition: Sequence[float] = None
+    max_sum_per_partition: Sequence[float] = None
+
+    def __post_init__(self):
+        attributes = dataclasses.asdict(self)
+        sizes = [len(value) for value in attributes.values() if value]
+        if not sizes:
+            raise ValueError("MultiParameterConfiguration must have at least 1"
+                             " non-empty attribute.")
+        if min(sizes) != max(sizes):
+            raise ValueError(
+                "All set attributes in MultiParameterConfiguration must have "
+                "the same length.")
+        if (self.min_sum_per_partition is None) != (self.max_sum_per_partition
+                                                    is None):
+            raise ValueError(
+                "MultiParameterConfiguration: min_sum_per_partition and "
+                "max_sum_per_partition must be both set or both None.")
+        self._size = sizes[0]
+
+    @property
+    def size(self):
+        return self._size
+
+    def get_aggregate_params(self, params: pipeline_dp.AggregateParams,
+                             index: int) -> pipeline_dp.AggregateParams:
+        """Returns AggregateParams with the index-th parameters."""
+        params = copy.copy(params)
+        if self.max_partitions_contributed:
+            params.max_partitions_contributed = self.max_partitions_contributed[
+                index]
+        if self.max_contributions_per_partition:
+            params.max_contributions_per_partition = self.max_contributions_per_partition[
+                index]
+        if self.min_sum_per_partition:
+            params.min_sum_per_partition = self.min_sum_per_partition[index]
+        if self.max_sum_per_partition:
+            params.max_sum_per_partition = self.max_sum_per_partition[index]
+        return params
+
+
+@dataclasses.dataclass
+class UtilityAnalysisOptions:
+    """Options for the utility analysis."""
+    epsilon: float
+    delta: float
+    aggregate_params: pipeline_dp.AggregateParams
+    multi_param_configuration: Optional[MultiParameterConfiguration] = None
+    partitions_sampling_prob: float = 1
+    pre_aggregated_data: bool = False
+
+    def __post_init__(self):
+        input_validators.validate_epsilon_delta(self.epsilon, self.delta,
+                                                "UtilityAnalysisOptions")
+        if self.partitions_sampling_prob <= 0 or self.partitions_sampling_prob > 1:
+            raise ValueError(
+                f"partitions_sampling_prob must be in the interval"
+                f" (0, 1], but {self.partitions_sampling_prob} given.")
+
+    @property
+    def n_configurations(self):
+        if self.multi_param_configuration is None:
+            return 1
+        return self.multi_param_configuration.size

--- a/utility_analysis_new/dp_engine.py
+++ b/utility_analysis_new/dp_engine.py
@@ -12,90 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """DPEngine for utility analysis."""
-import copy
-import dataclasses
-from typing import Callable, Iterable, Optional, Sequence, Union
+from typing import Iterable, Union
 
 import pipeline_dp
 from pipeline_dp import budget_accounting
 from pipeline_dp import combiners
 from pipeline_dp import contribution_bounders
 from pipeline_dp import pipeline_backend
+import utility_analysis_new
 import utility_analysis_new.contribution_bounders as utility_contribution_bounders
 import utility_analysis_new.combiners as utility_analysis_combiners
-
-
-@dataclasses.dataclass
-class PreAggregateExtractors:
-    partition_extractor: Callable
-    preaggregate_extractor: Callable
-
-
-@dataclasses.dataclass
-class MultiParameterConfiguration:
-    """Specifies parameters for multi-parameter Utility Analysis.
-
-    All MultiParameterConfiguration attributes corresponds to attributes in
-    pipeline_dp.AggregateParams.
-
-    UtilityAnalysisEngine can perform utility analysis for multiple sets of
-    parameters simultaneously. API for this is the following:
-    1. Specify blue-print AggregateParams instance.
-    2. Set MultiParameterConfiguration attributes (see the example below). Note
-    that each attribute is a sequence of parameter values for which the utility
-    analysis will be run. All attributes that have non-None values must have
-    the same length.
-    3. Pass the created objects to UtilityAnalysisEngine.aggregate().
-
-    Example:
-        max_partitions_contributed = [1, 2]
-        max_contributions_per_partition = [10, 11]
-
-        Then the utility analysis will be performed for
-          AggregateParams(max_partitions_contributed=1, max_contributions_per_partition=10)
-          AggregateParams(max_partitions_contributed=2, max_contributions_per_partition=11)
-    """
-    max_partitions_contributed: Sequence[int] = None
-    max_contributions_per_partition: Sequence[int] = None
-    min_sum_per_partition: Sequence[float] = None
-    max_sum_per_partition: Sequence[float] = None
-
-    def __post_init__(self):
-        attributes = dataclasses.asdict(self)
-        sizes = [len(value) for value in attributes.values() if value]
-        if not sizes:
-            raise ValueError("MultiParameterConfiguration must have at least 1"
-                             " non-empty attribute.")
-        if min(sizes) != max(sizes):
-            raise ValueError(
-                "All set attributes in MultiParameterConfiguration must have "
-                "the same length.")
-        if (self.min_sum_per_partition is None) != (self.max_sum_per_partition
-                                                    is None):
-            raise ValueError(
-                "MultiParameterConfiguration: min_sum_per_partition and "
-                "max_sum_per_partition must be both set or both None.")
-        self._size = sizes[0]
-
-    @property
-    def size(self):
-        return self._size
-
-    def get_aggregate_params(self, params: pipeline_dp.AggregateParams,
-                             index: int) -> pipeline_dp.AggregateParams:
-        """Returns AggregateParams with the index-th parameters."""
-        params = copy.copy(params)
-        if self.max_partitions_contributed:
-            params.max_partitions_contributed = self.max_partitions_contributed[
-                index]
-        if self.max_contributions_per_partition:
-            params.max_contributions_per_partition = self.max_contributions_per_partition[
-                index]
-        if self.min_sum_per_partition:
-            params.min_sum_per_partition = self.min_sum_per_partition[index]
-        if self.max_sum_per_partition:
-            params.max_sum_per_partition = self.max_sum_per_partition[index]
-        return params
 
 
 class UtilityAnalysisEngine(pipeline_dp.DPEngine):
@@ -107,46 +33,35 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
         self._is_public_partitions = None
         self._sampling_probability = 1.0
 
-    def analyze(self,
-                col,
-                params: pipeline_dp.AggregateParams,
-                data_extractors: Union[pipeline_dp.DataExtractors,
-                                       PreAggregateExtractors],
-                public_partitions=None,
-                multi_param_configuration: Optional[
-                    MultiParameterConfiguration] = None,
-                partitions_sampling_prob: float = 1.0):
+    def analyze(
+            self,
+            col,
+            options: utility_analysis_new.UtilityAnalysisOptions,
+            data_extractors: Union[pipeline_dp.DataExtractors,
+                                   utility_analysis_new.PreAggregateExtractors],
+            public_partitions=None):
         """Performs utility analysis for DP aggregations per partition.
 
         Args:
           col: collection where all elements are of the same type.
-          params: specifies which metrics to compute and computation parameters.
+          options: options for utility analysis.
           data_extractors: functions that extract needed pieces of information
             from elements of 'col'.
           public_partitions: A collection of partition keys that will be present
             in the result. If not provided, the utility analysis with private
             partition selection will be performed.
-          multi_param_configuration: if provided the utility analysis for
-            multiple parameters will be performed: 'params' is used as
-            blue-print and non-None attributes from 'multi_param_configuration'
-            are used for creating multiple AggregateParams. See docstring for
-            MultiParameterConfiguration for more details.
-          partitions_sampling_prob: todo
 
         Returns:
             A collection with elements (pk, utility analysis metrics).
         """
-        _check_utility_analysis_params(params, public_partitions)
+        _check_utility_analysis_params(options.aggregate_params,
+                                       public_partitions)  # todo
         self._is_public_partitions = public_partitions is not None
-        self._multi_run_configuration = multi_param_configuration
-        self._sampling_probability = partitions_sampling_prob
-        self._is_aggregated_data = True
-        result = super().aggregate(col, params, data_extractors,
-                                   public_partitions)
+        self._options = options
+        result = super().aggregate(col, options.aggregate_params,
+                                   data_extractors, public_partitions)
         self._is_public_partitions = None
-        self._multi_run_configuration = None
-        self._sampling_probability = 1.0
-        self._is_aggregated_data = False
+        self._options = None
         return result
 
     def _create_contribution_bounder(
@@ -192,12 +107,12 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
     def _get_aggregate_params(
         self, params: pipeline_dp.AggregateParams
     ) -> Iterable[pipeline_dp.AggregateParams]:
-        if self._multi_run_configuration is None:
+        multi_run_configuration = self._options.multi_param_configuration
+        if multi_run_configuration is None:
             yield params
         else:
-            for i in range(self._multi_run_configuration.size):
-                yield self._multi_run_configuration.get_aggregate_params(
-                    params, i)
+            for i in range(multi_run_configuration.size):
+                yield multi_run_configuration.get_aggregate_params(params, i)
 
     def _select_private_partitions_internal(
             self, col, max_partitions_contributed: int,

--- a/utility_analysis_new/dp_engine.py
+++ b/utility_analysis_new/dp_engine.py
@@ -14,7 +14,7 @@
 """DPEngine for utility analysis."""
 import copy
 import dataclasses
-from typing import Iterable, Optional, Sequence
+from typing import Callable, Iterable, Optional, Sequence, Union
 
 import pipeline_dp
 from pipeline_dp import budget_accounting
@@ -23,6 +23,12 @@ from pipeline_dp import contribution_bounders
 from pipeline_dp import pipeline_backend
 import utility_analysis_new.contribution_bounders as utility_contribution_bounders
 import utility_analysis_new.combiners as utility_analysis_combiners
+
+
+@dataclasses.dataclass
+class PreAggregateExtractors:
+    partition_extractor: Callable
+    preaggregate_extractor: Callable
 
 
 @dataclasses.dataclass
@@ -104,7 +110,8 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
     def analyze(self,
                 col,
                 params: pipeline_dp.AggregateParams,
-                data_extractors: pipeline_dp.DataExtractors,
+                data_extractors: Union[pipeline_dp.DataExtractors,
+                                       PreAggregateExtractors],
                 public_partitions=None,
                 multi_param_configuration: Optional[
                     MultiParameterConfiguration] = None,

--- a/utility_analysis_new/dp_engine.py
+++ b/utility_analysis_new/dp_engine.py
@@ -151,7 +151,7 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
         self, col,
         data_extractors: Union[pipeline_dp.DataExtractors,
                                utility_analysis_new.PreAggregateExtractors]):
-        """todo"""
+        """Extract columns using data_extractors."""
         if self._options.pre_aggregated_data:
             # todo: check data_extractors is PreAggregateExtractors
             return self._backend.map(

--- a/utility_analysis_new/dp_engine.py
+++ b/utility_analysis_new/dp_engine.py
@@ -101,14 +101,14 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
         self._is_public_partitions = None
         self._sampling_probability = 1.0
 
-    def aggregate(self,
-                  col,
-                  params: pipeline_dp.AggregateParams,
-                  data_extractors: pipeline_dp.DataExtractors,
-                  public_partitions=None,
-                  multi_param_configuration: Optional[
-                      MultiParameterConfiguration] = None,
-                  partitions_sampling_prob: float = 1.0):
+    def analyze(self,
+                col,
+                params: pipeline_dp.AggregateParams,
+                data_extractors: pipeline_dp.DataExtractors,
+                public_partitions=None,
+                multi_param_configuration: Optional[
+                    MultiParameterConfiguration] = None,
+                partitions_sampling_prob: float = 1.0):
         """Performs utility analysis for DP aggregations per partition.
 
         Args:
@@ -133,11 +133,13 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
         self._is_public_partitions = public_partitions is not None
         self._multi_run_configuration = multi_param_configuration
         self._sampling_probability = partitions_sampling_prob
+        self._is_aggregated_data = True
         result = super().aggregate(col, params, data_extractors,
                                    public_partitions)
         self._is_public_partitions = None
         self._multi_run_configuration = None
         self._sampling_probability = 1.0
+        self._is_aggregated_data = False
         return result
 
     def _create_contribution_bounder(

--- a/utility_analysis_new/dp_engine.py
+++ b/utility_analysis_new/dp_engine.py
@@ -164,8 +164,8 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
         self, col, params: pipeline_dp.AggregateParams,
         data_extractors: Union[pipeline_dp.DataExtractors,
                                utility_analysis_new.PreAggregateExtractors]):
-        # Do not check data_extractors. It is already checked in the base class
-        # does not support PreAggregateExtractors.
+        # Do not check data_extractors. The parent implementation does not
+        # support PreAggregateExtractors.
         super()._check_aggregate_params(col,
                                         params,
                                         data_extractors=None,
@@ -181,8 +181,9 @@ def _check_utility_analysis_params(
         if not isinstance(data_extractors,
                           utility_analysis_new.PreAggregateExtractors):
             raise ValueError(
-                "utility_analysis_new.PreAggregateExtractors should be specified for pre-aggregated data."
-            )
+                "options.pre_aggregated_data is set to true but "
+                "PreAggregateExtractors aren't provided. PreAggregateExtractors"
+                " should be specified for pre-aggregated data.")
     elif not isinstance(data_extractors, pipeline_dp.DataExtractors):
         raise ValueError(
             "pipeline_dp.DataExtractors should be specified for raw data.")

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -66,8 +66,12 @@ class TuneOptions:
         function_to_minimize: which function of the error to minimize. In case
           if this argument is a callable, it should take 1 argument of type
           AggregateErrorMetrics and return float.
-        partitions_sampling_prob: todo
         parameters_to_tune: specifies which parameters to tune.
+        partitions_sampling_prob: the probability with which each partition
+        will be sampled before running tuning. It is useful for speed-up
+        computations on the large dataset.
+        pre_aggregated_data: when True the input data is already pre-aggregated,
+        otherwise the input data are raw.
     """
     epsilon: float
     delta: float

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -30,7 +30,7 @@ import numpy as np
 
 @dataclass
 class UtilityAnalysisRun:
-    params: utility_analysis.UtilityAnalysisOptions
+    params: utility_analysis_new.UtilityAnalysisOptions
     result: metrics.AggregateErrorMetrics
 
 
@@ -99,14 +99,14 @@ class TuneResult:
     """
     options: TuneOptions
     contribution_histograms: histograms.DatasetHistograms
-    utility_analysis_parameters: utility_analysis_new.dp_engine.MultiParameterConfiguration
+    utility_analysis_parameters: utility_analysis_new.MultiParameterConfiguration
     index_best: int
     utility_analysis_results: List[metrics.AggregateMetrics]
 
 
 def _find_candidate_parameters(
     hist: histograms.DatasetHistograms, parameters_to_tune: ParametersToTune
-) -> utility_analysis_new.dp_engine.MultiParameterConfiguration:
+) -> utility_analysis_new.MultiParameterConfiguration:
     """Uses some heuristics to find (hopefully) good enough parameters."""
     # TODO: decide where to put QUANTILES_TO_USE, maybe TuneOptions?
     QUANTILES_TO_USE = [0.9, 0.95, 0.98, 0.99, 0.995]
@@ -140,15 +140,15 @@ def _find_candidate_parameters(
     else:
         assert False, "Nothing to tune."
 
-    return utility_analysis_new.dp_engine.MultiParameterConfiguration(
+    return utility_analysis_new.MultiParameterConfiguration(
         max_partitions_contributed=l0_bounds,
         max_contributions_per_partition=linf_bounds)
 
 
 def _convert_utility_analysis_to_tune_result(
         utility_analysis_result: Tuple, tune_options: TuneOptions,
-        run_configurations: utility_analysis_new.dp_engine.
-    MultiParameterConfiguration, use_public_partitions: bool,
+        run_configurations: utility_analysis_new.MultiParameterConfiguration,
+        use_public_partitions: bool,
         contribution_histograms: histograms.DatasetHistograms) -> TuneResult:
     assert len(utility_analysis_result) == run_configurations.size
     # TODO(dvadym): implement relative error.
@@ -205,7 +205,7 @@ def tune(col,
     candidates = _find_candidate_parameters(contribution_histograms,
                                             options.parameters_to_tune)
 
-    utility_analysis_options = utility_analysis.UtilityAnalysisOptions(
+    utility_analysis_options = utility_analysis_new.UtilityAnalysisOptions(
         options.epsilon,
         options.delta,
         options.aggregate_params,

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -71,7 +71,8 @@ class TuneOptions:
         will be sampled before running tuning. It is useful for speed-up
         computations on the large dataset.
         pre_aggregated_data: when True the input data is already pre-aggregated,
-        otherwise the input data are raw.
+        otherwise the input data are raw. Preaggregated data also can be
+        sampled.
     """
     epsilon: float
     delta: float

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -69,7 +69,7 @@ class TuneOptions:
         parameters_to_tune: specifies which parameters to tune.
         partitions_sampling_prob: the probability with which each partition
         will be sampled before running tuning. It is useful for speed-up
-        computations on the large dataset.
+        computations on the large datasets.
         pre_aggregated_data: when True the input data is already pre-aggregated,
         otherwise the input data are raw. Preaggregated data also can be
         sampled.

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -197,7 +197,9 @@ def tune(col,
          computed with compute_contribution_histograms().
         options: options for tuning.
         data_extractors: functions that extract needed pieces of information
-          from elements of 'col'.
+          from elements of 'col'. In case if the analysis performed on
+          pre-aggregated data, it should have type PreAggregateExtractors
+          otherwise DataExtractors.
         public_partitions: A collection of partition keys that will be present
           in the result. If not provided, tuning will be performed assuming
           private partition selection is used.

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -167,7 +167,8 @@ def tune(col,
          backend: pipeline_backend.PipelineBackend,
          contribution_histograms: histograms.DatasetHistograms,
          options: TuneOptions,
-         data_extractors: pipeline_dp.DataExtractors,
+         data_extractors: Union[pipeline_dp.DataExtractors,
+                                utility_analysis_new.PreAggregateExtractors],
          public_partitions=None,
          return_utility_analysis_per_partition: bool = False) -> TuneResult:
     """Tunes parameters.

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -74,6 +74,7 @@ class TuneOptions:
     aggregate_params: pipeline_dp.AggregateParams
     function_to_minimize: Union[MinimizingFunction, Callable]
     parameters_to_tune: ParametersToTune
+    pre_aggregated_data: bool = False
 
     def __post_init__(self):
         input_validators.validate_epsilon_delta(self.epsilon, self.delta,

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -67,6 +67,7 @@ class TuneOptions:
         function_to_minimize: which function of the error to minimize. In case
           if this argument is a callable, it should take 1 argument of type
           AggregateErrorMetrics and return float.
+        partitions_sampling_prob: todo
         parameters_to_tune: specifies which parameters to tune.
     """
     epsilon: float
@@ -74,6 +75,7 @@ class TuneOptions:
     aggregate_params: pipeline_dp.AggregateParams
     function_to_minimize: Union[MinimizingFunction, Callable]
     parameters_to_tune: ParametersToTune
+    partitions_sampling_prob: float = 1
     pre_aggregated_data: bool = False
 
     def __post_init__(self):
@@ -206,10 +208,12 @@ def tune(col,
                                             options.parameters_to_tune)
 
     utility_analysis_options = utility_analysis_new.UtilityAnalysisOptions(
-        options.epsilon,
-        options.delta,
-        options.aggregate_params,
-        multi_param_configuration=candidates)
+        epsilon=options.epsilon,
+        delta=options.delta,
+        aggregate_params=options.aggregate_params,
+        multi_param_configuration=candidates,
+        partitions_sampling_prob=options.partitions_sampling_prob,
+        pre_aggregated_data=options.pre_aggregated_data)
     result = utility_analysis.perform_utility_analysis(
         col, backend, utility_analysis_options, data_extractors,
         public_partitions, return_utility_analysis_per_partition)

--- a/utility_analysis_new/tests/combiners_test.py
+++ b/utility_analysis_new/tests/combiners_test.py
@@ -436,7 +436,8 @@ class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
         combiner = self._create_combiner()
         data = [1, 2, 3]
         n_partitions = 500
-        sparse, dense = combiner.create_accumulator((data, n_partitions))
+        sparse, dense = combiner.create_accumulator(
+            (len(data), sum(data), n_partitions))
         self.assertEqual(sparse, [(len(data), sum(data), n_partitions)])
         self.assertIsNone(dense)
 
@@ -514,7 +515,9 @@ class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
     def test_compute_metrics(self, num_partitions, contribution_values,
                              expected_metrics):
         combiner = self._create_combiner()
-        acc = combiner.create_accumulator((contribution_values, num_partitions))
+        acc = combiner.create_accumulator(
+            (len(contribution_values), sum(contribution_values),
+             num_partitions))
         self.assertEqual(expected_metrics, combiner.compute_metrics(acc)[0])
 
     def test_two_internal_combiners(self):
@@ -526,7 +529,7 @@ class UtilityAnalysisCompoundCombinerTest(parameterized.TestCase):
                                               return_named_tuple=False)
 
         data, n_partitions = [1, 2, 3], 100
-        acc = combiner.create_accumulator((data, n_partitions))
+        acc = combiner.create_accumulator((len(data), sum(data), n_partitions))
 
         acc = combiner.merge_accumulators(acc, acc)
         self.assertEqual(([(3, 6, 100), (3, 6, 100)], None), acc)

--- a/utility_analysis_new/tests/contribution_bounders_test.py
+++ b/utility_analysis_new/tests/contribution_bounders_test.py
@@ -26,8 +26,8 @@ CrossAndPerPartitionContributionParams = collections.namedtuple(
     "CrossAndPerPartitionContributionParams",
     ["max_partitions_contributed", "max_contributions_per_partition"])
 
-# input_values is a tuple (value, num_partitions_contributed)
-aggregate_fn = lambda input_value: len(input_value[0])
+# input_values is a tuple (count, sum, num_partitions_contributed)
+aggregate_fn = lambda input_value: input_value[0]
 
 
 def _create_report_generator():
@@ -116,6 +116,21 @@ class SamplingL0LinfContributionBounderTest(parameterized.TestCase):
                            (('pid1', 'pk4'), 1)]
         # Check per- and cross-partition contribution limits are not enforced.
         self.assertEqual(set(expected_result), set(bound_result))
+
+
+class SamplingL0LinfContributionBounderTest(parameterized.TestCase):
+
+    def test_contribution_bounding(self):
+        input = [('pk1', (1, 2, 3)), ('pk2', (2, 3, 4)), ('pk1', (10, 11, 12)),
+                 ("pk3", (100, 101, 102))]
+
+        bounder = contribution_bounders.NoOpContributionBounder()
+        bound_result = list(
+            bounder.bound_contributions(input, None, pipeline_dp.LocalBackend(),
+                                        None, aggregate_fn))
+        expected_result = [((None, 'pk1'), 1), ((None, 'pk2'), 2),
+                           ((None, 'pk1'), 10), ((None, 'pk3'), 100)]
+        self.assertSequenceEqual(set(expected_result), set(bound_result))
 
 
 if __name__ == '__main__':

--- a/utility_analysis_new/tests/contribution_bounders_test.py
+++ b/utility_analysis_new/tests/contribution_bounders_test.py
@@ -27,7 +27,7 @@ CrossAndPerPartitionContributionParams = collections.namedtuple(
     ["max_partitions_contributed", "max_contributions_per_partition"])
 
 # input_values is a tuple (count, sum, num_partitions_contributed)
-aggregate_fn = lambda input_value: input_value[0]
+count_aggregate_fn = lambda input_value: input_value[0]  # returns count
 
 
 def _create_report_generator():
@@ -50,7 +50,7 @@ class SamplingL0LinfContributionBounderTest(parameterized.TestCase):
             bounder.bound_contributions(input, params,
                                         pipeline_dp.LocalBackend(),
                                         _create_report_generator(),
-                                        aggregate_fn))
+                                        count_aggregate_fn))
 
     def test_contribution_bounding_empty_col(self):
         input = []
@@ -121,13 +121,21 @@ class SamplingL0LinfContributionBounderTest(parameterized.TestCase):
 class SamplingL0LinfContributionBounderTest(parameterized.TestCase):
 
     def test_contribution_bounding(self):
+        # Arrange.
+        # input has format (partition_key, (count, sum, num_partitions_contributed)).
         input = [('pk1', (1, 2, 3)), ('pk2', (2, 3, 4)), ('pk1', (10, 11, 12)),
                  ("pk3", (100, 101, 102))]
-
         bounder = contribution_bounders.NoOpContributionBounder()
+
+        # Act.
         bound_result = list(
-            bounder.bound_contributions(input, None, pipeline_dp.LocalBackend(),
-                                        None, aggregate_fn))
+            bounder.bound_contributions(input,
+                                        params=None,
+                                        backend=pipeline_dp.LocalBackend(),
+                                        report_generator=None,
+                                        aggregate_fn=count_aggregate_fn))
+
+        # Assert.
         expected_result = [((None, 'pk1'), 1), ((None, 'pk2'), 2),
                            ((None, 'pk1'), 10), ((None, 'pk3'), 100)]
         self.assertSequenceEqual(set(expected_result), set(bound_result))

--- a/utility_analysis_new/tests/contribution_bounders_test.py
+++ b/utility_analysis_new/tests/contribution_bounders_test.py
@@ -120,7 +120,7 @@ class SamplingL0LinfContributionBounderTest(parameterized.TestCase):
 
 class SamplingL0LinfContributionBounderTest(parameterized.TestCase):
 
-    def test_contribution_bounding(self):
+    def test_contribution_bounding_doesnt_drop_contributions(self):
         # Arrange.
         # input has format (partition_key, (count, sum, num_partitions_contributed)).
         input = [('pk1', (1, 2, 3)), ('pk2', (2, 3, 4)), ('pk1', (10, 11, 12)),

--- a/utility_analysis_new/tests/dp_engine_test.py
+++ b/utility_analysis_new/tests/dp_engine_test.py
@@ -143,7 +143,7 @@ class DpEngine(parameterized.TestCase):
                     backend=pipeline_dp.LocalBackend())
                 col = [0, 1, 2]
                 engine.analyze(col,
-                               test_case["params"],
+                               options,
                                test_case["data_extractor"],
                                public_partitions=test_case["public_partitions"])
 
@@ -162,7 +162,7 @@ class DpEngine(parameterized.TestCase):
         data_extractor = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x,
             partition_extractor=lambda x: f"pk{x}",
-            value_extractor=lambda x: None)
+            value_extractor=lambda x: 0)
 
         engine = dp_engine.UtilityAnalysisEngine(
             budget_accountant=budget_accountant,
@@ -199,7 +199,7 @@ class DpEngine(parameterized.TestCase):
         data_extractors = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x[0],
             partition_extractor=lambda x: f"pk{x[1]}",
-            value_extractor=lambda x: None)
+            value_extractor=lambda x: 0)
 
         engine = dp_engine.UtilityAnalysisEngine(
             budget_accountant=budget_accountant,
@@ -258,7 +258,7 @@ class DpEngine(parameterized.TestCase):
         data_extractors = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x[0],
             partition_extractor=lambda x: x[1],
-            value_extractor=lambda x: None)
+            value_extractor=lambda x: 0)
 
         public_partitions = ["pk0", "pk1"]
 

--- a/utility_analysis_new/tests/dp_engine_test.py
+++ b/utility_analysis_new/tests/dp_engine_test.py
@@ -140,11 +140,10 @@ class DpEngine(parameterized.TestCase):
                     budget_accountant=budget_accountant,
                     backend=pipeline_dp.LocalBackend())
                 col = [0, 1, 2]
-                engine.aggregate(
-                    col,
-                    test_case["params"],
-                    test_case["data_extractor"],
-                    public_partitions=test_case["public_partitions"])
+                engine.analyze(col,
+                               test_case["params"],
+                               test_case["data_extractor"],
+                               public_partitions=test_case["public_partitions"])
 
     def test_aggregate_public_partition_e2e(self):
         # Arrange
@@ -167,10 +166,10 @@ class DpEngine(parameterized.TestCase):
             budget_accountant=budget_accountant,
             backend=pipeline_dp.LocalBackend())
 
-        col = engine.aggregate(col=col,
-                               params=aggregator_params,
-                               data_extractors=data_extractor,
-                               public_partitions=public_partitions)
+        col = engine.analyze(col=col,
+                             params=aggregator_params,
+                             data_extractors=data_extractor,
+                             public_partitions=public_partitions)
         budget_accountant.compute_budgets()
 
         col = list(col)
@@ -202,9 +201,9 @@ class DpEngine(parameterized.TestCase):
             budget_accountant=budget_accountant,
             backend=pipeline_dp.LocalBackend())
 
-        col = engine.aggregate(col=col,
-                               params=aggregator_params,
-                               data_extractors=data_extractor)
+        col = engine.analyze(col=col,
+                             params=aggregator_params,
+                             data_extractors=data_extractor)
         budget_accountant.compute_budgets()
 
         col = list(col)
@@ -257,11 +256,11 @@ class DpEngine(parameterized.TestCase):
 
         public_partitions = ["pk0", "pk1"]
 
-        output = engine.aggregate(input,
-                                  aggregate_params,
-                                  data_extractors,
-                                  public_partitions=public_partitions,
-                                  multi_param_configuration=multi_param)
+        output = engine.analyze(input,
+                                aggregate_params,
+                                data_extractors,
+                                public_partitions=public_partitions,
+                                multi_param_configuration=multi_param)
         budget_accountant.compute_budgets()
 
         output = list(output)
@@ -320,10 +319,10 @@ class DpEngine(parameterized.TestCase):
             backend=pipeline_dp.LocalBackend())
 
         partitions_sampling_prob = 0.25
-        engine.aggregate(col=[1, 2, 3],
-                         params=aggregator_params,
-                         data_extractors=data_extractor,
-                         partitions_sampling_prob=partitions_sampling_prob)
+        engine.analyze(col=[1, 2, 3],
+                       params=aggregator_params,
+                       data_extractors=data_extractor,
+                       partitions_sampling_prob=partitions_sampling_prob)
         mock_sampler_init.assert_called_once_with(partitions_sampling_prob)
 
 

--- a/utility_analysis_new/tests/dp_engine_test.py
+++ b/utility_analysis_new/tests/dp_engine_test.py
@@ -106,6 +106,7 @@ class UtilityAnalysisEngineTest(parameterized.TestCase):
             max_contributions_per_partition=1)
 
     def test_invalid_utility_analysis_params_throws_exception(self):
+        # Arrange.
         default_extractors = self._get_default_extractors()
         default_params = self._get_default_aggregate_params()
         params_with_custom_combiners = copy.copy(default_params)
@@ -157,6 +158,7 @@ class UtilityAnalysisEngineTest(parameterized.TestCase):
             engine = dp_engine.UtilityAnalysisEngine(
                 budget_accountant=budget_accountant,
                 backend=pipeline_dp.LocalBackend())
+            # Act and assert.
             with self.assertRaisesRegex(
                     Exception, expected_regex=test_case["error_message"]):
                 engine.analyze([0, 1, 2],

--- a/utility_analysis_new/tests/utility_analysis_test.py
+++ b/utility_analysis_new/tests/utility_analysis_test.py
@@ -17,7 +17,6 @@ from absl.testing import parameterized
 
 import pipeline_dp
 import utility_analysis_new
-from utility_analysis_new import utility_analysis
 
 
 class UtilityAnalysis(parameterized.TestCase):
@@ -29,7 +28,8 @@ class UtilityAnalysis(parameterized.TestCase):
             value_extractor=lambda x: x,
         )
 
-    def test_wo_public_partitions(self):
+    @parameterized.parameters(False, True)
+    def test_wo_public_partitions(self, pre_aggregated: bool):
         # Arrange
         aggregate_params = pipeline_dp.AggregateParams(
             noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
@@ -41,17 +41,33 @@ class UtilityAnalysis(parameterized.TestCase):
 
         # Input collection has 10 privacy ids where each privacy id
         # contributes to the same 10 partitions, three times in each partition.
-        col = [(i, j) for i in range(10) for j in range(10)] * 3
-        data_extractors = pipeline_dp.DataExtractors(
-            privacy_id_extractor=lambda x: x[0],
-            partition_extractor=lambda x: f"pk{x[1]}",
-            value_extractor=lambda x: 0)
+        if not pre_aggregated:
+            col = [(i, j) for i in range(10) for j in range(10)] * 3
+        else:
+            # This is pre-agregated dataset, namely each element has a format
+            # (partition_key, (count, sum, num_partition_contributed).
+            # And each element is in one-to-one correspondence to pairs
+            # (privacy_id, partition_key) from the dataset.
+            col = [(i, (3, 0, 10)) for i in range(10)] * 10
+
+        if not pre_aggregated:
+            data_extractors = pipeline_dp.DataExtractors(
+                privacy_id_extractor=lambda x: x[0],
+                partition_extractor=lambda x: f"pk{x[1]}",
+                value_extractor=lambda x: 0)
+        else:
+            data_extractors = utility_analysis_new.PreAggregateExtractors(
+                partition_extractor=lambda x: f"pk{x[0]}",
+                preaggregate_extractor=lambda x: x[1])
 
         col = utility_analysis_new.perform_utility_analysis(
             col=col,
             backend=pipeline_dp.LocalBackend(),
             options=utility_analysis_new.UtilityAnalysisOptions(
-                epsilon=2, delta=0.9, aggregate_params=aggregate_params),
+                epsilon=2,
+                delta=0.9,
+                aggregate_params=aggregate_params,
+                pre_aggregated_data=pre_aggregated),
             data_extractors=data_extractors)
 
         col = list(col)

--- a/utility_analysis_new/tests/utility_analysis_test.py
+++ b/utility_analysis_new/tests/utility_analysis_test.py
@@ -45,7 +45,7 @@ class UtilityAnalysis(parameterized.TestCase):
         data_extractors = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x[0],
             partition_extractor=lambda x: f"pk{x[1]}",
-            value_extractor=lambda x: None)
+            value_extractor=lambda x: 0)
 
         col = utility_analysis_new.perform_utility_analysis(
             col=col,
@@ -172,7 +172,7 @@ class UtilityAnalysis(parameterized.TestCase):
         data_extractor = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x,
             partition_extractor=lambda x: f"pk{x}",
-            value_extractor=lambda x: None)
+            value_extractor=lambda x: 0)
 
         col = utility_analysis_new.perform_utility_analysis(
             col=col,
@@ -241,7 +241,7 @@ class UtilityAnalysis(parameterized.TestCase):
         data_extractors = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x[0],
             partition_extractor=lambda x: x[1],
-            value_extractor=lambda x: None)
+            value_extractor=lambda x: 0)
 
         public_partitions = ["pk0", "pk1"]
 

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -13,21 +13,16 @@
 # limitations under the License.
 """Public API for performing utility analysis."""
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Union
+from typing import List, Optional, Union
 
 import pipeline_dp
 from pipeline_dp import combiners
 from pipeline_dp import pipeline_backend
 from pipeline_dp import input_validators
+import utility_analysis_new
 from utility_analysis_new import dp_engine
 from utility_analysis_new import metrics
 import utility_analysis_new.combiners as utility_analysis_combiners
-
-
-@dataclass
-class PreAggregateExtractors:
-    partition_extractor: Callable
-    preaggregate_extractor: Callable
 
 
 @dataclass
@@ -56,13 +51,14 @@ class UtilityAnalysisOptions:
         return self.multi_param_configuration.size
 
 
-def perform_utility_analysis(col,
-                             backend: pipeline_backend.PipelineBackend,
-                             options: UtilityAnalysisOptions,
-                             data_extractors: Union[pipeline_dp.DataExtractors,
-                                                    PreAggregateExtractors],
-                             public_partitions=None,
-                             return_per_partition: bool = False):
+def perform_utility_analysis(
+        col,
+        backend: pipeline_backend.PipelineBackend,
+        options: UtilityAnalysisOptions,
+        data_extractors: Union[pipeline_dp.DataExtractors,
+                               utility_analysis_new.PreAggregateExtractors],
+        public_partitions=None,
+        return_per_partition: bool = False):
     """Performs utility analysis for DP aggregations.
 
     Args:

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Public API for performing utility analysis."""
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import List, Union
 
 import pipeline_dp
 from pipeline_dp import combiners

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -48,7 +48,6 @@ def perform_utility_analysis(
     Returns:
       1 element collection which contains utility analysis metrics.
     """
-    # todo add validation: data_extractors and pre-aggregated data.
     budget_accountant = pipeline_dp.NaiveBudgetAccountant(
         total_epsilon=options.epsilon, total_delta=options.delta)
     engine = dp_engine.UtilityAnalysisEngine(

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -39,7 +39,9 @@ def perform_utility_analysis(
       backend: PipelineBackend with which the utility analysis will be run.
       options: options for utility analysis.
       data_extractors: functions that extract needed pieces of information
-        from elements of 'col'.
+        from elements of 'col'. In case if the analysis performed on
+        pre-aggregated data, it should have type PreAggregateExtractors
+        otherwise DataExtractors.
       public_partitions: A collection of partition keys that will be present
         in the result. If not provided, the utility analysis with private
         partition selection will be performed.


### PR DESCRIPTION
This PR implements running utility analysis on pre-aggregated data (previously it was possible only on the raw data).

The implementations consists of the following:

1. The extracting of needed columns (e.g. privacy_id, partition_key) with extractors is moved to a separate `DPEngine._extract_columns` method which is overriden in UtilityAnalysisEngine (because for pre-aggregated data the different data extraction).
2. Computing of count, sum per `(privacy_id, partition_key)` was moved from `CompoundCombiner` to `ContributionBounding` (that's because count and sum is already computed in for per-aggregated data)
3. Introduced `NoOpContributionBounder` for using for pre-aggregated data (because all that needed for contribution bounding is already computed in pre-aggregted data).
4. `pre_aggregated_data` field is introduced in all structures where needed.

**Note:** Tests will be fixed and new tests will added in the following commits