### PR TITLE
Expose contributions_already_enforced in SparkAPI

### DIFF
--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -384,8 +384,15 @@ class VarianceParams:
         partition_extractor: A function for partition id extraction from a collection record.
         value_extractor: A function for extraction of value
             for which the sum will be calculated.
-
-  """
+        budget_weight: Relative weight of the privacy budget allocated to
+            partition selection.
+        noise_kind: The type of noise to use for the DP calculations.
+        contribution_bounds_already_enforced: assume that the input dataset
+            complies with the bounds provided in max_partitions_contributed and
+            max_contributions_per_partition. This option can be used if the
+            dataset does not contain any identifiers that can be used to enforce
+            contribution bounds automatically.
+    """
     max_partitions_contributed: int
     max_contributions_per_partition: int
     min_value: float
@@ -422,7 +429,15 @@ class MeanParams:
             the result.
         value_extractor: A function for extraction of value
             for which the sum will be calculated.
-  """
+        budget_weight: Relative weight of the privacy budget allocated to
+            partition selection.
+        noise_kind: The type of noise to use for the DP calculations.
+        contribution_bounds_already_enforced: assume that the input dataset
+            complies with the bounds provided in max_partitions_contributed and
+            max_contributions_per_partition. This option can be used if the
+            dataset does not contain any identifiers that can be used to enforce
+            contribution bounds automatically.
+    """
     max_partitions_contributed: int
     max_contributions_per_partition: int
     min_value: float
@@ -455,6 +470,11 @@ class CountParams:
         partition_extractor: A function which, given an input element, will return its partition id.
         budget_weight: Relative weight of the privacy budget allocated for this
             operation.
+        contribution_bounds_already_enforced: assume that the input dataset
+            complies with the bounds provided in max_partitions_contributed and
+            max_contributions_per_partition. This option can be used if the
+            dataset does not contain any identifiers that can be used to enforce
+            contribution bounds automatically.
     """
 
     noise_kind: NoiseKind

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -463,11 +463,12 @@ class CountParams:
 
     Attributes:
         noise_kind: The type of noise to use for the DP calculations.
-        max_partitions_contributed: A bound on the number of partitions to which one
-            unit of privacy (e.g., a user) can contribute.
-        max_contributions_per_partition: A bound on the number of times one unit of
-            privacy (e.g. a user) can contribute to a partition.
-        partition_extractor: A function which, given an input element, will return its partition id.
+        max_partitions_contributed: A bound on the number of partitions to which
+            one unit of privacy (e.g., a user) can contribute.
+        max_contributions_per_partition: A bound on the number of times one unit
+            of privacy (e.g. a user) can contribute to a partition.
+        partition_extractor: A function which, given an input element, will
+            return its partition id.
         budget_weight: Relative weight of the privacy budget allocated for this
             operation.
         contribution_bounds_already_enforced: assume that the input dataset
@@ -499,11 +500,19 @@ class PrivacyIdCountParams:
 
     Attributes:
         noise_kind: The type of noise to use for the DP calculations.
-        max_partitions_contributed: A bound on the number of partitions to which one
-            unit of privacy (e.g., a user) can contribute.
+        max_partitions_contributed: A bound on the number of partitions to which
+            one unit of privacy (e.g., a user) can contribute.
         budget_weight: Relative weight of the privacy budget allocated for this
             operation.
-        partition_extractor: A function which, given an input element, will return its partition id.
+        partition_extractor: A function which, given an input element, will
+            return its partition id.
+        budget_weight: Relative weight of the privacy budget allocated for this
+            operation.
+        contribution_bounds_already_enforced: assume that the input dataset
+            complies with the bounds provided in max_partitions_contributed and
+            max_contributions_per_partition. This option can be used if the
+            dataset does not contain any identifiers that can be used to enforce
+            contribution bounds automatically.
     """
 
     noise_kind: NoiseKind

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -322,15 +322,24 @@ class SumParams:
     """Specifies parameters for differentially-private sum calculation.
 
     Attributes:
-        noise_kind: The type of noise to use for the DP calculations.
-        max_partitions_contributed: A bounds on the number of partitions to which one
-            unit of privacy (e.g., a user) can contribute.
-        max_contributions_per_partition: A bound on the number of times one unit of
-            privacy (e.g. a user) can contribute to a partition.
+        max_partitions_contributed: A bounds on the number of partitions to
+            which one unit of privacy (e.g., a user) can contribute.
+        max_contributions_per_partition: A bound on the number of times one unit
+            of privacy (e.g. a user) can contribute to a partition.
         min_value: Lower bound on each value.
         max_value: Upper bound on each value.
-        partition_extractor: A function which, given an input element, will return its partition id.
-        value_extractor: A function which, given an input element, will return its value.
+        partition_extractor: A function which, given an input element, will
+            return its partition id.
+        value_extractor: A function which, given an input element, will return
+            its value.
+        budget_weight: Relative weight of the privacy budget allocated to
+            partition selection.
+        noise_kind: The type of noise to use for the DP calculations.
+        contribution_bounds_already_enforced: assume that the input dataset
+            complies with the bounds provided in max_partitions_contributed and
+            max_contributions_per_partition. This option can be used if the
+            dataset does not contain any identifiers that can be used to enforce
+            contribution bounds automatically.
     """
     max_partitions_contributed: int
     max_contributions_per_partition: int
