### PR TITLE
Refactoring of Combiners, PrivacyIdCount and Count now use Sum

### DIFF
--- a/analysis/combiners.py
+++ b/analysis/combiners.py
@@ -61,6 +61,10 @@ class UtilityAnalysisCombiner(pipeline_dp.Combiner):
     def explain_computation(self):
         """No-op."""
 
+    def metrics_names(self) -> List[str]:
+        """Not used for utility analysis combiners."""
+        return []
+
 
 @dataclass
 class SumOfRandomVariablesMoments:
@@ -204,58 +208,6 @@ class PartitionSelectionCombiner(UtilityAnalysisCombiner):
             params.aggregate_params.partition_selection_strategy, params.eps,
             params.delta, params.aggregate_params.max_partitions_contributed)
 
-    def metrics_names(self) -> List[str]:
-        return ['probability_to_keep']
-
-
-class CountCombiner(UtilityAnalysisCombiner):
-    """A combiner for utility analysis counts."""
-    # (count, per_partition_error, expected_cross_partition_error,
-    # var_cross_partition_error)
-    AccumulatorType = Tuple[int, int, float, float]
-
-    def __init__(self, params: pipeline_dp.combiners.CombinerParams):
-        self._params = params
-
-    @property
-    def _is_public_partitions(self):
-        return self._partition_selection_budget is None
-
-    def create_accumulator(self, data: PreaggregatedData) -> AccumulatorType:
-        """Creates an accumulator for data."""
-        count, sum_, n_partitions = data
-        max_per_partition = self._params.aggregate_params.max_contributions_per_partition
-        max_partitions = self._params.aggregate_params.max_partitions_contributed
-        l0_prob_keep_contribution = min(1, max_partitions /
-                                        n_partitions) if n_partitions > 0 else 0
-        per_partition_contribution = min(max_per_partition, count)
-        per_partition_error = per_partition_contribution - count
-        expected_cross_partition_error = -per_partition_contribution * (
-            1 - l0_prob_keep_contribution)
-        var_cross_partition_error = per_partition_contribution**2 * l0_prob_keep_contribution * (
-            1 - l0_prob_keep_contribution)
-
-        return (count, per_partition_error, expected_cross_partition_error,
-                var_cross_partition_error)
-
-    def compute_metrics(self, acc: AccumulatorType) -> metrics.CountMetrics:
-        count, per_partition_error, expected_cross_partition_error, var_cross_partition_error = acc
-        std_noise = dp_computations.compute_dp_count_noise_std(
-            self._params.scalar_noise_params)
-        return metrics.CountMetrics(
-            count=count,
-            per_partition_error=per_partition_error,
-            expected_cross_partition_error=expected_cross_partition_error,
-            std_cross_partition_error=math.sqrt(var_cross_partition_error),
-            std_noise=std_noise,
-            noise_kind=self._params.aggregate_params.noise_kind)
-
-    def metrics_names(self) -> List[str]:
-        return [
-            'count', 'per_partition_error', 'expected_cross_partition_error',
-            'std_cross_partition_error', 'std_noise', 'noise_kind'
-        ]
-
 
 class SumCombiner(UtilityAnalysisCombiner):
     """A combiner for utility analysis sums."""
@@ -304,24 +256,33 @@ class SumCombiner(UtilityAnalysisCombiner):
             std_noise=std_noise,
             noise_kind=self._params.aggregate_params.noise_kind)
 
-    def metrics_names(self) -> List[str]:
-        return [
-            'sum', 'per_partition_error_min', 'per_partition_error_max',
-            'expected_cross_partition_error', 'std_cross_partition_error',
-            'std_noise', 'noise_kind'
-        ]
+
+class CountCombiner(SumCombiner):
+    """A combiner for utility analysis counts."""
+    # (partition_sum, per_partition_error_min, per_partition_error_max,
+    # expected_cross_partition_error, var_cross_partition_error)
+    AccumulatorType = Tuple[float, float, float, float, float]
+
+    def create_accumulator(self, data: PreaggregatedData) -> AccumulatorType:
+        count, _sum, n_partitions = data
+        data = count, count, n_partitions
+        self._params.aggregate_params.min_sum_per_partition = 0.0
+        self._params.aggregate_params.max_sum_per_partition = self._params.aggregate_params.max_contributions_per_partition
+        return super().create_accumulator(data)
 
 
-class PrivacyIdCountCombiner(CountCombiner):
+class PrivacyIdCountCombiner(SumCombiner):
     """A combiner for utility analysis privacy ID counts."""
