### PR TITLE
Refactor UtilityAnalysisEngine.analyze

### DIFF
--- a/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
+++ b/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
@@ -112,10 +112,14 @@ def per_partition_utility_analysis():
     data_extractors = get_data_extractors()
     public_partitions = list(range(1, 8)) if FLAGS.public_partitions else None
 
-    result = utility_analysis_engine.analyze(
-        restaurant_visits_rows, aggregate_params, data_extractors,
-        public_partitions, get_multi_params(),
-        FLAGS.partition_sampling_probability)
+    options = utility_analysis_new.UtilityAnalysisOptions(
+        1,
+        1e-6,
+        aggregate_params,
+        multi_param_configuration=get_multi_params(),
+        partitions_sampling_prob=FLAGS.partition_sampling_probability)
+    result = utility_analysis_engine.analyze(restaurant_visits_rows, options,
+                                             data_extractors, public_partitions)
 
     budget_accountant.compute_budgets()
 

--- a/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
+++ b/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
@@ -113,9 +113,9 @@ def per_partition_utility_analysis():
     public_partitions = list(range(1, 8)) if FLAGS.public_partitions else None
 
     options = utility_analysis_new.UtilityAnalysisOptions(
-        1,
-        1e-6,
-        aggregate_params,
+        epsilon=1,
+        delta=1e-6,
+        aggregate_params=aggregate_params,
         multi_param_configuration=get_multi_params(),
         partitions_sampling_prob=FLAGS.partition_sampling_probability)
     result = utility_analysis_engine.analyze(restaurant_visits_rows, options,

--- a/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
+++ b/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
@@ -112,7 +112,7 @@ def per_partition_utility_analysis():
     data_extractors = get_data_extractors()
     public_partitions = list(range(1, 8)) if FLAGS.public_partitions else None
 
-    result = utility_analysis_engine.aggregate(
+    result = utility_analysis_engine.analyze(
         restaurant_visits_rows, aggregate_params, data_extractors,
         public_partitions, get_multi_params(),
         FLAGS.partition_sampling_probability)

--- a/pipeline_dp/__init__.py
+++ b/pipeline_dp/__init__.py
@@ -21,6 +21,7 @@ from pipeline_dp.aggregate_params import PartitionSelectionStrategy
 from pipeline_dp.aggregate_params import PrivacyIdCountParams
 from pipeline_dp.aggregate_params import SelectPartitionsParams
 from pipeline_dp.aggregate_params import SumParams
+from pipeline_dp.budget_accounting import Budget
 from pipeline_dp.budget_accounting import BudgetAccountant
 from pipeline_dp.budget_accounting import NaiveBudgetAccountant
 from pipeline_dp.combiners import Combiner

--- a/pipeline_dp/__init__.py
+++ b/pipeline_dp/__init__.py
@@ -21,7 +21,6 @@ from pipeline_dp.aggregate_params import PartitionSelectionStrategy
 from pipeline_dp.aggregate_params import PrivacyIdCountParams
 from pipeline_dp.aggregate_params import SelectPartitionsParams
 from pipeline_dp.aggregate_params import SumParams
-from pipeline_dp.budget_accounting import Budget
 from pipeline_dp.budget_accounting import BudgetAccountant
 from pipeline_dp.budget_accounting import NaiveBudgetAccountant
 from pipeline_dp.combiners import Combiner

--- a/utility_analysis_new/dp_engine.py
+++ b/utility_analysis_new/dp_engine.py
@@ -33,7 +33,6 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
                  backend: pipeline_backend.PipelineBackend):
         super().__init__(budget_accountant, backend)
         self._is_public_partitions = None
-        self._sampling_probability = 1.0
 
     def analyze(self,
                 col,
@@ -69,7 +68,7 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
     ) -> contribution_bounders.ContributionBounder:
         """Creates ContributionBounder for utility analysis."""
         return utility_contribution_bounders.SamplingL0LinfContributionBounder(
-            self._sampling_probability)
+            self._options.partitions_sampling_prob)
 
     def _create_compound_combiner(
         self, aggregate_params: pipeline_dp.AggregateParams
@@ -126,7 +125,6 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
 
 def _check_utility_analysis_params(params: pipeline_dp.AggregateParams,
                                    public_partitions=None):
-
     if params.custom_combiners is not None:
         raise NotImplementedError("custom combiners are not supported")
     if not (set(params.metrics).issubset({

--- a/utility_analysis_new/tests/dp_engine_test.py
+++ b/utility_analysis_new/tests/dp_engine_test.py
@@ -337,7 +337,7 @@ class DpEngine(parameterized.TestCase):
         engine.analyze(col=[1, 2, 3],
                        options=options,
                        data_extractors=data_extractor)
-        # mock_sampler_init.assert_called_once_with(partitions_sampling_prob)
+        mock_sampler_init.assert_called_once_with(0.25)
 
 
 if __name__ == '__main__':

--- a/utility_analysis_new/tests/dp_engine_test.py
+++ b/utility_analysis_new/tests/dp_engine_test.py
@@ -140,11 +140,10 @@ class DpEngine(parameterized.TestCase):
                     budget_accountant=budget_accountant,
                     backend=pipeline_dp.LocalBackend())
                 col = [0, 1, 2]
-                engine.aggregate(
-                    col,
-                    test_case["params"],
-                    test_case["data_extractor"],
-                    public_partitions=test_case["public_partitions"])
+                engine.analyze(col,
+                               test_case["params"],
+                               test_case["data_extractor"],
+                               public_partitions=test_case["public_partitions"])
 
     def test_aggregate_public_partition_e2e(self):
         # Arrange
@@ -167,10 +166,10 @@ class DpEngine(parameterized.TestCase):
             budget_accountant=budget_accountant,
             backend=pipeline_dp.LocalBackend())
 
-        col = engine.aggregate(col=col,
-                               params=aggregator_params,
-                               data_extractors=data_extractor,
-                               public_partitions=public_partitions)
+        col = engine.analyze(col=col,
+                             params=aggregator_params,
+                             data_extractors=data_extractor,
+                             public_partitions=public_partitions)
         budget_accountant.compute_budgets()
 
         col = list(col)
@@ -202,9 +201,9 @@ class DpEngine(parameterized.TestCase):
             budget_accountant=budget_accountant,
             backend=pipeline_dp.LocalBackend())
 
-        col = engine.aggregate(col=col,
-                               params=aggregator_params,
-                               data_extractors=data_extractor)
+        col = engine.analyze(col=col,
+                             params=aggregator_params,
+                             data_extractors=data_extractor)
         budget_accountant.compute_budgets()
 
         col = list(col)
@@ -257,11 +256,11 @@ class DpEngine(parameterized.TestCase):
 
         public_partitions = ["pk0", "pk1"]
 
-        output = engine.aggregate(input,
-                                  aggregate_params,
-                                  data_extractors,
-                                  public_partitions=public_partitions,
-                                  multi_param_configuration=multi_param)
+        output = engine.analyze(input,
+                                aggregate_params,
+                                data_extractors,
+                                public_partitions=public_partitions,
+                                multi_param_configuration=multi_param)
         budget_accountant.compute_budgets()
 
         output = list(output)
@@ -320,10 +319,10 @@ class DpEngine(parameterized.TestCase):
             backend=pipeline_dp.LocalBackend())
 
         partitions_sampling_prob = 0.25
