### PR TITLE
Fix split budget for multi configuration in Utility Analysis

### DIFF
--- a/analysis/tests/utility_analysis_engine_test.py
+++ b/analysis/tests/utility_analysis_engine_test.py
@@ -330,14 +330,14 @@ class UtilityAnalysisEngineTest(parameterized.TestCase):
                                per_partition_error_max=0.0,
                                expected_cross_partition_error=-0.5,
                                std_cross_partition_error=0.5,
-                               std_noise=11.6640625,
+                               std_noise=5.87109375,
                                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN),
             metrics.SumMetrics(sum=1.0,
                                per_partition_error_min=0.0,
                                per_partition_error_max=0.0,
                                expected_cross_partition_error=0,
                                std_cross_partition_error=0.0,
-                               std_noise=32.99095075973487,
+                               std_noise=16.60596081442783,
                                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
         ]
         expected_pk1 = [
@@ -346,19 +346,21 @@ class UtilityAnalysisEngineTest(parameterized.TestCase):
                                per_partition_error_max=-1.0,
                                expected_cross_partition_error=-0.5,
                                std_cross_partition_error=0.5,
-                               std_noise=11.6640625,
+                               std_noise=5.87109375,
                                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN),
             metrics.SumMetrics(sum=2.0,
                                per_partition_error_min=0.0,
                                per_partition_error_max=0.0,
                                expected_cross_partition_error=0,
                                std_cross_partition_error=0.0,
-                               std_noise=32.99095075973487,
+                               std_noise=16.60596081442783,
                                noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
         ]
 
         self.assertSequenceEqual(expected_pk0, output[0][1])
         self.assertSequenceEqual(expected_pk1, output[1][1])
+        # Check that the number of budget requests equal to number of metrics.
+        self.assertLen(budget_accountant._mechanisms, 1)
 
     @patch('pipeline_dp.sampling_utils.ValueSampler.__init__')
     def test_partition_sampling(self, mock_sampler_init):

--- a/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
+++ b/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
@@ -84,9 +84,11 @@ def get_data_extractors():
 def get_multi_params():
     multi_param = None
     if FLAGS.multi_parameters:
+        max_partitions_contributed = list(range(1, 11))
+        max_contributions_per_partition = [1] * len(max_partitions_contributed)
         multi_param = analysis.MultiParameterConfiguration(
-            max_partitions_contributed=[1, 1, 2],
-            max_contributions_per_partition=[1, 1, 2])
+            max_partitions_contributed=max_partitions_contributed,
+            max_contributions_per_partition=max_contributions_per_partition)
     return multi_param
 
 

--- a/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
+++ b/examples/restaurant_visits/run_without_frameworks_utility_analysis.py
@@ -84,11 +84,9 @@ def get_data_extractors():
 def get_multi_params():
     multi_param = None
     if FLAGS.multi_parameters:
-        max_partitions_contributed = list(range(1, 11))
-        max_contributions_per_partition = [1] * len(max_partitions_contributed)
         multi_param = analysis.MultiParameterConfiguration(
-            max_partitions_contributed=max_partitions_contributed,
-            max_contributions_per_partition=max_contributions_per_partition)
+            max_partitions_contributed=[1, 1, 2],
+            max_contributions_per_partition=[1, 1, 2])
     return multi_param
 
 


### PR DESCRIPTION
##What was broken?

For simplicity assume that `metrics=[count, sum]` and there are 2 configurations to compute - `max_partition_contributed = [1,2]`.

For computing each metric for each input configuration `UtilityAnalysisCombiner` is created, before this PR the code was the following

```
for metric in metrics:
  for configuration in configurations:
      budget = request_budget()
      // create  combiner
```

The problem is that it requests budget 2*2 = 4 times. Which is incorrect, since different configurations have different budget. This PR fixes that by ensuring that for each metric independently of the number of configurations `request_budget` is called once.