-    # (count, per_partition_error, expected_cross_partition_error,
-    # var_cross_partition_error)
-    AccumulatorType = Tuple[int, int, float, float]
+    # (partition_sum, per_partition_error_min, per_partition_error_max,
+    # expected_cross_partition_error, var_cross_partition_error)
+    AccumulatorType = Tuple[float, float, float, float, float]
 
     def create_accumulator(self, data: PreaggregatedData) -> AccumulatorType:
         count, _sum, n_partitions = data
         count = 1 if count > 0 else 0
-        data = count, _sum, n_partitions
+        data = count, count, n_partitions
+        self._params.aggregate_params.min_sum_per_partition = 0.0
+        self._params.aggregate_params.max_sum_per_partition = 1.0
         return super().create_accumulator(data)
 
 
@@ -406,11 +367,15 @@ class AggregateErrorMetricsAccumulator:
 
     error_l0_expected: float
     error_linf_expected: float
+    error_linf_min_expected: float
+    error_linf_max_expected: float
     error_l0_variance: float
     error_variance: float
     error_quantiles: List[float]
     rel_error_l0_expected: float
     rel_error_linf_expected: float
+    rel_error_linf_min_expected: float
+    rel_error_linf_max_expected: float
     rel_error_l0_variance: float
     rel_error_variance: float
     rel_error_quantiles: List[float]
@@ -435,6 +400,10 @@ class AggregateErrorMetricsAccumulator:
             error_l0_expected=self.error_l0_expected + other.error_l0_expected,
             error_linf_expected=self.error_linf_expected +
             other.error_linf_expected,
+            error_linf_min_expected=self.error_linf_min_expected +
+            other.error_linf_min_expected,
+            error_linf_max_expected=self.error_linf_max_expected +
+            other.error_linf_max_expected,
             error_l0_variance=self.error_l0_variance + other.error_l0_variance,
             error_variance=self.error_variance + other.error_variance,
             error_quantiles=[
@@ -445,6 +414,10 @@ class AggregateErrorMetricsAccumulator:
             other.rel_error_l0_expected,
             rel_error_linf_expected=self.rel_error_linf_expected +
             other.rel_error_linf_expected,
+            rel_error_linf_min_expected=self.rel_error_linf_min_expected +
+            other.rel_error_linf_min_expected,
+            rel_error_linf_max_expected=self.rel_error_linf_max_expected +
+            other.rel_error_linf_max_expected,
             rel_error_l0_variance=self.rel_error_l0_variance +
             other.rel_error_l0_variance,
             rel_error_variance=self.rel_error_variance +
@@ -482,8 +455,8 @@ class AggregateErrorMetricsCompoundCombiner(combiners.CompoundCombiner):
         return 1, tuple(accumulators)
 
 
-class CountAggregateErrorMetricsCombiner(pipeline_dp.Combiner):
-    """A combiner for aggregating errors across partitions for Count"""
+class SumAggregateErrorMetricsCombiner(pipeline_dp.Combiner):
+    """A combiner for aggregating errors across partitions for Sum"""
     AccumulatorType = AggregateErrorMetricsAccumulator
 
     def __init__(self, metric_type: metrics.AggregateMetricType,
@@ -492,49 +465,63 @@ class CountAggregateErrorMetricsCombiner(pipeline_dp.Combiner):
         self._error_quantiles = _invert_error_quantiles(error_quantiles)
 
     def create_accumulator(self,
-                           metrics: metrics.CountMetrics,
+                           m: metrics.SumMetrics,
                            prob_to_keep: float = 1) -> AccumulatorType:
         """Creates an accumulator for metrics."""
         # Data drop ratio metrics
-        total_aggregate = metrics.count
-        data_dropped_l0 = -metrics.expected_cross_partition_error
-        data_dropped_linf = -metrics.per_partition_error
-        data_dropped_partition_selection = (1 - prob_to_keep) * (
-            metrics.count + metrics.expected_cross_partition_error +
-            metrics.per_partition_error)
+        total_aggregate = m.sum
+        # TODO: Compute data_dropped metrics
+        data_dropped_l0 = 0
+        data_dropped_linf = 0
+        data_dropped_partition_selection = 0
+        if self._metric_type != metrics.AggregateMetricType.SUM:
+            data_dropped_l0 = -m.expected_cross_partition_error
+            data_dropped_linf = -m.per_partition_error_max
+            data_dropped_partition_selection = (
+                1 - prob_to_keep) * (m.sum + m.expected_cross_partition_error +
+                                     m.per_partition_error_max)
 
         # Absolute error metrics
-        error_l0_expected = prob_to_keep * metrics.expected_cross_partition_error
-        error_linf_expected = prob_to_keep * metrics.per_partition_error
-        error_l0_variance = prob_to_keep * metrics.std_cross_partition_error**2
-        error_variance = prob_to_keep * (metrics.std_cross_partition_error**2 +
-                                         metrics.std_noise**2)
+        error_l0_expected = prob_to_keep * m.expected_cross_partition_error
+        error_linf_min_expected = prob_to_keep * m.per_partition_error_min
+        error_linf_max_expected = prob_to_keep * m.per_partition_error_max
+        error_linf_expected = error_linf_min_expected + error_linf_max_expected
+        error_l0_variance = prob_to_keep * m.std_cross_partition_error**2
+        error_variance = prob_to_keep * (m.std_cross_partition_error**2 +
+                                         m.std_noise**2)
         error_quantiles = _compute_error_quantiles(self._error_quantiles,
-                                                   prob_to_keep, metrics)
+                                                   prob_to_keep, m)
         error_expected_w_dropped_partitions = prob_to_keep * (
-            metrics.expected_cross_partition_error +
-            metrics.per_partition_error) + (1 - prob_to_keep) * -metrics.count
+            m.expected_cross_partition_error + m.per_partition_error_min +
+            m.per_partition_error_max) + (1 - prob_to_keep) * -m.sum
 
         # Relative error metrics
