### PR TITLE
Expose explain computations in API

### DIFF
--- a/examples/movie_view_ratings/run_on_beam.py
+++ b/examples/movie_view_ratings/run_on_beam.py
@@ -58,6 +58,7 @@ def main(unused_argv):
                                    budget_accountant=budget_accountant,
                                    privacy_id_extractor=lambda mv: mv.user_id))
 
+        explain_computation_report = pipeline_dp.ExplainComputationReport()
         # Calculate the private sum
         dp_result = private_movie_views | "Private Sum" >> private_beam.Sum(
             SumParams(
@@ -75,6 +76,10 @@ def main(unused_argv):
                 # The value we're aggregating: we're summing up ratings
                 value_extractor=lambda mv: mv.rating))
         budget_accountant.compute_budgets()
+
+        # Generate the Explain Computation Report. It must be called after
+        # budget_accountant.compute_budgets().
+        print(explain_computation_report.text())
 
         # Save the results
         dp_result | beam.io.WriteToText(FLAGS.output_file)

--- a/examples/movie_view_ratings/run_on_spark.py
+++ b/examples/movie_view_ratings/run_on_spark.py
@@ -15,7 +15,7 @@
 
 For running:
 1. Install Python and run on the command line `pip install pipeline-dp pyspark absl-py`
-2. Run python python run_on_beam.py --input_file=<path to data.txt from 3> --output_file=<...>
+2. Run python run_on_beam.py --input_file=<path to data.txt from 3> --output_file=<...>
 """
 
 from absl import app
@@ -55,6 +55,7 @@ def main(unused_argv):
     private_movie_views = \
         make_private(movie_views, budget_accountant, lambda mv: mv.user_id)
 
+    explain_computation_report = pipeline_dp.ExplainComputationReport()
     # Calculate the private sum
     dp_result = private_movie_views.sum(
         SumParams(
@@ -70,10 +71,12 @@ def main(unused_argv):
             # The aggregation key: we're grouping by movies
             partition_extractor=lambda mv: mv.movie_id,
             # The value we're aggregating: we're summing up ratings
-            value_extractor=lambda mv: mv.rating))
+            value_extractor=lambda mv: mv.rating),
+        out_explain_computaton_report=explain_computation_report)
 
     budget_accountant.compute_budgets()
 
+    print(explain_computation_report.text())
     # Save the results
     dp_result.saveAsTextFile(FLAGS.output_file)
 

--- a/examples/movie_view_ratings/run_on_spark.py
+++ b/examples/movie_view_ratings/run_on_spark.py
@@ -76,7 +76,10 @@ def main(unused_argv):
 
     budget_accountant.compute_budgets()
 
+    # Generate the Explain Computation Report. It must be called after
+    # budget_accountant.compute_budgets().
     print(explain_computation_report.text())
+
     # Save the results
     dp_result.saveAsTextFile(FLAGS.output_file)
 

--- a/examples/movie_view_ratings/run_without_frameworks.py
+++ b/examples/movie_view_ratings/run_without_frameworks.py
@@ -69,14 +69,26 @@ def main(unused_argv):
         privacy_id_extractor=lambda mv: mv.user_id,
         value_extractor=lambda mv: mv.rating)
 
+    # Create the Explain Computation report object for passing it into
+    # DPEngine.aggregate().
+    explain_computation_report = pipeline_dp.ExplainComputationReport()
+
     # Create a computational graph for the aggregation.
     # All computations are lazy. dp_result is iterable, but iterating it would
     # fail until budget is computed (below).
     # It’s possible to call DPEngine.aggregate multiple times with different
     # metrics to compute.
-    dp_result = dp_engine.aggregate(movie_views, params, data_extractors)
+    dp_result = dp_engine.aggregate(
+        movie_views,
+        params,
+        data_extractors,
+        out_explain_computaton_report=explain_computation_report)
 
     budget_accountant.compute_budgets()
+
+    # Generate the Explain Computation report. It must be called after
+    # budget_accountant.compute_budgets().
+    print(explain_computation_report.text())
 
     # Here's where the lazy iterator initiates computations and gets transformed
     # into actual results

--- a/pipeline_dp/__init__.py
+++ b/pipeline_dp/__init__.py
@@ -31,5 +31,6 @@ from pipeline_dp.pipeline_backend import BeamBackend
 from pipeline_dp.pipeline_backend import LocalBackend
 from pipeline_dp.pipeline_backend import PipelineBackend
 from pipeline_dp.pipeline_backend import SparkRDDBackend
+from pipeline_dp.report_generator import ExplainComputationReport
 
 __version__ = '0.2.1rc1'

--- a/pipeline_dp/__init__.py
+++ b/pipeline_dp/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pipeline_dp.report_generator import ExplainComputationReport
 from pipeline_dp.aggregate_params import AggregateParams
 from pipeline_dp.aggregate_params import CountParams
 from pipeline_dp.aggregate_params import MechanismType
@@ -31,6 +32,5 @@ from pipeline_dp.pipeline_backend import BeamBackend
 from pipeline_dp.pipeline_backend import LocalBackend
 from pipeline_dp.pipeline_backend import PipelineBackend
 from pipeline_dp.pipeline_backend import SparkRDDBackend
-from pipeline_dp.report_generator import ExplainComputationReport
 
 __version__ = '0.2.1rc1'

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -14,7 +14,7 @@
 """DP aggregations."""
 import dataclasses
 import functools
-from typing import Any, Callable, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 import pipeline_dp
 from pipeline_dp import combiners
@@ -67,7 +67,9 @@ class DPEngine:
                   col,
                   params: pipeline_dp.AggregateParams,
                   data_extractors: DataExtractors,
-                  public_partitions=None):
+                  public_partitions=None,
+                  out_explain_computaton_report: Optional[
+                      pipeline_dp.ExplainComputationReport] = None):
         """Computes DP aggregate metrics.
 
         Args:
