### PR TITLE
Moving dataclasses to a separate file

### DIFF
--- a/utility_analysis_new/__init__.py
+++ b/utility_analysis_new/__init__.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from utility_analysis_new.dp_engine import MultiParameterConfiguration
+from utility_analysis_new.data_structures import MultiParameterConfiguration
+from utility_analysis_new.data_structures import UtilityAnalysisOptions
 from utility_analysis_new.histograms import compute_dataset_histograms
 from utility_analysis_new.histograms import DatasetHistograms
 from utility_analysis_new.metrics import AggregateMetrics
@@ -23,4 +24,3 @@ from utility_analysis_new.parameter_tuning import TuneOptions
 from utility_analysis_new.parameter_tuning import TuneResult
 from utility_analysis_new.parameter_tuning import UtilityAnalysisRun
 from utility_analysis_new.utility_analysis import perform_utility_analysis
-from utility_analysis_new.utility_analysis import UtilityAnalysisOptions

--- a/utility_analysis_new/data_structures.py
+++ b/utility_analysis_new/data_structures.py
@@ -107,27 +107,3 @@ class UtilityAnalysisOptions:
         if self.multi_param_configuration is None:
             return 1
         return self.multi_param_configuration.size
-
-
-@dataclasses.dataclass
-class UtilityAnalysisOptions:
-    """Options for the utility analysis."""
-    epsilon: float
-    delta: float
-    aggregate_params: pipeline_dp.AggregateParams
-    multi_param_configuration: Optional[MultiParameterConfiguration] = None
-    partitions_sampling_prob: float = 1
-
-    def __post_init__(self):
-        input_validators.validate_epsilon_delta(self.epsilon, self.delta,
-                                                "UtilityAnalysisOptions")
-        if self.partitions_sampling_prob <= 0 or self.partitions_sampling_prob > 1:
-            raise ValueError(
-                f"partitions_sampling_prob must be in the interval"
-                f" (0, 1], but {self.partitions_sampling_prob} given.")
-
-    @property
-    def n_configurations(self):
-        if self.multi_param_configuration is None:
-            return 1
-        return self.multi_param_configuration.size

--- a/utility_analysis_new/data_structures.py
+++ b/utility_analysis_new/data_structures.py
@@ -1,0 +1,133 @@
+# Copyright 2022 OpenMined.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contains API dataclasses."""
+
+import copy
+import dataclasses
+from typing import Callable, Optional, Sequence
+
+import pipeline_dp
+from pipeline_dp import input_validators
+
+
+@dataclasses.dataclass
+class MultiParameterConfiguration:
+    """Specifies parameters for multi-parameter Utility Analysis.
+    All MultiParameterConfiguration attributes corresponds to attributes in
+    pipeline_dp.AggregateParams.
+    UtilityAnalysisEngine can perform utility analysis for multiple sets of
+    parameters simultaneously. API for this is the following:
+    1. Specify blue-print AggregateParams instance.
+    2. Set MultiParameterConfiguration attributes (see the example below). Note
+    that each attribute is a sequence of parameter values for which the utility
+    analysis will be run. All attributes that have non-None values must have
+    the same length.
+    3. Pass the created objects to UtilityAnalysisEngine.aggregate().
+    Example:
+        max_partitions_contributed = [1, 2]
+        max_contributions_per_partition = [10, 11]
+        Then the utility analysis will be performed for
+          AggregateParams(max_partitions_contributed=1, max_contributions_per_partition=10)
+          AggregateParams(max_partitions_contributed=2, max_contributions_per_partition=11)
+    """
+    max_partitions_contributed: Sequence[int] = None
+    max_contributions_per_partition: Sequence[int] = None
+    min_sum_per_partition: Sequence[float] = None
+    max_sum_per_partition: Sequence[float] = None
+
+    def __post_init__(self):
+        attributes = dataclasses.asdict(self)
+        sizes = [len(value) for value in attributes.values() if value]
+        if not sizes:
+            raise ValueError("MultiParameterConfiguration must have at least 1"
+                             " non-empty attribute.")
+        if min(sizes) != max(sizes):
+            raise ValueError(
+                "All set attributes in MultiParameterConfiguration must have "
+                "the same length.")
+        if (self.min_sum_per_partition is None) != (self.max_sum_per_partition
+                                                    is None):
+            raise ValueError(
+                "MultiParameterConfiguration: min_sum_per_partition and "
+                "max_sum_per_partition must be both set or both None.")
+        self._size = sizes[0]
+
+    @property
+    def size(self):
+        return self._size
+
+    def get_aggregate_params(self, params: pipeline_dp.AggregateParams,
+                             index: int) -> pipeline_dp.AggregateParams:
+        """Returns AggregateParams with the index-th parameters."""
+        params = copy.copy(params)
+        if self.max_partitions_contributed:
+            params.max_partitions_contributed = self.max_partitions_contributed[
+                index]
+        if self.max_contributions_per_partition:
+            params.max_contributions_per_partition = self.max_contributions_per_partition[
+                index]
+        if self.min_sum_per_partition:
+            params.min_sum_per_partition = self.min_sum_per_partition[index]
+        if self.max_sum_per_partition:
+            params.max_sum_per_partition = self.max_sum_per_partition[index]
+        return params
+
+
+@dataclasses.dataclass
+class UtilityAnalysisOptions:
+    """Options for the utility analysis."""
+    epsilon: float
+    delta: float
+    aggregate_params: pipeline_dp.AggregateParams
+    multi_param_configuration: Optional[MultiParameterConfiguration] = None
+    partitions_sampling_prob: float = 1
+    pre_aggregated_data: bool = False
+
+    def __post_init__(self):
+        input_validators.validate_epsilon_delta(self.epsilon, self.delta,
+                                                "UtilityAnalysisOptions")
+        if self.partitions_sampling_prob <= 0 or self.partitions_sampling_prob > 1:
+            raise ValueError(
+                f"partitions_sampling_prob must be in the interval"
+                f" (0, 1], but {self.partitions_sampling_prob} given.")
+
+    @property
+    def n_configurations(self):
+        if self.multi_param_configuration is None:
+            return 1
+        return self.multi_param_configuration.size
+
+
+@dataclasses.dataclass
+class UtilityAnalysisOptions:
+    """Options for the utility analysis."""
+    epsilon: float
+    delta: float
+    aggregate_params: pipeline_dp.AggregateParams
+    multi_param_configuration: Optional[MultiParameterConfiguration] = None
+    partitions_sampling_prob: float = 1
+
+    def __post_init__(self):
+        input_validators.validate_epsilon_delta(self.epsilon, self.delta,
+                                                "UtilityAnalysisOptions")
+        if self.partitions_sampling_prob <= 0 or self.partitions_sampling_prob > 1:
+            raise ValueError(
+                f"partitions_sampling_prob must be in the interval"
+                f" (0, 1], but {self.partitions_sampling_prob} given.")
+
+    @property
+    def n_configurations(self):
+        if self.multi_param_configuration is None:
+            return 1
+        return self.multi_param_configuration.size

