### PR TITLE
Refactor analysis output metrics: part 2 Per-partition utlity metrics to cross-partition

### DIFF
--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -82,8 +82,9 @@ def _sum_metrics_to_metric_utility(
     absolute_error = _sum_metrics_to_value_error(
         sum_metrics, keep_prob=partition_keep_probability)
     if sum_metrics.sum == 0:
-        # Relative error can't be computed. Set relative errors to 0 in order
-        # not to influence aggregated relative error.
+        # When the actual value is 0, the relative error can't be computed. Set
+        # relative errors to 0 in order not to influence aggregated relative
+        # error.
         relative_error = metrics.ValueErrors.get_empty()
     else:
         relative_error = absolute_error.to_relative(sum_metrics.sum)

--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -1,0 +1,99 @@
+# Copyright 2022 OpenMined.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility Analysis cross partition combiners."""
+import copy
+import dataclasses
+
+import pipeline_dp
+from analysis import metrics
+from typing import Optional
+import math
+
+
+def _sum_metrics_to_data_dropped(
+        sum_metrics: metrics.SumMetrics,
+        dp_metric: pipeline_dp.Metrics) -> Optional[metrics.DataDropInfo]:
+    """Finds Data drop information from per-partition metrics."""
+    # TODO(dvadym): implement
+    return None
+
+
+def _create_contribution_bounding_errors(
+        sum_metrics: metrics.SumMetrics) -> metrics.ContributionBoundingErrors:
+    """Creates ContributionBoundingErrors from per-partition metrics."""
+    l0_mean = sum_metrics.expected_cross_partition_error
+    l0_var = sum_metrics.std_cross_partition_error**2
+    l0_mean_var = metrics.MeanVariance(mean=l0_mean, var=l0_var)
+    linf_min = sum_metrics.per_partition_error_min
+    linf_max = sum_metrics.per_partition_error_max
+    return metrics.ContributionBoundingErrors(l0=l0_mean_var,
+                                              linf_min=linf_min,
+                                              linf_max=linf_max)
+
+
+def _sum_metrics_to_value_error(sum_metrics: metrics.SumMetrics,
+                                keep_prob: float) -> metrics.ValueErrors:
+    """Creates ValueErrors from per-partition metrics."""
+    value = sum_metrics.sum
+    bounding_errors = _create_contribution_bounding_errors(sum_metrics)
+    mean = bounding_errors.l0.mean + bounding_errors.linf_min + bounding_errors.linf_max
+    variance = sum_metrics.std_cross_partition_error**2 + sum_metrics.std_noise**2
+
+    rmse = math.sqrt(mean**2 + variance)
+    l1 = 0  # TODO(dvadym) compute it.
+    rmse_with_dropped_partitions = keep_prob * rmse + (1 -
+                                                       keep_prob) * abs(value)
+    l1_with_dropped_partitions = 0  # TODO(dvadym) compute it.
+    result = metrics.ValueErrors(
+        bounding_errors=bounding_errors,
+        mean=mean,
+        variance=variance,
+        rmse=rmse,
+        l1=l1,
+        rmse_with_dropped_partitions=rmse_with_dropped_partitions,
+        l1_with_dropped_partitions=l1_with_dropped_partitions)
+    return result
+
+
+def _sum_metrics_to_metric_utility(
+        sum_metrics: metrics.SumMetrics, dp_metric: pipeline_dp.Metrics,
+        partition_keep_probability: float) -> metrics.MetricUtility:
+    """Creates cross partition MetricUtility from 1 partition utility.
+
+    Attributes:
+        sum_metrics: per-partition utility metric.
+        dp_metric: metric for which utility is computed (e.g. COUNT)
+        partition_keep_probability: partition selection probability.
+    """
+    assert dp_metric != pipeline_dp.Metrics.SUM, "Cross-partition metrics are not implemented for Sum"
+    is_empty_public = sum_metrics.sum == 0  # it wouldn't work for SUM.
+    data_dropped = _sum_metrics_to_data_dropped(sum_metrics, dp_metric)
+    absolute_error = _sum_metrics_to_value_error(
+        sum_metrics, keep_prob=partition_keep_probability)
+    if sum_metrics.sum == 0:
+        # Relative error can't be computed. Set relative errors to 0 in order
+        # not to influence aggregated relative error.
+        relative_error = metrics.ValueErrors.get_empty()
+    else:
+        relative_error = absolute_error.to_relative(sum_metrics.sum)
+    return metrics.MetricUtility(
+        metric=dp_metric,
+        num_dataset_partitions=1,
+        num_non_public_partitions=0,  # todo(dvadym): to implement it.
+        num_empty_partitions=1 if is_empty_public else 0,
+        noise_std=sum_metrics.std_noise,
+        noise_kind=sum_metrics.noise_kind,
+        ratio_data_dropped=data_dropped,
+        absolute_error=absolute_error,
+        relative_error=relative_error)

--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -69,7 +69,7 @@ def _sum_metrics_to_value_error(sum_metrics: metrics.SumMetrics,
 def _sum_metrics_to_metric_utility(
         sum_metrics: metrics.SumMetrics, dp_metric: pipeline_dp.Metrics,
         partition_keep_probability: float) -> metrics.MetricUtility:
-    """Creates cross partition MetricUtility from 1 partition utility.
+    """Creates cross-partition MetricUtility from 1 partition utility.
 
     Attributes:
         sum_metrics: per-partition utility metric.
@@ -77,17 +77,13 @@ def _sum_metrics_to_metric_utility(
         partition_keep_probability: partition selection probability.
     """
     assert dp_metric != pipeline_dp.Metrics.SUM, "Cross-partition metrics are not implemented for Sum"
-    is_empty_public = sum_metrics.sum == 0  # it wouldn't work for SUM.
+    # The next line does not work for SUM because the user can contribute 0.
+    is_empty_public = sum_metrics.sum == 0
     data_dropped = _sum_metrics_to_data_dropped(sum_metrics, dp_metric)
     absolute_error = _sum_metrics_to_value_error(
         sum_metrics, keep_prob=partition_keep_probability)
-    if sum_metrics.sum == 0:
-        # When the actual value is 0, the relative error can't be computed. Set
-        # relative errors to 0 in order not to influence aggregated relative
-        # error.
-        relative_error = metrics.ValueErrors.get_empty()
-    else:
-        relative_error = absolute_error.to_relative(sum_metrics.sum)
+    relative_error = absolute_error.to_relative(sum_metrics.sum)
+
     return metrics.MetricUtility(
         metric=dp_metric,
         num_dataset_partitions=1,

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -175,6 +175,7 @@ class ContributionBoundingErrors:
     linf_max: float
 
     def to_relative(self, value: float) -> 'ContributionBoundingErrors':
+        """Converts from the absolute to the relative error dividing by actual value."""
         l0_rel_mean_var = MeanVariance(self.l0.mean / value,
                                        self.l0.var / value**2)
         return ContributionBoundingErrors(l0=l0_rel_mean_var,
@@ -198,7 +199,8 @@ class ValueErrors:
 
     Attributes:
         bounding_errors: contribution bounding errors.
-        bias: averaged across partitions E(dp_value - actual_value).
+        mean: averaged across partitions E(dp_value - actual_value), aka
+         statistical bias.
         variance: averaged across partitions Var(dp_value - actual_value).
         rmse: averaged across partitions sqrt(E(dp_value - actual_value)^2).
         l1: averaged across partitions E|dp_value - actual_value|.
@@ -221,14 +223,16 @@ class ValueErrors:
     l1_with_dropped_partitions: float
 
     def to_relative(self, value: float):
+        """Converts from the absolute to the relative error dividing by actual value."""
         return ValueErrors(
             self.bounding_errors.to_relative(value),
             mean=self.mean / value,
             variance=self.variance / value**2,
             rmse=self.rmse / value,
             l1=self.l1 / value,
-            rmse_with_dropped_partitions=self.rmse_with_dropped_partitions,
-            l1_with_dropped_partitions=self.l1_with_dropped_partitions)
+            rmse_with_dropped_partitions=self.rmse_with_dropped_partitions /
+            value,
+            l1_with_dropped_partitions=self.l1_with_dropped_partitions / value)
 
     @classmethod
     def get_empty(cls):

--- a/analysis/tests/cross_partition_combiners_test.py
+++ b/analysis/tests/cross_partition_combiners_test.py
@@ -1,0 +1,75 @@
+# Copyright 2022 OpenMined.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Cross partition utility analysis combiners."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import math
+
+from analysis import metrics
+from analysis import cross_partition_combiners
+import pipeline_dp
+
+
+class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
+
+    @staticmethod
+    def get_sum_metrics():
+        return metrics.SumMetrics(sum=10.0,
+                                  per_partition_error_min=3.0,
+                                  per_partition_error_max=-5.0,
+                                  expected_cross_partition_error=-2.0,
+                                  std_cross_partition_error=3.0,
+                                  std_noise=4.0,
+                                  noise_kind=pipeline_dp.NoiseKind.LAPLACE)
+
+    def test_metric_utility_count(self):
+        input = self.get_sum_metrics()
+        output: metrics.MetricUtility = cross_partition_combiners._sum_metrics_to_metric_utility(
+            input, pipeline_dp.Metrics.COUNT, partition_keep_probability=1.0)
+
+        self.assertEqual(output.metric, pipeline_dp.Metrics.COUNT)
+        self.assertEqual(output.num_dataset_partitions, 1)
+        self.assertEqual(output.num_empty_partitions, 0)
+        self.assertEqual(output.noise_kind, input.noise_kind)
+        self.assertEqual(output.noise_std, input.std_noise)
+
+        # Check absolute_error.
+        abs_error: metrics.ValueErrors = output.absolute_error
+        self.assertEqual(abs_error.mean, -4)
+        self.assertEqual(abs_error.variance, 25)
+        self.assertAlmostEqual(abs_error.rmse,
+                               math.sqrt(4 * 4 + 25),
+                               delta=1e-12)
+
+        bounding_errors = abs_error.bounding_errors
+        self.assertEqual(bounding_errors.l0, metrics.MeanVariance(-2.0, 9))
+        self.assertEqual(bounding_errors.linf_min, 3.0)
+        self.assertEqual(bounding_errors.linf_max, -5.0)
+
+        # Check relative_error.
+        expected_rel_error = abs_error.to_relative(input.sum)
+        self.assertEqual(output.relative_error, expected_rel_error)
+        self.assertAlmostEqual(output.relative_error.mean, -0.4, delta=1e-12)
+
+    def test_metric_utility_empty_partition(self):
+        input = self.get_sum_metrics()
+        input.sum = 0
+        output: metrics.MetricUtility = cross_partition_combiners._sum_metrics_to_metric_utility(
+            input, pipeline_dp.Metrics.COUNT, partition_keep_probability=1.0)
+        self.assertEqual(output.num_empty_partitions, 1)
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/analysis/tests/cross_partition_combiners_test.py
+++ b/analysis/tests/cross_partition_combiners_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for Cross partition utility analysis combiners."""
+"""Tests for cross-partition utility analysis combiners."""
 
 from absl.testing import absltest
 from absl.testing import parameterized


### PR DESCRIPTION
This refactoring is about introducing new output dataclasses for cross-partition utility metrics. It includes the following parts.
1. Introducing the new dataclasses, [PR](https://github.com/OpenMined/PipelineDP/pull/400)
2. Converting per-partition utility metric for 1 partition to a cross partition utility metric (this PR) 
3. Combining  cross partition utility metric (next PRs), the new combiners for that (in cross_partition_combiner.py)
4. Updating `perform_utility_analysis` for using new combiners.