@@ -91,6 +93,9 @@ class DPEngine:
             self._report_generators.append(
                 report_generator.ReportGenerator(params, "aggregate",
                                                  public_partitions is not None))
+            if out_explain_computaton_report is not None:
+                out_explain_computaton_report._set_report_generator(
+                    self._current_report_generator)
             col = self._aggregate(col, params, data_extractors,
                                   public_partitions)
             budget = self._budget_accountant._compute_budget_for_aggregation(

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -80,8 +80,9 @@ class DPEngine:
           public_partitions: A collection of partition keys that will be present
             in the result. If not provided, partitions will be selected in a DP
             manner.
-          out_explain_computaton_report: if specified, it will contain
-            the Explain Computation report for this aggregation.
+          out_explain_computaton_report: an output argument, if specified,
+            it will contain the Explain Computation report for this aggregation.
+            For more details see the docstring to report_generator.py.
 
         Returns:
           Collection of (partition_key, result_dictionary), where

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -76,10 +76,12 @@ class DPEngine:
           col: collection where all elements are of the same type.
           params: specifies which metrics to compute and computation parameters.
           data_extractors: functions that extract needed pieces of information
-          from elements of 'col'.
+            from elements of 'col'.
           public_partitions: A collection of partition keys that will be present
-          in the result. If not provided, partitions will be selected in a DP
-          manner.
+            in the result. If not provided, partitions will be selected in a DP
+            manner.
+          out_explain_computaton_report: if specified, it will contain
+            the Explain Computation report for this aggregation.
 
         Returns:
           Collection of (partition_key, result_dictionary), where

--- a/pipeline_dp/private_beam.py
+++ b/pipeline_dp/private_beam.py
@@ -99,10 +99,24 @@ class Variance(PrivatePTransform):
     def __init__(self,
                  variance_params: aggregate_params.VarianceParams,
                  label: Optional[str] = None,
-                 public_partitions=None):
+                 public_partitions=None,
+                 out_explain_computaton_report: Optional[
+                     pipeline_dp.ExplainComputationReport] = None):
+        """Initialize.
+
+         Args:
+             variance_params: parameters for calculation
+             public_partitions: A collection of partition keys that will be
+               present in the result. Optional. If not provided, partitions will be selected in a DP
+               manner.
+             out_explain_computaton_report: if specified, it will contain
+                the Explain Computation report for this aggregation. For
+                more details see the docstring to report_generator.py.
+         """
         super().__init__(return_anonymized=True, label=label)
         self._variance_params = variance_params
         self._public_partitions = public_partitions
+        self._explain_computaton_report = out_explain_computaton_report
 
     def expand(self, pcol: pvalue.PCollection) -> pvalue.PCollection:
         backend = pipeline_dp.BeamBackend()
@@ -125,8 +139,12 @@ class Variance(PrivatePTransform):
             value_extractor=lambda x: self._variance_params.value_extractor(x[1]
                                                                            ))
 
-        dp_result = dp_engine.aggregate(pcol, params, data_extractors,
-                                        self._public_partitions)
+        dp_result = dp_engine.aggregate(
+            pcol,
+            params,
+            data_extractors,
+            self._public_partitions,
+            out_explain_computaton_report=self._explain_computaton_report)
         # dp_result : (partition_key, [dp_variance])
 
         # aggregate() returns a namedtuple of metrics for each partition key.
@@ -144,10 +162,24 @@ class Mean(PrivatePTransform):
     def __init__(self,
                  mean_params: aggregate_params.MeanParams,
                  label: Optional[str] = None,
-                 public_partitions=None):
+                 public_partitions=None,
+                 out_explain_computaton_report: Optional[
+                     pipeline_dp.ExplainComputationReport] = None):
+        """Initialize
+
+        Args:
+            mean_params: parameters for calculation
+            public_partitions: A collection of partition keys that will be
+              present in the result. Optional. If not provided, partitions will
+              be selected in a DP manner.
+            out_explain_computaton_report: if specified, it will contain
+               the Explain Computation report for this aggregation. For
+               more details see the docstring to report_generator.py.
+        """
         super().__init__(return_anonymized=True, label=label)
         self._mean_params = mean_params
         self._public_partitions = public_partitions
+        self._explain_computaton_report = out_explain_computaton_report
 
     def expand(self, pcol: pvalue.PCollection) -> pvalue.PCollection:
         backend = pipeline_dp.BeamBackend()