-        if metrics.count == 0:  # For empty public partitions, to avoid division by 0
+        if m.sum == 0:  # For empty public partitions & partitions with zero sum, to avoid division by 0
             rel_error_l0_expected = 0
             rel_error_linf_expected = 0
+            rel_error_linf_min_expected = 0
+            rel_error_linf_max_expected = 0
             rel_error_l0_variance = 0
             rel_error_variance = 0
             rel_error_quantiles = [0] * len(self._error_quantiles)
             rel_error_expected_w_dropped_partitions = 0
         else:
-            rel_error_l0_expected = error_l0_expected / metrics.count
-            rel_error_linf_expected = error_linf_expected / metrics.count
-            rel_error_l0_variance = error_l0_variance / (metrics.count**2)
-            rel_error_variance = error_variance / (metrics.count**2)
+            # We take the absolute value of the denominator because it can be
+            # negative.
+            rel_error_l0_expected = error_l0_expected / abs(m.sum)
+            rel_error_linf_min_expected = error_linf_min_expected / abs(m.sum)
+            rel_error_linf_max_expected = error_linf_max_expected / abs(m.sum)
+            rel_error_linf_expected = rel_error_linf_min_expected + rel_error_linf_max_expected
+            rel_error_l0_variance = error_l0_variance / (m.sum**2)
+            rel_error_variance = error_variance / (m.sum**2)
             rel_error_quantiles = [
-                error / metrics.count for error in error_quantiles
+                error / abs(m.sum) for error in error_quantiles
             ]
-            rel_error_expected_w_dropped_partitions = error_expected_w_dropped_partitions / metrics.count
+            rel_error_expected_w_dropped_partitions = error_expected_w_dropped_partitions / abs(
+                m.sum)
 
         # Noise metrics