-        engine.aggregate(col=[1, 2, 3],
-                         params=aggregator_params,
-                         data_extractors=data_extractor,
-                         partitions_sampling_prob=partitions_sampling_prob)
+        engine.analyze(col=[1, 2, 3],
+                       params=aggregator_params,
+                       data_extractors=data_extractor,
+                       partitions_sampling_prob=partitions_sampling_prob)
         mock_sampler_init.assert_called_once_with(partitions_sampling_prob)
 
 

--- a/utility_analysis_new/tests/dp_engine_test.py
+++ b/utility_analysis_new/tests/dp_engine_test.py
@@ -136,12 +136,15 @@ class DpEngine(parameterized.TestCase):
                                         expected_regex=test_case["desc"]):
                 budget_accountant = budget_accounting.NaiveBudgetAccountant(
                     total_epsilon=1, total_delta=1e-10)
+                options = utility_analysis_new.UtilityAnalysisOptions(
+                    epsilon=1, delta=0, aggregate_params=test_case["params"])
                 engine = dp_engine.UtilityAnalysisEngine(
                     budget_accountant=budget_accountant,
                     backend=pipeline_dp.LocalBackend())
                 col = [0, 1, 2]
+
                 engine.analyze(col,
-                               test_case["params"],
+                               options,
                                test_case["data_extractor"],
                                public_partitions=test_case["public_partitions"])
 