@@ -169,8 +201,12 @@ class Mean(PrivatePTransform):
             privacy_id_extractor=lambda x: x[0],
             value_extractor=lambda x: self._mean_params.value_extractor(x[1]))
 
-        dp_result = dp_engine.aggregate(pcol, params, data_extractors,
-                                        self._public_partitions)
+        dp_result = dp_engine.aggregate(
+            pcol,
+            params,
+            data_extractors,
+            self._public_partitions,
+            out_explain_computaton_report=self._explain_computaton_report)
         # dp_result : (partition_key, [dp_mean])
 
         # aggregate() returns a namedtuple of metrics for each partition key.
@@ -188,10 +224,24 @@ class Sum(PrivatePTransform):
     def __init__(self,
                  sum_params: aggregate_params.SumParams,
                  label: Optional[str] = None,
-                 public_partitions=None):
+                 public_partitions=None,
+                 out_explain_computaton_report: Optional[
+                     pipeline_dp.ExplainComputationReport] = None):
+        """Initialize.
+
+        Args:
+           sum_params: parameters for calculation
+           public_partitions: A collection of partition keys that will be
+              present in the result. Optional. If not provided, partitions will
+              be selected in a DP manner.
+           out_explain_computaton_report: if specified, it will contain
+              the Explain Computation report for this aggregation. For
+              more details see the docstring to report_generator.py.
+        """
         super().__init__(return_anonymized=True, label=label)
         self._sum_params = sum_params
         self._public_partitions = public_partitions
+        self._explain_computaton_report = out_explain_computaton_report
 
     def expand(self, pcol: pvalue.PCollection) -> pvalue.PCollection:
         backend = pipeline_dp.BeamBackend()
@@ -213,8 +263,12 @@ class Sum(PrivatePTransform):
             privacy_id_extractor=lambda x: x[0],
             value_extractor=lambda x: self._sum_params.value_extractor(x[1]))
 
-        dp_result = dp_engine.aggregate(pcol, params, data_extractors,
-                                        self._public_partitions)
+        dp_result = dp_engine.aggregate(
+            pcol,
+            params,
+            data_extractors,
+            self._public_partitions,
+            out_explain_computaton_report=self._explain_computaton_report)
         # dp_result : (partition_key, [dp_sum])
 
         # aggregate() returns a namedtuple of metrics for each partition key.
@@ -232,10 +286,24 @@ class Count(PrivatePTransform):
     def __init__(self,
                  count_params: aggregate_params.CountParams,
                  label: Optional[str] = None,
-                 public_partitions=None):
+                 public_partitions=None,
+                 out_explain_computaton_report: Optional[
+                     pipeline_dp.ExplainComputationReport] = None):
+        """Initialize.
+
+        Args:
+            count_params: parameters for calculation
+            public_partitions: A collection of partition keys that will be
+              present in the result. Optional. If not provided, partitions will
+              be selected in a DP manner.
+            out_explain_computaton_report: if specified, it will contain
+               the Explain Computation report for this aggregation. For
+               more details see the docstring to report_generator.py.
+        """
         super().__init__(return_anonymized=True, label=label)
         self._count_params = count_params
         self._public_partitions = public_partitions
+        self._explain_computaton_report = out_explain_computaton_report
 
     def expand(self, pcol: pvalue.PCollection) -> pvalue.PCollection:
         backend = pipeline_dp.BeamBackend()
@@ -257,8 +325,12 @@ class Count(PrivatePTransform):
             # doesn't use value extractor.
             value_extractor=lambda x: None)
 
-        dp_result = dp_engine.aggregate(pcol, params, data_extractors,
-                                        self._public_partitions)
+        dp_result = dp_engine.aggregate(
+            pcol,
+            params,
+            data_extractors,
+            self._public_partitions,
+            out_explain_computaton_report=self._explain_computaton_report)
         # dp_result : (partition_key, [dp_count])
 
         # aggregate() returns a namedtuple of metrics for each partition key.
@@ -276,10 +348,24 @@ class PrivacyIdCount(PrivatePTransform):
     def __init__(self,
                  privacy_id_count_params: aggregate_params.PrivacyIdCountParams,
                  label: Optional[str] = None,
-                 public_partitions=None):
+                 public_partitions=None,
+                 out_explain_computaton_report: Optional[
+                     pipeline_dp.ExplainComputationReport] = None):
+        """Initialize.
+
+        Args:
+            privacy_id_count_params: parameters for calculation
+            public_partitions: A collection of partition keys that will be
+              present in the result. Optional. If not provided, partitions will
+              be selected in a DP manner.
+            out_explain_computaton_report: if specified, it will contain
+               the Explain Computation report for this aggregation. For
+               more details see the docstring to report_generator.py.
+        """
         super().__init__(return_anonymized=True, label=label)
         self._privacy_id_count_params = privacy_id_count_params
         self._public_partitions = public_partitions
+        self._explain_computaton_report = out_explain_computaton_report
 
     def expand(self, pcol: pvalue.PCollection) -> pvalue.PCollection:
         backend = pipeline_dp.BeamBackend()