-        noise_std = metrics.std_noise
+        noise_std = m.std_noise
 
         return AggregateErrorMetricsAccumulator(
             num_partitions=1,
@@ -545,11 +532,15 @@ class CountAggregateErrorMetricsCombiner(pipeline_dp.Combiner):
             data_dropped_partition_selection=data_dropped_partition_selection,
             error_l0_expected=error_l0_expected,
             error_linf_expected=error_linf_expected,
+            error_linf_min_expected=error_linf_min_expected,
+            error_linf_max_expected=error_linf_max_expected,
             error_l0_variance=error_l0_variance,
             error_variance=error_variance,
             error_quantiles=error_quantiles,
             rel_error_l0_expected=rel_error_l0_expected,
             rel_error_linf_expected=rel_error_linf_expected,
+            rel_error_linf_min_expected=rel_error_linf_min_expected,
+            rel_error_linf_max_expected=rel_error_linf_max_expected,
             rel_error_l0_variance=rel_error_l0_variance,
             rel_error_variance=rel_error_variance,
             rel_error_quantiles=rel_error_quantiles,
@@ -568,9 +559,13 @@ class CountAggregateErrorMetricsCombiner(pipeline_dp.Combiner):
                         acc: AccumulatorType) -> metrics.AggregateErrorMetrics:
         """Computes metrics based on the accumulator properties."""
         error_l0_expected = acc.error_l0_expected / acc.kept_partitions_expected
-        error_linf_expected = acc.error_linf_expected / acc.kept_partitions_expected
+        error_linf_min_expected = acc.error_linf_min_expected / acc.kept_partitions_expected
+        error_linf_max_expected = acc.error_linf_max_expected / acc.kept_partitions_expected
+        error_linf_expected = error_linf_min_expected + error_linf_max_expected
         rel_error_l0_expected = acc.rel_error_l0_expected / acc.kept_partitions_expected
