### PR TITLE
(WIP) Support to PLD composition #259

### DIFF
--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -48,14 +48,7 @@ class MechanismSpec:
 
     @property
     def noise_standard_deviation(self):
-        """Noise value for the mechanism.
-
-        Raises:
-            AssertionError: The noise value is not calculated yet.
-        """
-        if self._noise_standard_deviation is None:
-            raise AssertionError(
-                "Noise standard deviation is not calculated yet.")
+        """Noise value for the mechanism. It can be None before budget is computed."""
         return self._noise_standard_deviation
 
     @property

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -149,17 +149,23 @@ class CombinerParams:
     @property
     def delta(self):
         return self._mechanism_spec.delta
+    
+    @property
+    def noise_standard_deviation(self):
+        return self._mechanism_spec.noise_standard_deviation
 
     @property
     def scalar_noise_params(self):
         return dp_computations.ScalarNoiseParams(
-            self.eps, self.delta, self.aggregate_params.min_value,
+            self.eps, self.delta,
+            self.aggregate_params.min_value,
             self.aggregate_params.max_value,
             self.aggregate_params.min_sum_per_partition,
             self.aggregate_params.max_sum_per_partition,
             self.aggregate_params.max_partitions_contributed,
             self.aggregate_params.max_contributions_per_partition,
-            self.aggregate_params.noise_kind)
+            self.aggregate_params.noise_kind,
+            self.noise_standard_deviation)
 
     @property
     def additive_vector_noise_params(

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -198,9 +198,8 @@ class NaiveBudgetAccountantTest(parameterized.TestCase):
 class PLDBudgetAccountantTest(unittest.TestCase):
 
     def test_noise_not_calculated(self):
-        with self.assertRaises(AssertionError):
-            mechanism = MechanismSpec(MechanismType.LAPLACE)
-            print(mechanism.noise_standard_deviation())
+        mechanism = MechanismSpec(MechanismType.LAPLACE)
+        self.assertEqual(None, mechanism.noise_standard_deviation)
 
     def test_invalid_epsilon(self):
         with self.assertRaises(ValueError):
@@ -257,7 +256,7 @@ class PLDBudgetAccountantTest(unittest.TestCase):
             epsilon: float
             delta: float
             expected_pipeline_noise_std: float
-            mechanisms: []
+            mechanisms: list
 
         testcases = [
             ComputeBudgetTestCase(

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -221,7 +221,7 @@ class DPComputationsTest(parameterized.TestCase):
             value=20, eps=0.5, delta=1e-10, l2_sensitivity=3)
 
         # Assert
-        gaussian_mechanism.assert_called_with(0.5, 1e-10, 3)
+        gaussian_mechanism.assert_called_with(epsilon=0.5, delta=1e-10, sensitivity=3)
         mock_gaussian_mechanism.add_noise.assert_called_with(20)
         self.assertEqual("value_with_noise", anonymized_value)
 


### PR DESCRIPTION
## Description
Solving "Advance composition in PipelineDP" #259 

The approach I'm using is: 
- Propagates noise_standard_deviation (in the case of NaiveAccountant, it is None throughout)
- When it reaches apply_laplace_mechanism/apply_gaussian_mechanism, if noise_standard_deviation is NOT None, we use it for noise (ignoring eps/delta)
- Otherwise (if noise_standard_deviation is None), eps/delta are used to add noise.

Tasks:
- [x] Add noise_standard_deviation to **scalar** computations and parameters
- [x] Ajust tests to pass after changes
- [ ] Create tests for **scalar** computations with noise_standard_deviation
- [ ] Same as above, just to **vector** sum computation

Additionally:
- I've also did some minor changes, like two TODOs in the `dp_computations.py` and formatting.
- I see that `request_budget` receives `noise_standard_deviation`, do you know why? not sure if it is needed, as `noise_standard_deviation` is only calculated in compute_budgets.