@@ -299,8 +385,12 @@ class PrivacyIdCount(PrivatePTransform):
             # PrivacyIdCount ignores values.
             value_extractor=lambda x: None)
 
-        dp_result = dp_engine.aggregate(pcol, params, data_extractors,
-                                        self._public_partitions)
+        dp_result = dp_engine.aggregate(
+            pcol,
+            params,
+            data_extractors,
+            self._public_partitions,
+            out_explain_computaton_report=self._explain_computaton_report)
         # dp_result : (partition_key, [dp_privacy_id_count])
 
         # aggregate() returns a namedtuple of metrics for each partition key.

--- a/pipeline_dp/private_beam.py
+++ b/pipeline_dp/private_beam.py
@@ -107,11 +107,12 @@ class Variance(PrivatePTransform):
          Args:
              variance_params: parameters for calculation
              public_partitions: A collection of partition keys that will be
-               present in the result. Optional. If not provided, partitions will be selected in a DP
-               manner.
-             out_explain_computaton_report: if specified, it will contain
-                the Explain Computation report for this aggregation. For
-                more details see the docstring to report_generator.py.
+               present in the result. Optional. If not provided, partitions will
+               be selected in a DP manner.
+             out_explain_computaton_report: an output argument, if specified,
+                it will contain the Explain Computation report for this
+                aggregation. For more details see the docstring to
+                report_generator.py.
          """
         super().__init__(return_anonymized=True, label=label)
         self._variance_params = variance_params
@@ -172,9 +173,10 @@ class Mean(PrivatePTransform):
             public_partitions: A collection of partition keys that will be
               present in the result. Optional. If not provided, partitions will
               be selected in a DP manner.
-            out_explain_computaton_report: if specified, it will contain
-               the Explain Computation report for this aggregation. For
-               more details see the docstring to report_generator.py.
+            out_explain_computaton_report: an output argument, if specified,
+              it will contain the Explain Computation report for this
+              aggregation. For more details see the docstring to
+              report_generator.py.
         """
         super().__init__(return_anonymized=True, label=label)
         self._mean_params = mean_params
@@ -234,9 +236,10 @@ class Sum(PrivatePTransform):
            public_partitions: A collection of partition keys that will be
               present in the result. Optional. If not provided, partitions will
               be selected in a DP manner.
-           out_explain_computaton_report: if specified, it will contain
-              the Explain Computation report for this aggregation. For
-              more details see the docstring to report_generator.py.
+           out_explain_computaton_report: an output argument, if specified,
+              it will contain the Explain Computation report for this
+              aggregation. For more details see the docstring to
+              report_generator.py.
         """
         super().__init__(return_anonymized=True, label=label)
         self._sum_params = sum_params
@@ -296,9 +299,10 @@ class Count(PrivatePTransform):
             public_partitions: A collection of partition keys that will be
               present in the result. Optional. If not provided, partitions will
               be selected in a DP manner.
-            out_explain_computaton_report: if specified, it will contain
-               the Explain Computation report for this aggregation. For
-               more details see the docstring to report_generator.py.
+            out_explain_computaton_report: an output argument, if specified,
+              it will contain the Explain Computation report for this
+              aggregation. For more details see the docstring to
+              report_generator.py.
         """
         super().__init__(return_anonymized=True, label=label)
         self._count_params = count_params
@@ -358,9 +362,10 @@ class PrivacyIdCount(PrivatePTransform):
             public_partitions: A collection of partition keys that will be
               present in the result. Optional. If not provided, partitions will
               be selected in a DP manner.
-            out_explain_computaton_report: if specified, it will contain
-               the Explain Computation report for this aggregation. For
-               more details see the docstring to report_generator.py.
+            out_explain_computaton_report: an output argument, if specified,
+              it will contain the Explain Computation report for this
+              aggregation. For more details see the docstring to
+              report_generator.py.
         """
         super().__init__(return_anonymized=True, label=label)
         self._privacy_id_count_params = privacy_id_count_params

--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -59,16 +59,23 @@ class PrivateRDD:
         rdd = self._rdd.flatMapValues(fn)
         return make_private(rdd, self._budget_accountant, None)
 
-    def variance(self,
-                 variance_params: aggregate_params.VarianceParams,
-                 public_partitions=None) -> RDD:
+    def variance(
+        self,
+        variance_params: aggregate_params.VarianceParams,
+        public_partitions=None,
+        out_explain_computaton_report: Optional[
+            pipeline_dp.ExplainComputationReport] = None
+    ) -> RDD:
         """Computes a DP variance.
 
         Args:
             variance_params: parameters for calculation