@@ -342,6 +351,7 @@ class SumParams:
     high: float = None  # deprecated
     budget_weight: float = 1
     noise_kind: NoiseKind = NoiseKind.LAPLACE
+    contribution_bounds_already_enforced: bool = False
     public_partitions: Union[Iterable, 'PCollection',
                              'RDD'] = None  # deprecated
 
@@ -374,6 +384,7 @@ class VarianceParams:
         partition_extractor: A function for partition id extraction from a collection record.
         value_extractor: A function for extraction of value
             for which the sum will be calculated.
+
   """
     max_partitions_contributed: int
     max_contributions_per_partition: int
@@ -383,6 +394,7 @@ class VarianceParams:
     value_extractor: Callable
     budget_weight: float = 1
     noise_kind: NoiseKind = NoiseKind.LAPLACE
+    contribution_bounds_already_enforced: bool = False
     public_partitions: Union[Iterable, 'PCollection',
                              'RDD'] = None  # deprecated
 
@@ -419,6 +431,7 @@ class MeanParams:
     value_extractor: Callable
     budget_weight: float = 1
     noise_kind: NoiseKind = NoiseKind.LAPLACE
+    contribution_bounds_already_enforced: bool = False
     public_partitions: Union[Iterable, 'PCollection',
                              'RDD'] = None  # deprecated
 
@@ -449,6 +462,7 @@ class CountParams:
     max_contributions_per_partition: int
     partition_extractor: Callable
     budget_weight: float = 1
+    contribution_bounds_already_enforced: bool = False
     public_partitions: Union[Iterable, 'PCollection',
                              'RDD'] = None  # deprecated
 
@@ -476,6 +490,7 @@ class PrivacyIdCountParams:
     max_partitions_contributed: int
     partition_extractor: Callable
     budget_weight: float = 1
+    contribution_bounds_already_enforced: bool = False
     public_partitions: Union[Sequence, 'PCollection',
                              'RDD'] = None  # deprecated
 

--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -83,12 +83,16 @@ class PrivateRDD:
             max_contributions_per_partition,
             min_value=variance_params.min_value,
             max_value=variance_params.max_value,
-            budget_weight=variance_params.budget_weight)
+            budget_weight=variance_params.budget_weight,
+            contribution_bounds_already_enforced=variance_params.
+            contribution_bounds_already_enforced)
 
+        value_extractor_needed = not variance_params.contribution_bounds_already_enforced
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: variance_params.partition_extractor(x[
                 1]),
-            privacy_id_extractor=lambda x: x[0],
+            privacy_id_extractor=self._get_privacy_id_extractor(
+                params.contribution_bounds_already_enforced),
             value_extractor=lambda x: variance_params.value_extractor(x[1]))
 
         dp_result = dp_engine.aggregate(self._rdd, params, data_extractors,
@@ -126,11 +130,14 @@ class PrivateRDD:
             max_contributions_per_partition,
             min_value=mean_params.min_value,
             max_value=mean_params.max_value,
-            budget_weight=mean_params.budget_weight)
+            budget_weight=mean_params.budget_weight,
+            contribution_bounds_already_enforced=mean_params.
+            contribution_bounds_already_enforced)
 
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: mean_params.partition_extractor(x[1]),
-            privacy_id_extractor=lambda x: x[0],
+            privacy_id_extractor=self._get_privacy_id_extractor(
+                params.contribution_bounds_already_enforced),
             value_extractor=lambda x: mean_params.value_extractor(x[1]))
 
         dp_result = dp_engine.aggregate(self._rdd, params, data_extractors,
@@ -152,9 +159,9 @@ class PrivateRDD:
 
         Args:
             sum_params: parameters for calculation
-            public_partitions: A collection of partition keys that will be present in
-          the result. Optional. If not provided, partitions will be selected in a DP
-          manner.
+            public_partitions: A collection of partition keys that will be
+               present in the result. Optional. If not provided, partitions will
+               be selected in a DP manner.
         """
 
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
@@ -168,11 +175,14 @@ class PrivateRDD:
             max_contributions_per_partition,
             min_value=sum_params.min_value,
             max_value=sum_params.max_value,
