### PR TITLE
Extend muti parameter analysis configuration with noise_kind and partition_selection_strategy

### DIFF
--- a/analysis/data_structures.py
+++ b/analysis/data_structures.py
@@ -71,6 +71,9 @@ class MultiParameterConfiguration:
     max_contributions_per_partition: Sequence[int] = None
     min_sum_per_partition: Sequence[float] = None
     max_sum_per_partition: Sequence[float] = None
+    noise_kind: Sequence[pipeline_dp.NoiseKind] = None
+    partition_selection_strategy: Sequence[
+        pipeline_dp.PartitionSelectionStrategy] = None
 
     def __post_init__(self):
         attributes = dataclasses.asdict(self)
@@ -107,6 +110,11 @@ class MultiParameterConfiguration:
             params.min_sum_per_partition = self.min_sum_per_partition[index]
         if self.max_sum_per_partition:
             params.max_sum_per_partition = self.max_sum_per_partition[index]
+        if self.noise_kind:
+            params.noise_kind = self.noise_kind[index]
+        if self.partition_selection_strategy:
+            params.partition_selection_strategy = self.partition_selection_strategy[
+                index]
         return params
 
 

--- a/analysis/tests/data_structures_test.py
+++ b/analysis/tests/data_structures_test.py
@@ -1,0 +1,113 @@
+# Copyright 2022 OpenMined.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Data structures Test"""
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import analysis
+import pipeline_dp
+
+
+class MultiParameterConfiguration(parameterized.TestCase):
+
+    @parameterized.named_parameters(
+        dict(testcase_name="All MultiParameterConfiguration fields unset",
+             error_msg="MultiParameterConfiguration must have at least 1 "
+             "non-empty attribute.",
+             max_partitions_contributed=None,
+             max_contributions_per_partition=None,
+             min_sum_per_partition=None,
+             max_sum_per_partition=None,
+             noise_kind=None,
+             partition_selection_strategy=None),
+        dict(testcase_name="Attributes different size 1",
+             error_msg="All set attributes in MultiParameterConfiguration must "
+             "have the same length.",
+             max_partitions_contributed=[1],
+             max_contributions_per_partition=[1, 2],
+             min_sum_per_partition=None,
+             max_sum_per_partition=None,
+             noise_kind=None,
+             partition_selection_strategy=None),
+        dict(testcase_name="Attributes different size 2",
+             error_msg="All set attributes in MultiParameterConfiguration must "
+             "have the same length.",
+             max_partitions_contributed=None,
+             max_contributions_per_partition=None,
+             min_sum_per_partition=[1, 1, 1],
+             max_sum_per_partition=[2],
+             noise_kind=None,
+             partition_selection_strategy=None),
+        dict(testcase_name="Attributes different size 3",
+             error_msg="All set attributes in MultiParameterConfiguration must "
+             "have the same length.",
+             max_partitions_contributed=None,
+             max_contributions_per_partition=None,
+             min_sum_per_partition=None,
+             max_sum_per_partition=None,
+             noise_kind=[pipeline_dp.NoiseKind.GAUSSIAN] * 2,
+             partition_selection_strategy=[
+                 pipeline_dp.PartitionSelectionStrategy.TRUNCATED_GEOMETRIC
+             ] * 3),
+        dict(testcase_name="One of min_sum_per_partition, "
+             "max_sum_per_partition is None",
+             error_msg="MultiParameterConfiguration: min_sum_per_partition and "
+             "max_sum_per_partition must be both set or both None.",
+             max_partitions_contributed=None,
+             max_contributions_per_partition=None,
+             min_sum_per_partition=[1, 1, 1],
+             max_sum_per_partition=None,
+             noise_kind=None,
+             partition_selection_strategy=None),
+    )
+    def test_validation(self, error_msg, max_partitions_contributed,
+                        max_contributions_per_partition, min_sum_per_partition,
+                        max_sum_per_partition, noise_kind,
+                        partition_selection_strategy):
+        with self.assertRaisesRegex(ValueError, error_msg):
+            analysis.MultiParameterConfiguration(
+                max_partitions_contributed, max_contributions_per_partition,
+                min_sum_per_partition, max_sum_per_partition, noise_kind,
+                partition_selection_strategy)
+
+    def test_get_aggregate_params(self):
+        params = pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            metrics=[pipeline_dp.Metrics.COUNT],
+            max_partitions_contributed=1,
+            max_contributions_per_partition=1)
+
+        max_partitions_contributed = [10, 12, 15]
+        noise_kind = [pipeline_dp.NoiseKind.LAPLACE] * 2 + [
+            pipeline_dp.NoiseKind.GAUSSIAN
+        ]
+        selection_strategy = [
+            pipeline_dp.PartitionSelectionStrategy.GAUSSIAN_THRESHOLDING
+        ] * 3
+        multi_params = analysis.MultiParameterConfiguration(
+            max_partitions_contributed=max_partitions_contributed,
+            noise_kind=noise_kind,
+            partition_selection_strategy=selection_strategy)
+        self.assertTrue(3, multi_params.size)
+
+        for i in range(multi_params.size):
+            ith_params = multi_params.get_aggregate_params(params, i)
+            params.max_partitions_contributed = max_partitions_contributed[i]
+            params.noise_kind = noise_kind[i]
+            params.partition_selection_strategy = selection_strategy[i]
+            self.assertEqual(params, ith_params)
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/analysis/tests/utility_analysis_engine_test.py
+++ b/analysis/tests/utility_analysis_engine_test.py
@@ -24,65 +24,6 @@ from analysis import metrics
 import analysis
 
 