-            public_partitions: A collection of partition keys that will be present in
-          the result. Optional. If not provided, partitions will be selected in a DP
-          manner.
+            public_partitions: A collection of partition keys that will be
+              present in the result. Optional. If not provided, partitions will be selected in a DP
+              manner.
+            out_explain_computaton_report: if specified, it will contain
+               the Explain Computation report for this aggregation. For
+               more details see the docstring to report_generator.py.
         """
 
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
@@ -95,8 +102,12 @@ class PrivateRDD:
                 params.contribution_bounds_already_enforced),
             value_extractor=lambda x: variance_params.value_extractor(x[1]))
 
-        dp_result = dp_engine.aggregate(self._rdd, params, data_extractors,
-                                        public_partitions)
+        dp_result = dp_engine.aggregate(
+            self._rdd,
+            params,
+            data_extractors,
+            public_partitions,
+            out_explain_computaton_report=out_explain_computaton_report)
         # dp_result : (partition_key, (variance=dp_variance))
 
         # aggregate() returns a namedtuple of metrics for each partition key.
@@ -107,18 +118,24 @@ class PrivateRDD:
 
         return dp_result
 
-    def mean(self,
-             mean_params: aggregate_params.MeanParams,
-             public_partitions=None) -> RDD:
+    def mean(
+        self,
+        mean_params: aggregate_params.MeanParams,
+        public_partitions=None,
+        out_explain_computaton_report: Optional[
+            pipeline_dp.ExplainComputationReport] = None
+    ) -> RDD:
         """Computes a DP mean.
 
         Args:
             mean_params: parameters for calculation
-            public_partitions: A collection of partition keys that will be present in
-          the result. Optional. If not provided, partitions will be selected in a DP
-          manner.
+            public_partitions: A collection of partition keys that will be
+              present in the result. Optional. If not provided, partitions will
+              be selected in a DP manner.
+            out_explain_computaton_report: if specified, it will contain
+               the Explain Computation report for this aggregation. For
+               more details see the docstring to report_generator.py.
         """
-
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
         dp_engine = pipeline_dp.DPEngine(self._budget_accountant, backend)
 
@@ -140,8 +157,12 @@ class PrivateRDD:
                 params.contribution_bounds_already_enforced),
             value_extractor=lambda x: mean_params.value_extractor(x[1]))
 
-        dp_result = dp_engine.aggregate(self._rdd, params, data_extractors,
-                                        public_partitions)
+        dp_result = dp_engine.aggregate(
+            self._rdd,
+            params,
+            data_extractors,
+            public_partitions,
+            out_explain_computaton_report=out_explain_computaton_report)
         # dp_result : (partition_key, (mean=dp_mean))
 
         # aggregate() returns a namedtuple of metrics for each partition key.
@@ -166,6 +187,9 @@ class PrivateRDD:
             public_partitions: A collection of partition keys that will be
                present in the result. Optional. If not provided, partitions will
                be selected in a DP manner.
+            out_explain_computaton_report: if specified, it will contain
+               the Explain Computation report for this aggregation. For
+               more details see the docstring to report_generator.py.
         """
 
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
@@ -205,18 +229,24 @@ class PrivateRDD:
 
         return dp_result
 
-    def count(self,
-              count_params: aggregate_params.CountParams,
-              public_partitions=None) -> RDD:
+    def count(
+        self,
+        count_params: aggregate_params.CountParams,
+        public_partitions=None,
+        out_explain_computaton_report: Optional[
+            pipeline_dp.ExplainComputationReport] = None
+    ) -> RDD:
         """Computes a DP count.
 
         Args:
             count_params: parameters for calculation
-            public_partitions: A collection of partition keys that will be present in
-          the result. Optional. If not provided, partitions will be selected in a DP
-          manner.
+            public_partitions: A collection of partition keys that will be
+              present in the result. Optional. If not provided, partitions will
+              be selected in a DP manner.
+            out_explain_computaton_report: if specified, it will contain
+               the Explain Computation report for this aggregation. For
+               more details see the docstring to report_generator.py.
         """
-
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
         dp_engine = pipeline_dp.DPEngine(self._budget_accountant, backend)
 
@@ -237,8 +267,12 @@ class PrivateRDD:
                 params.contribution_bounds_already_enforced),
             value_extractor=lambda x: None)
 
-        dp_result = dp_engine.aggregate(self._rdd, params, data_extractors,
-                                        public_partitions)
+        dp_result = dp_engine.aggregate(
+            self._rdd,
+            params,
+            data_extractors,
+            public_partitions,
+            out_explain_computaton_report=out_explain_computaton_report)
         # dp_result : (partition_key, (count=dp_count))
 
         # aggregate() returns a namedtuple of metrics for each partition key.
@@ -250,18 +284,23 @@ class PrivateRDD:
         return dp_result
 
     def privacy_id_count(
-            self,
-            privacy_id_count_params: aggregate_params.PrivacyIdCountParams,
-            public_partitions=None) -> RDD:
+        self,
+        privacy_id_count_params: aggregate_params.PrivacyIdCountParams,
+        public_partitions=None,
+        out_explain_computaton_report: Optional[
+            pipeline_dp.ExplainComputationReport] = None
+    ) -> RDD:
         """Computes a DP Privacy ID count.
 
         Args:
             privacy_id_count_params: parameters for calculation
-            public_partitions: A collection of partition keys that will be present in
-          the result. Optional. If not provided, partitions will be selected in a DP
-          manner.
+            public_partitions: A collection of partition keys that will be
+              present in the result. Optional. If not provided, partitions will
+              be selected in a DP manner.
+            out_explain_computaton_report: if specified, it will contain
+               the Explain Computation report for this aggregation. For
+               more details see the docstring to report_generator.py.
         """
