### PR TITLE
Expose UniqueLabelGenerator from BeamBackend

### DIFF
--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -218,6 +218,10 @@ class BeamBackend(PipelineBackend):
         super().__init__()
         self._ulg = UniqueLabelsGenerator(suffix)
 
+    @property
+    def unique_lable_generator(self) -> UniqueLabelsGenerator:
+        return self._ulg
+
     def to_collection(self, collection_or_iterable, col, stage_name: str):
         if isinstance(collection_or_iterable, beam.PCollection):
             return collection_or_iterable


### PR DESCRIPTION
This is convenient, since sometimes it's needed to generate unique labels also in code which uses PipelineDP 