-            budget_weight=sum_params.budget_weight)
+            budget_weight=sum_params.budget_weight,
+            contribution_bounds_already_enforced=sum_params.
+            contribution_bounds_already_enforced)
 
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: sum_params.partition_extractor(x[1]),
-            privacy_id_extractor=lambda x: x[0],
+            privacy_id_extractor=self._get_privacy_id_extractor(
+                params.contribution_bounds_already_enforced),
             value_extractor=lambda x: sum_params.value_extractor(x[1]))
 
         dp_result = dp_engine.aggregate(self._rdd, params, data_extractors,
@@ -208,12 +218,15 @@ class PrivateRDD:
             max_partitions_contributed=count_params.max_partitions_contributed,
             max_contributions_per_partition=count_params.
             max_contributions_per_partition,
-            budget_weight=count_params.budget_weight)
+            budget_weight=count_params.budget_weight,
+            contribution_bounds_already_enforced=count_params.
+            contribution_bounds_already_enforced)
 
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: count_params.partition_extractor(x[1]
                                                                           ),
-            privacy_id_extractor=lambda x: x[0],
+            privacy_id_extractor=self._get_privacy_id_extractor(
+                params.contribution_bounds_already_enforced),
             value_extractor=lambda x: None)
 
         dp_result = dp_engine.aggregate(self._rdd, params, data_extractors,
@@ -249,12 +262,15 @@ class PrivateRDD:
             metrics=[pipeline_dp.Metrics.PRIVACY_ID_COUNT],
             max_partitions_contributed=privacy_id_count_params.
             max_partitions_contributed,
-            max_contributions_per_partition=1)
+            max_contributions_per_partition=1,
+            contribution_bounds_already_enforced=privacy_id_count_params.
+            contribution_bounds_already_enforced)
 
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: privacy_id_count_params.
             partition_extractor(x[1]),
-            privacy_id_extractor=lambda x: x[0],
+            privacy_id_extractor=self._get_privacy_id_extractor(
+                params.contribution_bounds_already_enforced),
             # PrivacyIdCount ignores values.
             value_extractor=lambda x: None)
 
@@ -293,6 +309,12 @@ class PrivateRDD:
             privacy_id_extractor=lambda x: x[0])
 
         return dp_engine.select_partitions(self._rdd, params, data_extractors)
+
+    def _get_privacy_id_extractor(self,
+                                  contribution_bounds_already_enforced: bool):
+        if contribution_bounds_already_enforced:
+            return None
+        return lambda x: x[0]
 
 
 def make_private(rdd: RDD,

--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -313,6 +313,8 @@ class PrivateRDD:
     def _get_privacy_id_extractor(self,
                                   contribution_bounds_already_enforced: bool):
         if contribution_bounds_already_enforced:
+            # Privacy ids are not needed when contribution bounding already
+            # enforced.
             return None
         return lambda x: x[0]
 


### PR DESCRIPTION
When the input dataset already contains a limited number of records per individual, `contributions_already_enforced = True` can be used. As a result no contribution bounding happens