-
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
         dp_engine = pipeline_dp.DPEngine(self._budget_accountant, backend)
 
@@ -282,8 +321,12 @@ class PrivateRDD:
             # PrivacyIdCount ignores values.
             value_extractor=lambda x: None)
 
-        dp_result = dp_engine.aggregate(self._rdd, params, data_extractors,
-                                        public_partitions)
+        dp_result = dp_engine.aggregate(
+            self._rdd,
+            params,
+            data_extractors,
+            public_partitions,
+            out_explain_computaton_report=out_explain_computaton_report)
         # dp_result : (partition_key, (privacy_id_count=dp_privacy_id_count))
 
         # aggregate() returns a namedtuple of metrics for each partition key.

--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pyspark import RDD
-from typing import Callable
+from typing import Callable, Optional
 
 import pipeline_dp
 from pipeline_dp import aggregate_params, budget_accounting
@@ -152,9 +152,13 @@ class PrivateRDD:
 
         return dp_result
 
-    def sum(self,
-            sum_params: aggregate_params.SumParams,
-            public_partitions=None) -> RDD:
+    def sum(
+        self,
+        sum_params: aggregate_params.SumParams,
+        public_partitions=None,
+        out_explain_computaton_report: Optional[
+            pipeline_dp.ExplainComputationReport] = None
+    ) -> RDD:
         """Computes a DP sum.
 
         Args:
@@ -185,8 +189,12 @@ class PrivateRDD:
                 params.contribution_bounds_already_enforced),
             value_extractor=lambda x: sum_params.value_extractor(x[1]))
 
-        dp_result = dp_engine.aggregate(self._rdd, params, data_extractors,
-                                        public_partitions)
+        dp_result = dp_engine.aggregate(
+            self._rdd,
+            params,
+            data_extractors,
+            public_partitions,
+            out_explain_computaton_report=out_explain_computaton_report)
         # dp_result : (partition_key, (sum=dp_sum))
 
         # aggregate() returns a namedtuple of metrics for each partition key.

--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -191,7 +191,6 @@ class PrivateRDD:
                the Explain Computation report for this aggregation. For
                more details see the docstring to report_generator.py.
         """
-
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
         dp_engine = pipeline_dp.DPEngine(self._budget_accountant, backend)
 

--- a/pipeline_dp/private_spark.py
+++ b/pipeline_dp/private_spark.py
@@ -73,9 +73,10 @@ class PrivateRDD:
             public_partitions: A collection of partition keys that will be
               present in the result. Optional. If not provided, partitions will be selected in a DP
               manner.
-            out_explain_computaton_report: if specified, it will contain
-               the Explain Computation report for this aggregation. For
-               more details see the docstring to report_generator.py.
+            out_explain_computaton_report: an output argument, if specified,
+              it will contain the Explain Computation report for this
+              aggregation. For more details see the docstring to
+              report_generator.py.
         """
 
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
@@ -132,9 +133,10 @@ class PrivateRDD:
             public_partitions: A collection of partition keys that will be
               present in the result. Optional. If not provided, partitions will
               be selected in a DP manner.
-            out_explain_computaton_report: if specified, it will contain
-               the Explain Computation report for this aggregation. For
-               more details see the docstring to report_generator.py.
+            out_explain_computaton_report: an output argument, if specified,
+              it will contain the Explain Computation report for this
+              aggregation. For more details see the docstring to
+              report_generator.py.
         """
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
         dp_engine = pipeline_dp.DPEngine(self._budget_accountant, backend)
@@ -187,9 +189,10 @@ class PrivateRDD:
             public_partitions: A collection of partition keys that will be
                present in the result. Optional. If not provided, partitions will
                be selected in a DP manner.
-            out_explain_computaton_report: if specified, it will contain
-               the Explain Computation report for this aggregation. For
-               more details see the docstring to report_generator.py.
+            out_explain_computaton_report: an output argument, if specified,
+              it will contain the Explain Computation report for this
+              aggregation. For more details see the docstring to
+              report_generator.py.
         """
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
         dp_engine = pipeline_dp.DPEngine(self._budget_accountant, backend)
@@ -242,9 +245,10 @@ class PrivateRDD:
             public_partitions: A collection of partition keys that will be
               present in the result. Optional. If not provided, partitions will
               be selected in a DP manner.
-            out_explain_computaton_report: if specified, it will contain
-               the Explain Computation report for this aggregation. For
-               more details see the docstring to report_generator.py.
+            out_explain_computaton_report: an output argument, if specified,
+              it will contain the Explain Computation report for this
+              aggregation. For more details see the docstring to
+              report_generator.py.
         """
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
         dp_engine = pipeline_dp.DPEngine(self._budget_accountant, backend)
@@ -296,9 +300,10 @@ class PrivateRDD:
             public_partitions: A collection of partition keys that will be
               present in the result. Optional. If not provided, partitions will
               be selected in a DP manner.