@@ -166,8 +169,10 @@ class DpEngine(parameterized.TestCase):
             budget_accountant=budget_accountant,
             backend=pipeline_dp.LocalBackend())
 
+        options = utility_analysis_new.UtilityAnalysisOptions(
+            epsilon=1, delta=0, aggregate_params=aggregator_params)
         col = engine.analyze(col=col,
-                             params=aggregator_params,
+                             options=options,
                              data_extractors=data_extractor,
                              public_partitions=public_partitions)
         budget_accountant.compute_budgets()
@@ -192,7 +197,7 @@ class DpEngine(parameterized.TestCase):
         # Input collection has 10 privacy ids where each privacy id
         # contributes to the same 10 partitions, three times in each partition.
         col = [(i, j) for i in range(10) for j in range(10)] * 3
-        data_extractor = pipeline_dp.DataExtractors(
+        data_extractors = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x[0],
             partition_extractor=lambda x: f"pk{x[1]}",
             value_extractor=lambda x: None)
@@ -201,9 +206,11 @@ class DpEngine(parameterized.TestCase):
             budget_accountant=budget_accountant,
             backend=pipeline_dp.LocalBackend())
 
+        options = utility_analysis_new.UtilityAnalysisOptions(
+            epsilon=1, delta=0, aggregate_params=aggregator_params)
         col = engine.analyze(col=col,
-                             params=aggregator_params,
-                             data_extractors=data_extractor)
+                             options=options,
+                             data_extractors=data_extractors)
         budget_accountant.compute_budgets()
 
         col = list(col)
@@ -256,11 +263,15 @@ class DpEngine(parameterized.TestCase):
 
         public_partitions = ["pk0", "pk1"]
 
+        options = utility_analysis_new.UtilityAnalysisOptions(
+            epsilon=1,
+            delta=0,
+            aggregate_params=aggregate_params,
+            multi_param_configuration=multi_param)
         output = engine.analyze(input,
-                                aggregate_params,
-                                data_extractors,
-                                public_partitions=public_partitions,
-                                multi_param_configuration=multi_param)
+                                options=options,
+                                data_extractors=data_extractors,
+                                public_partitions=public_partitions)
         budget_accountant.compute_budgets()
 
         output = list(output)
@@ -318,12 +329,15 @@ class DpEngine(parameterized.TestCase):
             budget_accountant=budget_accountant,
             backend=pipeline_dp.LocalBackend())
 
-        partitions_sampling_prob = 0.25
+        options = utility_analysis_new.UtilityAnalysisOptions(
+            epsilon=1,
+            delta=0,
+            aggregate_params=aggregator_params,
+            partitions_sampling_prob=0.25)
         engine.analyze(col=[1, 2, 3],
-                       params=aggregator_params,
-                       data_extractors=data_extractor,
-                       partitions_sampling_prob=partitions_sampling_prob)
-        mock_sampler_init.assert_called_once_with(partitions_sampling_prob)
+                       options=options,
+                       data_extractors=data_extractor)
+        # mock_sampler_init.assert_called_once_with(partitions_sampling_prob)
 
 
 if __name__ == '__main__':

--- a/utility_analysis_new/utility_analysis.py
+++ b/utility_analysis_new/utility_analysis.py
@@ -52,13 +52,11 @@ def perform_utility_analysis(
         total_epsilon=options.epsilon, total_delta=options.delta)
     engine = dp_engine.UtilityAnalysisEngine(
         budget_accountant=budget_accountant, backend=backend)
-    per_partition_analysis_result = engine.aggregate(
+    per_partition_analysis_result = engine.analyze(
         col,
-        params=options.aggregate_params,
+        options=options,
         data_extractors=data_extractors,
-        public_partitions=public_partitions,
-        multi_param_configuration=options.multi_param_configuration,
-        partitions_sampling_prob=options.partitions_sampling_prob)
+        public_partitions=public_partitions)
     budget_accountant.compute_budgets()
     # per_partition_analysis_result : (partition_key, per_partition_metrics)
     per_partition_analysis_result = backend.to_multi_transformable_collection(


### PR DESCRIPTION
This is a refactoring PR which contains the following changes.

1. Renaming `DPEngine.aggregate` -> `DPEngine.analyze` (this function performs analysis, not DP aggregation)
2. This function now takes `UtilityAnalysisOptions` instead of bunch of paramers