### PR TITLE
fix to description of usage of public partitions

### DIFF
--- a/examples/codelab/codelab_PipelineDP.ipynb
+++ b/examples/codelab/codelab_PipelineDP.ipynb
@@ -797,19 +797,16 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "ToCpVK7fYTfY"
       },
       "source": [
-        "  This sets it as an additional input to the `pipeline_dp.AggregateParams` class:\n",
+        "  This sets it as an additional input to the `dp_engine.aggregate()` function:\n",
         "\n",
         "```\n",
-        "params = pipeline_dp.AggregateParams(\n",
-        "     noise_kind=pipeline_dp.NoiseKind.LAPLACE,\n",
-        "     metrics=[pipeline_dp.Metrics.COUNT],\n",
-        "     max_partitions_contributed=1,\n",
-        "     max_contributions_per_partition=1)\n",
+        "dp_result = dp_engine.aggregate(data, params, data_extractors, public_partitions)\n",
         "```\n",
         "\n",
         "  If you use public partitions and `LAPLACE` noise, it's possible to set the `total_delta` argument to a `0` value.\n",
@@ -1361,6 +1358,7 @@
     },
     "kernelspec": {
       "display_name": "Python 3",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {
@@ -1373,7 +1371,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.12"
+      "version": "3.9.2"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
+      }
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
## Description
This PR fixes the description of how to use public partititions. The code has been updated to pass public_partitions to dp_enging.aggregate, but the description still referred to the Params class. 

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- no test required, only markdown change. 

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