-            out_explain_computaton_report: if specified, it will contain
-               the Explain Computation report for this aggregation. For
-               more details see the docstring to report_generator.py.
+            out_explain_computaton_report: an output argument, if specified,
+              it will contain the Explain Computation report for this
+              aggregation. For more details see the docstring to
+              report_generator.py.
         """
         backend = pipeline_dp.SparkRDDBackend(self._rdd.context)
         dp_engine = pipeline_dp.DPEngine(self._budget_accountant, backend)

--- a/pipeline_dp/report_generator.py
+++ b/pipeline_dp/report_generator.py
@@ -18,8 +18,24 @@ aggregation performed by PipelineDP. It includes
 1. The input parameters (i.e. pipeline_dp.AggregateParams)
 2. The main stages the computation graphs.
 
-E.g.
+Example of the report
 
+DPEngine method: aggregate
+AggregateParams:
+ metrics=['SUM']
+ noise_kind=laplace
+ budget_weight=1
+ Contribution bounding:
+  max_partitions_contributed=2
+  max_contributions_per_partition=1
+  min_value=1
+  max_value=5
+ Partition selection: private partitions
+Computation graph:
+ 1. Per-partition contribution bounding: for each privacy_id and eachpartition, randomly select max(actual_contributions_per_partition, 1) contributions.
+ 2. Cross-partition contribution bounding: for each privacy_id randomly select max(actual_partition_contributed, 2) partitions
+ 3. Private Partition selection: using Truncated Geometric method with (eps=0.5, delta=1e-06)
+ 4. Computed sum with (eps=0.5 delta=0)
 """
 
 from pipeline_dp import aggregate_params as agg
@@ -74,7 +90,7 @@ class ReportGenerator:
 
 
 class ExplainComputationReport:
-    """Generates explain computation report for 1 DP aggregation.
+    """Container explain computation report for 1 DP aggregation.
 
     Explain computation reports contains configurations of the DP aggregations
     and the main stages of the computation graphs.
@@ -98,6 +114,6 @@ class ExplainComputationReport:
                              " passed as an argument to DP aggregation method?")
         try:
             return self._report_generator.report()
-        except:
+        except e:
             raise ValueError("Explain computation report failed to be generated"
                              ".\nWas BudgetAccountant.compute_budget() called?")

--- a/pipeline_dp/report_generator.py
+++ b/pipeline_dp/report_generator.py
@@ -11,7 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Generator for explaining DP computation reports."""
+"""Explain DP computation reports.
+
+An Explain Computation report contains a human readable description of a DP
+aggregation performed by PipelineDP. It includes
+1. The input parameters (i.e. pipeline_dp.AggregateParams)
+2. The main stages the computation graphs.
+
+E.g.
+
+"""
 
 from pipeline_dp import aggregate_params as agg
 
@@ -21,10 +30,10 @@ from typing import Optional, Union, Callable
 class ReportGenerator:
     """Generates a report based on the metrics and stages in the pipeline.
 