-class MultiParameterConfiguration(parameterized.TestCase):
-
-    @parameterized.named_parameters(
-        dict(testcase_name="All MultiParameterConfiguration fields unset",
-             error_msg="MultiParameterConfiguration must have at least 1 "
-             "non-empty attribute.",
-             max_partitions_contributed=None,
-             max_contributions_per_partition=None,
-             min_sum_per_partition=None,
-             max_sum_per_partition=None),
-        dict(testcase_name="Attributes different size 1",
-             error_msg="All set attributes in MultiParameterConfiguration must "
-             "have the same length.",
-             max_partitions_contributed=[1],
-             max_contributions_per_partition=[1, 2],
-             min_sum_per_partition=None,
-             max_sum_per_partition=None),
-        dict(testcase_name="Attributes different size 2",
-             error_msg="All set attributes in MultiParameterConfiguration must "
-             "have the same length.",
-             max_partitions_contributed=None,
-             max_contributions_per_partition=None,
-             min_sum_per_partition=[1, 1, 1],
-             max_sum_per_partition=[2]),
-        dict(testcase_name="One of min_sum_per_partition, "
-             "max_sum_per_partition is None",
-             error_msg="MultiParameterConfiguration: min_sum_per_partition and "
-             "max_sum_per_partition must be both set or both None.",
-             max_partitions_contributed=None,
-             max_contributions_per_partition=None,
-             min_sum_per_partition=[1, 1, 1],
-             max_sum_per_partition=None),
-    )
-    def test_validation(self, error_msg, max_partitions_contributed,
-                        max_contributions_per_partition, min_sum_per_partition,
-                        max_sum_per_partition):
-        with self.assertRaisesRegex(ValueError, error_msg):
-            analysis.MultiParameterConfiguration(
-                max_partitions_contributed, max_contributions_per_partition,
-                min_sum_per_partition, max_sum_per_partition)
-
-    def test_get_aggregate_params(self):
-        params = pipeline_dp.AggregateParams(
-            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
-            metrics=[pipeline_dp.Metrics.COUNT],
-            max_partitions_contributed=1,
-            max_contributions_per_partition=1)
-
-        max_partitions_contributed = [10, 12, 15]
-        multi_params = analysis.MultiParameterConfiguration(
-            max_partitions_contributed=max_partitions_contributed)
-        self.assertTrue(3, multi_params.size)
-
-        for i in range(multi_params.size):
-            ith_params = multi_params.get_aggregate_params(params, i)
-            params.max_partitions_contributed = max_partitions_contributed[i]
-            self.assertEqual(params, ith_params)
-
-
 class UtilityAnalysisEngineTest(parameterized.TestCase):
 
     def _get_default_extractors(self) -> pipeline_dp.DataExtractors:


### PR DESCRIPTION
This CL introduces the possibility to run multi-parameter Utility analysis with different `noise_kind` and `partition_selection_strategy`.