-        rel_error_linf_expected = acc.rel_error_linf_expected / acc.kept_partitions_expected
+        rel_error_linf_min_expected = acc.rel_error_linf_min_expected / acc.kept_partitions_expected
+        rel_error_linf_max_expected = acc.rel_error_linf_max_expected / acc.kept_partitions_expected
+        rel_error_linf_expected = rel_error_linf_min_expected + rel_error_linf_max_expected
         acc.total_aggregate = max(1.0, acc.total_aggregate)
         return metrics.AggregateErrorMetrics(
             metric_type=self._metric_type,
@@ -580,165 +575,28 @@ class CountAggregateErrorMetricsCombiner(pipeline_dp.Combiner):
             data_dropped_partition_selection / acc.total_aggregate,
             error_l0_expected=error_l0_expected,
             error_linf_expected=error_linf_expected,
+            error_linf_min_expected=error_linf_min_expected,
+            error_linf_max_expected=error_linf_max_expected,
             error_expected=error_l0_expected + error_linf_expected,
             error_l0_variance=acc.error_l0_variance /
             acc.kept_partitions_expected,
             error_variance=acc.error_variance / acc.kept_partitions_expected,
             error_quantiles=[
-                sum / acc.kept_partitions_expected
-                for sum in acc.error_quantiles
+                sum_ / acc.kept_partitions_expected
+                for sum_ in acc.error_quantiles
             ],
             rel_error_l0_expected=rel_error_l0_expected,
             rel_error_linf_expected=rel_error_linf_expected,
+            rel_error_linf_min_expected=rel_error_linf_min_expected,
+            rel_error_linf_max_expected=rel_error_linf_max_expected,
             rel_error_expected=rel_error_l0_expected + rel_error_linf_expected,
             rel_error_l0_variance=acc.rel_error_l0_variance /
             acc.kept_partitions_expected,
             rel_error_variance=acc.rel_error_variance /
             acc.kept_partitions_expected,
             rel_error_quantiles=[
-                sum / acc.kept_partitions_expected
-                for sum in acc.rel_error_quantiles
-            ],
-            error_expected_w_dropped_partitions=acc.
-            error_expected_w_dropped_partitions / acc.num_partitions,
-            rel_error_expected_w_dropped_partitions=acc.
-            rel_error_expected_w_dropped_partitions / acc.num_partitions,
-            noise_std=acc.noise_std)
-
-    def metrics_names(self) -> List[str]:
-        return [
-            'metric_type', 'ratio_data_dropped_l0', 'ratio_data_dropped_linf',
-            'ratio_data_dropped_partition_selection', 'error_l0_expected',
-            'error_linf_expected', 'error_expected', 'error_l0_variance',
-            'error_variance', 'error_quantiles', 'rel_error_l0_expected',
-            'rel_error_linf_expected', 'rel_error_expected',
-            'rel_error_l0_variance', 'rel_error_variance',
-            'rel_error_quantiles', 'noise_std'
-        ]
-
-    def explain_computation(self):
-        pass
-
-
-class SumAggregateErrorMetricsCombiner(pipeline_dp.Combiner):
-    """A combiner for aggregating errors across partitions for Sum"""
-    AccumulatorType = AggregateErrorMetricsAccumulator
-
-    def __init__(self, error_quantiles: List[float]):
-        self._error_quantiles = _invert_error_quantiles(error_quantiles)
-
-    def create_accumulator(self,
-                           metrics: metrics.SumMetrics,
-                           prob_to_keep: float = 1) -> AccumulatorType:
-        """Creates an accumulator for metrics."""
-        # Data drop ratio metrics
-        total_aggregate = metrics.sum
-        # TODO: Compute data_dropped metrics
-        data_dropped_l0 = 0
-        data_dropped_linf = 0
-        data_dropped_partition_selection = 0
-
-        # Absolute error metrics
-        error_l0_expected = prob_to_keep * metrics.expected_cross_partition_error
-        # TODO: Aggregate over per_partition_error min/max separately.
-        error_linf_expected = prob_to_keep * (metrics.per_partition_error_min +
-                                              metrics.per_partition_error_max)
-        error_l0_variance = prob_to_keep * metrics.std_cross_partition_error**2
-        error_variance = prob_to_keep * (metrics.std_cross_partition_error**2 +
-                                         metrics.std_noise**2)
-        error_quantiles = _compute_error_quantiles(self._error_quantiles,
-                                                   prob_to_keep, metrics)
-        error_expected_w_dropped_partitions = prob_to_keep * (
-            metrics.expected_cross_partition_error +
-            metrics.per_partition_error_min +
-            metrics.per_partition_error_max) + (1 - prob_to_keep) * -metrics.sum
-
-        # Relative error metrics
-        if metrics.sum == 0:  # For empty public partitions & partitions with zero sum, to avoid division by 0
-            rel_error_l0_expected = 0
-            rel_error_linf_expected = 0
-            rel_error_l0_variance = 0
-            rel_error_variance = 0
-            rel_error_quantiles = [0] * len(self._error_quantiles)
-            rel_error_expected_w_dropped_partitions = 0
-        else:
-            # We take the absolute value of the denominator because it can be
-            # negative.
-            rel_error_l0_expected = error_l0_expected / abs(metrics.sum)
-            rel_error_linf_expected = error_linf_expected / abs(metrics.sum)
-            rel_error_l0_variance = error_l0_variance / (metrics.sum**2)
-            rel_error_variance = error_variance / (metrics.sum**2)
-            rel_error_quantiles = [
-                error / abs(metrics.sum) for error in error_quantiles
-            ]
-            rel_error_expected_w_dropped_partitions = error_expected_w_dropped_partitions / abs(
-                metrics.sum)
-
-        # Noise metrics
-        noise_std = metrics.std_noise
-
-        return AggregateErrorMetricsAccumulator(
-            num_partitions=1,
-            kept_partitions_expected=prob_to_keep,
-            total_aggregate=total_aggregate,
-            data_dropped_l0=data_dropped_l0,
-            data_dropped_linf=data_dropped_linf,
-            data_dropped_partition_selection=data_dropped_partition_selection,
-            error_l0_expected=error_l0_expected,
-            error_linf_expected=error_linf_expected,
-            error_l0_variance=error_l0_variance,
-            error_variance=error_variance,
-            error_quantiles=error_quantiles,
-            rel_error_l0_expected=rel_error_l0_expected,
-            rel_error_linf_expected=rel_error_linf_expected,
-            rel_error_l0_variance=rel_error_l0_variance,
-            rel_error_variance=rel_error_variance,
-            rel_error_quantiles=rel_error_quantiles,
-            error_expected_w_dropped_partitions=
-            error_expected_w_dropped_partitions,
-            rel_error_expected_w_dropped_partitions=
-            rel_error_expected_w_dropped_partitions,
-            noise_std=noise_std,
-        )
-
-    def merge_accumulators(self, acc1: AccumulatorType, acc2: AccumulatorType):
-        """Merges two accumulators together additively."""
-        return acc1 + acc2
-
-    def compute_metrics(self,
-                        acc: AccumulatorType) -> metrics.AggregateErrorMetrics:
-        """Computes metrics based on the accumulator properties."""
-        error_l0_expected = acc.error_l0_expected / acc.kept_partitions_expected
-        error_linf_expected = acc.error_linf_expected / acc.kept_partitions_expected
-        rel_error_l0_expected = acc.rel_error_l0_expected / acc.kept_partitions_expected
-        rel_error_linf_expected = acc.rel_error_linf_expected / acc.kept_partitions_expected
-        acc.total_aggregate = max(1.0, acc.total_aggregate)
-        return metrics.AggregateErrorMetrics(
-            metric_type=metrics.AggregateMetricType.SUM,
-            ratio_data_dropped_l0=acc.data_dropped_l0 / acc.total_aggregate,
-            ratio_data_dropped_linf=acc.data_dropped_linf / acc.total_aggregate,
-            ratio_data_dropped_partition_selection=acc.
-            data_dropped_partition_selection / acc.total_aggregate,
-            error_l0_expected=error_l0_expected,
-            error_linf_expected=error_linf_expected,
-            error_expected=error_l0_expected + error_linf_expected,
-            error_l0_variance=acc.error_l0_variance /
-            acc.kept_partitions_expected,
-            error_variance=acc.error_variance / acc.kept_partitions_expected,
-            error_quantiles=[
-                sum / acc.kept_partitions_expected
-                for sum in acc.error_quantiles
-            ],
-            rel_error_l0_expected=rel_error_l0_expected,
-            rel_error_linf_expected=rel_error_linf_expected,
-            rel_error_expected=rel_error_l0_expected + rel_error_linf_expected,
-            rel_error_l0_variance=acc.rel_error_l0_variance /
-            acc.kept_partitions_expected,
-            rel_error_variance=acc.rel_error_variance /
-            acc.kept_partitions_expected,
-            rel_error_quantiles=[
-                sum / acc.kept_partitions_expected
-                for sum in acc.rel_error_quantiles
+                sum_ / acc.kept_partitions_expected
+                for sum_ in acc.rel_error_quantiles
             ],
             error_expected_w_dropped_partitions=acc.
             error_expected_w_dropped_partitions / acc.num_partitions,
@@ -828,10 +686,7 @@ def _compute_error_quantiles(quantiles: List[float], prob_to_keep: float,
             gaussian_sigma=metric.std_cross_partition_error,
             quantiles=quantiles,
             num_samples=10**3)
-    if isinstance(metric, metrics.SumMetrics):
-        per_partition_error = metric.per_partition_error_min + metric.per_partition_error_max
-    else:
-        per_partition_error = metric.per_partition_error
+    per_partition_error = metric.per_partition_error_min + metric.per_partition_error_max
     for q in error_distribution_quantiles:
         error_at_quantile = prob_to_keep * (float(q) + per_partition_error)
         errors.append(error_at_quantile)

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -21,35 +21,10 @@ import math
 
 
 @dataclass
-class CountMetrics:
-    """Stores metrics for the count utility analysis.
-
-  Attributes:
-      count: actual count of contributions per partition.
-      per_partition_error: the amount of error due to per-partition
-      contribution bounding.
-      expected_cross_partition_error: the expected amount of error due to
-      cross-partition contribution bounding.
-      std_cross_partition_error: the standard deviation of the error due to
-      cross-partition contribution bounding.
-      std_noise: the noise standard deviation.
-      noise_kind: the type of noise used.
-
-  s.t. the following holds (where E stands for Expectation):
-  E(count_after_contribution_bounding) = count + E(error)
-  where E(error) = per_partition_error + expected_cross_partition_error
-  """
-    count: int
-    per_partition_error: int
-    expected_cross_partition_error: float
-    std_cross_partition_error: float
-    std_noise: float
-    noise_kind: pipeline_dp.NoiseKind
-
-
-@dataclass
 class SumMetrics:
     """Stores metrics for the sum utility analysis.
+
+  Also used for count & privacy_id_count.
 
   Attributes:
       sum: actual sum of contributions per partition.
@@ -98,12 +73,16 @@ class AggregateErrorMetrics:
 
     error_l0_expected: float
     error_linf_expected: float
+    error_linf_min_expected: float
+    error_linf_max_expected: float
     error_expected: float
     error_l0_variance: float
     error_variance: float
     error_quantiles: List[float]
     rel_error_l0_expected: float
     rel_error_linf_expected: float
+    rel_error_linf_min_expected: float
+    rel_error_linf_max_expected: float
     rel_error_expected: float
     rel_error_l0_variance: float
     rel_error_variance: float

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -22,23 +22,23 @@ import math
 
 @dataclass
 class SumMetrics:
-    """Stores metrics for the sum utility analysis.
+    """Stores per-partition metrics for SUM utility analysis.
 
-  Also used for count & privacy_id_count.
+    It is also used to store COUNT and PRIVACY_ID_COUNT per-partition metrics.
 
-  Attributes:
-      sum: actual sum of contributions per partition.
-      per_partition_error_min: the amount of error due to contribution min clipping.
-      per_partition_error_max: the amount of error due to contribution max clipping.
-      expected_cross_partition_error: the expected amount of error due to cross-partition contribution bounding.
-      std_cross_partition_error: the standard deviation of the error due to cross-partition contribution bounding.
-      std_noise: the noise standard deviation.
-      noise_kind: the type of noise used.
+    Attributes:
+        sum: actual sum of contributions per partition.
+        per_partition_error_min: the amount of error due to contribution min clipping.
+        per_partition_error_max: the amount of error due to contribution max clipping.
+        expected_cross_partition_error: the expected amount of error due to cross-partition contribution bounding.
+        std_cross_partition_error: the standard deviation of the error due to cross-partition contribution bounding.
+        std_noise: the noise standard deviation.
+        noise_kind: the type of noise used.
 
-  s.t. the following holds (where E stands for Expectation):
-  E(sum_after_contribution_bounding) = sum + E(error)
-  where E(error) = per_partition_error_min + per_partition_error_max + expected_cross_partition_error
-  """
+    s.t. the following holds (where E stands for Expectation):
+    E(sum_after_contribution_bounding) = sum + E(error)
+    where E(error) = per_partition_error_min + per_partition_error_max + expected_cross_partition_error
+    """
     sum: float
     per_partition_error_min: float
     per_partition_error_max: float
@@ -56,12 +56,12 @@ class AggregateMetricType(Enum):
 
 @dataclass
 class AggregateErrorMetrics:
-    """Stores aggregate metrics for utility analysis.
+    """Stores aggregate cross-partition metrics for utility analysis.
 
-  All attributes in this dataclass are averages across partitions; except for
-  ratio_* attributes, which are simply the ratios of total data dropped
-  aggregated across partitions.
-  """
+    All attributes in this dataclass are averages across partitions; except for
+    ratio_* attributes, which are simply the ratios of total data dropped
+    aggregated across partitions.
+    """
     metric_type: AggregateMetricType
 
     ratio_data_dropped_l0: float

--- a/analysis/tests/dp_engine_test.py
+++ b/analysis/tests/dp_engine_test.py
@@ -262,7 +262,10 @@ class UtilityAnalysisEngineTest(parameterized.TestCase):
         # Assert
         self.assertLen(output, 10)
         # Assert count metrics are correct.
-        [self.assertTrue(v[1][1].per_partition_error == -10) for v in output]
+        [
+            self.assertTrue(v[1][1].per_partition_error_max == -10)
+            for v in output
+        ]
         [
             self.assertAlmostEqual(v[1][1].expected_cross_partition_error,
                                    -18.0,
@@ -325,32 +328,36 @@ class UtilityAnalysisEngineTest(parameterized.TestCase):
         [self.assertLen(partition_metrics, 2) for partition_metrics in output]
 
         expected_pk0 = [
-            metrics.CountMetrics(count=1,
-                                 per_partition_error=0,
-                                 expected_cross_partition_error=-0.5,
-                                 std_cross_partition_error=0.5,
-                                 std_noise=11.6640625,
-                                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN),
-            metrics.CountMetrics(count=1,
-                                 per_partition_error=0,
-                                 expected_cross_partition_error=0,
-                                 std_cross_partition_error=0.0,
-                                 std_noise=32.99095075973487,
-                                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
+            metrics.SumMetrics(sum=1.0,
+                               per_partition_error_min=0.0,
+                               per_partition_error_max=0.0,
+                               expected_cross_partition_error=-0.5,
+                               std_cross_partition_error=0.5,
+                               std_noise=11.6640625,
+                               noise_kind=pipeline_dp.NoiseKind.GAUSSIAN),
+            metrics.SumMetrics(sum=1.0,
+                               per_partition_error_min=0.0,
+                               per_partition_error_max=0.0,
+                               expected_cross_partition_error=0,
+                               std_cross_partition_error=0.0,
+                               std_noise=32.99095075973487,
+                               noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
         ]
         expected_pk1 = [
-            metrics.CountMetrics(count=2,
-                                 per_partition_error=-1,
-                                 expected_cross_partition_error=-0.5,
-                                 std_cross_partition_error=0.5,
-                                 std_noise=11.6640625,
-                                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN),
-            metrics.CountMetrics(count=2,
-                                 per_partition_error=0,
-                                 expected_cross_partition_error=0,
-                                 std_cross_partition_error=0.0,
-                                 std_noise=32.99095075973487,
-                                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
+            metrics.SumMetrics(sum=2.0,
+                               per_partition_error_min=0.0,
+                               per_partition_error_max=-1.0,
+                               expected_cross_partition_error=-0.5,
+                               std_cross_partition_error=0.5,
+                               std_noise=11.6640625,
+                               noise_kind=pipeline_dp.NoiseKind.GAUSSIAN),
+            metrics.SumMetrics(sum=2.0,
+                               per_partition_error_min=0.0,
+                               per_partition_error_max=0.0,
+                               expected_cross_partition_error=0,
+                               std_cross_partition_error=0.0,
+                               std_noise=32.99095075973487,
+                               noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
         ]
 
         self.assertSequenceEqual(expected_pk0, output[0][1])

--- a/analysis/utility_analysis.py
+++ b/analysis/utility_analysis.py
@@ -141,14 +141,14 @@ def _create_aggregate_error_compound_combiner(
         if pipeline_dp.Metrics.SUM in aggregate_params.metrics:
             internal_combiners.append(
                 utility_analysis_combiners.SumAggregateErrorMetricsCombiner(
-                    error_quantiles))
+                    metrics.AggregateMetricType.SUM, error_quantiles))
         if pipeline_dp.Metrics.COUNT in aggregate_params.metrics:
             internal_combiners.append(
-                utility_analysis_combiners.CountAggregateErrorMetricsCombiner(
+                utility_analysis_combiners.SumAggregateErrorMetricsCombiner(
                     metrics.AggregateMetricType.COUNT, error_quantiles))
         if pipeline_dp.Metrics.PRIVACY_ID_COUNT in aggregate_params.metrics:
             internal_combiners.append(
-                utility_analysis_combiners.CountAggregateErrorMetricsCombiner(
+                utility_analysis_combiners.SumAggregateErrorMetricsCombiner(
                     metrics.AggregateMetricType.PRIVACY_ID_COUNT,
                     error_quantiles))
     return utility_analysis_combiners.AggregateErrorMetricsCompoundCombiner(

--- a/analysis/utility_analysis_engine.py
+++ b/analysis/utility_analysis_engine.py
@@ -99,8 +99,9 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
         mechanism_type = aggregate_params.noise_kind.convert_to_mechanism_type()
         internal_combiners = []
         for params in self._get_aggregate_params(aggregate_params):
-            # WARNING: Do not change the order here, _create_aggregate_error_compound_combiner()
-            # in utility_analysis.py depends on it.
+            # WARNING: Do not change the order here,
+            # _create_aggregate_error_compound_combiner() in utility_analysis.py
+            # depends on it.
             if not self._is_public_partitions:
                 budget = self._budget_accountant.request_budget(
                     mechanism_type=pipeline_dp.MechanismType.GENERIC)


### PR DESCRIPTION
both for per-partition and cross-partition aggregation.