-  Each ReportGenerator corresponds to one aggregation which contains an
-  ordered set of stages. It collects information about the DP aggregation
-  and generates a report.
-  """
+    Each ReportGenerator corresponds to one aggregation which contains an
+    ordered set of stages. It collects information about the DP aggregation
+    and generates a report.
+    """
 
     def __init__(self,
                  params,
@@ -65,6 +74,11 @@ class ReportGenerator:
 
 
 class ExplainComputationReport:
+    """Generates explain computation report for 1 DP aggregation.
+
+    Explain computation reports contains configurations of the DP aggregations
+    and the main stages of the computation graphs.
+    """
 
     def __init__(self):
         self._report_generator = None
@@ -73,10 +87,17 @@ class ExplainComputationReport:
         self._report_generator = report_generator
 
     def text(self) -> str:
+        """Returns the text of the report.
+
+        Raises:
+            ValueError when this function is called before
+              BudgetAccountant.compute_budget().
+        """
         if self._report_generator is None:
-            raise ValueError("Report is empty.")
+            raise ValueError("The report_generator is not set.\nWas this object"
+                             " passed as an argument to DP aggregation method?")
         try:
             return self._report_generator.report()
         except:
-            raise ValueError("Report failed to be generated. Is "
-                             "BudgetAccountant.compute_budget() called?")
+            raise ValueError("Explain computation report failed to be generated"
+                             ".\nWas BudgetAccountant.compute_budget() called?")

--- a/pipeline_dp/report_generator.py
+++ b/pipeline_dp/report_generator.py
@@ -62,3 +62,21 @@ class ReportGenerator:
             else:
                 result.append(f" {i+1}. {stage_str}")
         return "\n".join(result)
+
+
+class ExplainComputationReport:
+
+    def __init__(self):
+        self._report_generator = None
+
+    def _set_report_generator(self, report_generator: ReportGenerator):
+        self._report_generator = report_generator
+
+    def text(self) -> str:
+        if self._report_generator is None:
+            raise ValueError("Report is empty.")
+        try:
+            return self._report_generator.report()
+        except:
+            raise ValueError("Report failed to be generated. Is "
+                             "BudgetAccountant.compute_budget() called?")

--- a/pipeline_dp/report_generator.py
+++ b/pipeline_dp/report_generator.py
@@ -20,22 +20,22 @@ aggregation performed by PipelineDP. It includes
 
 Example of the report
 
-DPEngine method: aggregate
-AggregateParams:
- metrics=['SUM']
- noise_kind=laplace
- budget_weight=1
- Contribution bounding:
-  max_partitions_contributed=2
-  max_contributions_per_partition=1
-  min_value=1
-  max_value=5
- Partition selection: private partitions
-Computation graph:
- 1. Per-partition contribution bounding: for each privacy_id and eachpartition, randomly select max(actual_contributions_per_partition, 1) contributions.
- 2. Cross-partition contribution bounding: for each privacy_id randomly select max(actual_partition_contributed, 2) partitions
- 3. Private Partition selection: using Truncated Geometric method with (eps=0.5, delta=1e-06)
- 4. Computed sum with (eps=0.5 delta=0)
+    DPEngine method: aggregate
+    AggregateParams:
+     metrics=['SUM']
+     noise_kind=laplace
+     budget_weight=1
+     Contribution bounding:
+      max_partitions_contributed=2
+      max_contributions_per_partition=10
+      min_value=1
+      max_value=5
+     Partition selection: private partitions
+    Computation graph:
+     1. Per-partition contribution bounding: for each privacy_id and each partition, randomly select max(actual_contributions_per_partition, 1) contributions.
+     2. Cross-partition contribution bounding: for each privacy_id randomly select max(actual_partition_contributed, 2) partitions
+     3. Private Partition selection: using Truncated Geometric method with (eps=0.5, delta=1e-06)
+     4. Computed sum with (eps=0.5 delta=0)
 """
 
 from pipeline_dp import aggregate_params as agg
@@ -90,11 +90,7 @@ class ReportGenerator:
 
 
 class ExplainComputationReport:
-    """Container explain computation report for 1 DP aggregation.
-
-    Explain computation reports contains configurations of the DP aggregations
-    and the main stages of the computation graphs.
-    """
+    """Container explain computation report for 1 DP aggregation."""
 
     def __init__(self):
         self._report_generator = None

--- a/tests/report_generator_test.py
+++ b/tests/report_generator_test.py
@@ -73,7 +73,7 @@ class ExplainComputationReportTest(unittest.TestCase):
 
         report_generator.add_stage(lambda: stage_fn)
 
-        with self.assertRaisesRegex(ValueError, "failed to be generated"):
+        with self.assertRaisesRegex(ValueError, "report_generator is not set"):
             report.text()
 
     def test_generate(self):

--- a/tests/report_generator_test.py
+++ b/tests/report_generator_test.py
@@ -55,5 +55,43 @@ class ReportGeneratorTest(unittest.TestCase):
         self.assertEqual(expected_report, report_generator.report())
 
 
+class ExplainComputationReportTest(unittest.TestCase):
+
+    def test_report_empty(self):
+        report = pipeline_dp.ExplainComputationReport()
+        with self.assertRaisesRegex(ValueError,
+                                    "The report_generator is not set"):
+            report.text()
+
+    def test_fail_to_generate(self):
+        report = pipeline_dp.ExplainComputationReport()
+        report_generator = ReportGenerator(None, "test_method")
+
+        # Simulate that one of the stages of report generation failed.
+        def stage_fn():
+            raise ValueError("Fail to generate")
+
+        report_generator.add_stage(lambda: stage_fn)
+
+        with self.assertRaisesRegex(ValueError, "failed to be generated"):
+            report.text()
+
+    def test_generate(self):
+        report = pipeline_dp.ExplainComputationReport()
+        params = pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.LAPLACE,
+            metrics=[pipeline_dp.Metrics.COUNT],
+            max_partitions_contributed=2,
+            max_contributions_per_partition=1)
+        report_generator = ReportGenerator(params, "test_method")
+        report_generator.add_stage("stage 1")
+        report_generator.add_stage("stage 2")
+        report._set_report_generator(report_generator)
+
+        text = report.text()
+        self.assertTrue("stage 1" in text)
+        self.assertTrue("stage 2" in text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR contains the following changes:
1.Introducing `ExplainComputationReport` class which is a container for explain computation report.
2.Adding `ExplainComputationReport` to `DPEngine.aggregate` arguments, for returning the report.
3.Adding `ExplainComputationReport` to Beam and Spark APIs.
4.Updating examples

## An example of the Explain Computation report:
```
DPEngine method: aggregate
AggregateParams:
 metrics=['SUM']
 noise_kind=laplace
 budget_weight=1
 Contribution bounding:
  max_partitions_contributed=2
  max_contributions_per_partition=1
  min_value=1
  max_value=5
 Partition selection: private partitions
Computation graph:
 1. Per-partition contribution bounding: for each privacy_id and eachpartition, randomly select max(actual_contributions_per_partition, 1) contributions.
 2. Cross-partition contribution bounding: for each privacy_id randomly select max(actual_partition_contributed, 2) partitions
 3. Private Partition selection: using Truncated Geometric method with (eps=0.5, delta=1e-06)
 4. Computed sum with (eps=0.5 delta=0)
```