### PR TITLE
Fix handling stage names in private_beam

### DIFF
--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -196,7 +196,7 @@ class UniqueLabelsGenerator:
 
     def __init__(self, suffix):
         self._labels = set()
-        self._suffix = suffix
+        self._suffix = ("_" + suffix) if suffix else ""
 
     def _add_if_unique(self, label):
         if label in self._labels:
@@ -207,11 +207,11 @@ class UniqueLabelsGenerator:
     def unique(self, label):
         if not label:
             label = "UNDEFINED_STAGE_NAME"
-        suffix_label = label + "_" + self._suffix
+        suffix_label = label + self._suffix
         if self._add_if_unique(suffix_label):
             return suffix_label
         for i in itertools.count(1):
-            label_candidate = f"{label}_{i}_{self._suffix}"
+            label_candidate = f"{label}_{i}{self._suffix}"
             if self._add_if_unique(label_candidate):
                 return label_candidate
 

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -252,7 +252,7 @@ class BeamBackendStageNameTest(unittest.TestCase):
             backend.map(col, lambda x: x, "SAME_MAP_NAME")
             backend.map(col, lambda x: x, "SAME_MAP_NAME")
 
-        self.assertEqual("UNIQUE_BACKEND_SUFFIX", backend._ulg._suffix)
+        self.assertEqual("_UNIQUE_BACKEND_SUFFIX", backend._ulg._suffix)
         self.assertEqual(3, len(backend._ulg._labels))
         self.assertIn("SAME_MAP_NAME_UNIQUE_BACKEND_SUFFIX",
                       backend._ulg._labels)

--- a/tests/private_beam_test.py
+++ b/tests/private_beam_test.py
@@ -41,6 +41,17 @@ class PrivateBeamTest(unittest.TestCase):
         return actual[0] == expected[0] and abs(actual[1] -
                                                 expected[1]) <= tolerance
 
+    def test_transform_with_same_label_work(self):
+        # Apache Beam requires that all stage_names were different.
+        # Calling MakePrivate twice and not getting exception, it's checked that
+        # private_beam handles uniqueness of inner stage names correctly.
+        pipeline = TestPipeline()
+        col = pipeline | beam.Create([])
+        pcol1 = col | private_beam.MakePrivate(budget_accountant=None,
+                                               privacy_id_extractor=lambda x: x)
+        pcol2 = col | private_beam.MakePrivate(budget_accountant=None,
+                                               privacy_id_extractor=lambda x: x)
+
     def test_make_private_transform_succeeds(self):
         runner = fn_api_runner.FnApiRunner()
         with beam.Pipeline(runner=runner) as pipeline:


### PR DESCRIPTION
Apache Beam requires that all stage_names were different. `pipeline_dp.BeamBackend` object ensures the uniqueness of the Beam stage names. But it is required to have the same object `BeamBackend` for all operations in private_beam.py.

This PR implements does by introducing a module level variable `_beam_backend` for this.