--- a/utility_analysis_new/parameter_tuning.py
+++ b/utility_analysis_new/parameter_tuning.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import pipeline_dp
-import utility_analysis_new
 from pipeline_dp import pipeline_backend
 from pipeline_dp import input_validators
-from utility_analysis_new import combiners
+import utility_analysis_new
 from utility_analysis_new import histograms
 from utility_analysis_new import metrics
 from utility_analysis_new import utility_analysis
@@ -30,7 +29,7 @@ import numpy as np
 
 @dataclass
 class UtilityAnalysisRun:
-    params: utility_analysis.UtilityAnalysisOptions
+    params: utility_analysis_new.UtilityAnalysisOptions
     result: metrics.AggregateErrorMetrics
 
 
@@ -98,14 +97,14 @@ class TuneResult:
     """
     options: TuneOptions
     contribution_histograms: histograms.DatasetHistograms
-    utility_analysis_parameters: utility_analysis_new.dp_engine.MultiParameterConfiguration
+    utility_analysis_parameters: utility_analysis_new.MultiParameterConfiguration
     index_best: int
     utility_analysis_results: List[metrics.AggregateMetrics]
 
 
 def _find_candidate_parameters(
     hist: histograms.DatasetHistograms, parameters_to_tune: ParametersToTune
-) -> utility_analysis_new.dp_engine.MultiParameterConfiguration:
+) -> utility_analysis_new.MultiParameterConfiguration:
     """Uses some heuristics to find (hopefully) good enough parameters."""
     # TODO: decide where to put QUANTILES_TO_USE, maybe TuneOptions?
     QUANTILES_TO_USE = [0.9, 0.95, 0.98, 0.99, 0.995]
@@ -139,15 +138,15 @@ def _find_candidate_parameters(
     else:
         assert False, "Nothing to tune."
 
-    return utility_analysis_new.dp_engine.MultiParameterConfiguration(
+    return utility_analysis_new.MultiParameterConfiguration(
         max_partitions_contributed=l0_bounds,
         max_contributions_per_partition=linf_bounds)
 
 
 def _convert_utility_analysis_to_tune_result(
         utility_analysis_result: Tuple, tune_options: TuneOptions,
-        run_configurations: utility_analysis_new.dp_engine.
-    MultiParameterConfiguration, use_public_partitions: bool,
+        run_configurations: utility_analysis_new.MultiParameterConfiguration,
+        use_public_partitions: bool,
         contribution_histograms: histograms.DatasetHistograms) -> TuneResult:
     assert len(utility_analysis_result) == run_configurations.size
     # TODO(dvadym): implement relative error.
@@ -203,7 +202,7 @@ def tune(col,
     candidates = _find_candidate_parameters(contribution_histograms,
                                             options.parameters_to_tune)
 
-    utility_analysis_options = utility_analysis.UtilityAnalysisOptions(
+    utility_analysis_options = utility_analysis_new.UtilityAnalysisOptions(
         options.epsilon,
         options.delta,
         options.aggregate_params,

--- a/utility_analysis_new/tests/utility_analysis_test.py
+++ b/utility_analysis_new/tests/utility_analysis_test.py
@@ -47,10 +47,10 @@ class UtilityAnalysis(parameterized.TestCase):
             partition_extractor=lambda x: f"pk{x[1]}",
             value_extractor=lambda x: None)
 
-        col = utility_analysis.perform_utility_analysis(
+        col = utility_analysis_new.perform_utility_analysis(
             col=col,
             backend=pipeline_dp.LocalBackend(),
-            options=utility_analysis.UtilityAnalysisOptions(
+            options=utility_analysis_new.UtilityAnalysisOptions(
                 epsilon=2, delta=0.9, aggregate_params=aggregate_params),
             data_extractors=data_extractors)
 
@@ -174,10 +174,10 @@ class UtilityAnalysis(parameterized.TestCase):
             partition_extractor=lambda x: f"pk{x}",
             value_extractor=lambda x: None)
 
-        col = utility_analysis.perform_utility_analysis(
+        col = utility_analysis_new.perform_utility_analysis(
             col=col,
             backend=pipeline_dp.LocalBackend(),
-            options=utility_analysis.UtilityAnalysisOptions(
+            options=utility_analysis_new.UtilityAnalysisOptions(
                 epsilon=2, delta=1e-10, aggregate_params=aggregator_params),
             data_extractors=data_extractor,
             public_partitions=public_partitions)
@@ -245,10 +245,10 @@ class UtilityAnalysis(parameterized.TestCase):
 
         public_partitions = ["pk0", "pk1"]
 
-        output = utility_analysis.perform_utility_analysis(
+        output = utility_analysis_new.perform_utility_analysis(
             col=input,
             backend=pipeline_dp.LocalBackend(),
-            options=utility_analysis.UtilityAnalysisOptions(
+            options=utility_analysis_new.UtilityAnalysisOptions(
                 epsilon=2,
                 delta=1e-10,
                 aggregate_params=aggregate_params,

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -19,42 +19,19 @@ import pipeline_dp
 from pipeline_dp import combiners
 from pipeline_dp import pipeline_backend
 from pipeline_dp import input_validators
+import utility_analysis_new
 from utility_analysis_new import dp_engine
 from utility_analysis_new import metrics
 import utility_analysis_new.combiners as utility_analysis_combiners
 
 
-@dataclass
-class UtilityAnalysisOptions:
-    """Options for the utility analysis."""
-    epsilon: float
-    delta: float
-    aggregate_params: pipeline_dp.AggregateParams
-    multi_param_configuration: Optional[
-        dp_engine.MultiParameterConfiguration] = None
-    partitions_sampling_prob: float = 1
-
-    def __post_init__(self):
-        input_validators.validate_epsilon_delta(self.epsilon, self.delta,
-                                                "UtilityAnalysisOptions")
-        if self.partitions_sampling_prob <= 0 or self.partitions_sampling_prob > 1:
-            raise ValueError(
-                f"partitions_sampling_prob must be in the interval"
-                f" (0, 1], but {self.partitions_sampling_prob} given.")
-
-    @property
-    def n_configurations(self):
-        if self.multi_param_configuration is None:
-            return 1
-        return self.multi_param_configuration.size
-
-
-def perform_utility_analysis(col,
-                             backend: pipeline_backend.PipelineBackend,
-                             options: UtilityAnalysisOptions,
-                             data_extractors: pipeline_dp.DataExtractors,
-                             public_partitions=None,
-                             return_per_partition: bool = False):
+def perform_utility_analysis(
+        col,
+        backend: pipeline_backend.PipelineBackend,
+        options: utility_analysis_new.UtilityAnalysisOptions,
+        data_extractors: pipeline_dp.DataExtractors,
+        public_partitions=None,
+        return_per_partition: bool = False):
     """Performs utility analysis for DP aggregations.
 
     Args:


### PR DESCRIPTION
This is refactoring PR.

Dataclasses `MultiParameterConfiguration` and `UtilityAnalysisOptions` moved to data_structures.py