### PR TITLE
Refactor analysis output metrics: part 6 Merging cross-partition utility metrics

### DIFF
--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -131,6 +131,8 @@ def _add_dataclasses_by_fields(dataclass1, dataclass2,
         if field.name in fields_to_ignore:
             continue
         value1 = getattr(dataclass1, field.name)
+        if value1 is None:
+            continue
         value2 = getattr(dataclass2, field.name)
         if dataclasses.is_dataclass(value1):
             _add_dataclasses_by_fields(value1, value2, fields_to_ignore)
@@ -138,10 +140,10 @@ def _add_dataclasses_by_fields(dataclass1, dataclass2,
         setattr(dataclass1, field.name, value1 + value2)
 
 
-def _multiply_float_dataclasses_field(dataclass, factor: float):
+def _multiply_float_dataclasses_field(dataclass, factor: float) -> None:
     """Recursively multiply all float fields of the dataclass by given number.
 
-    Warning: it modifies dataclass.
+    Warning: it modifies 'dataclass' argument.
     """
     fields = dataclasses.fields(dataclass)
     for field in fields:
@@ -152,3 +154,41 @@ def _multiply_float_dataclasses_field(dataclass, factor: float):
             setattr(dataclass, field.name, value * factor)
         if dataclasses.is_dataclass(value):
             _multiply_float_dataclasses_field(value, factor)
+
+
+def _merge_partition_selection_metrics(
+        utility1: metrics.PrivatePartitionSelectionMetrics,
+        utility2: metrics.PrivatePartitionSelectionMetrics) -> None:
+    """Merges cross-partition utility metrics.
+
+    Warning: it modifies 'utility1' argument.
+    """
+    utility1.num_partitions += utility2.num_partitions
+    utility1.dropped_partitions.mean += utility2.dropped_partitions.mean
+    utility1.dropped_partitions.var += utility2.dropped_partitions.var
+    # todo(dvadym): implement for ratio_dropped_data
+
+
+def _merge_metric_utility(utility1: metrics.MetricUtility,
+                          utility2: metrics.MetricUtility) -> None:
+    """Merges cross-partition metric utilities.
+
+    Warning: it modifies 'utility1' argument.
+    """
+    _add_dataclasses_by_fields(utility1, utility2,
+                               ["metric", "noise_std", "noise_kind"])
+
+
+def _merge_utility_reports(report1: metrics.UtilityReport,
+                           report2: metrics.UtilityReport):
+    """Merges cross-partition utility reports.
+
+    Warning: it modifies 'report1' argument.
+    """
+    _merge_partition_selection_metrics(report1.partition_selection_metrics,
+                                       report2.partition_selection_metrics)
+    if report1.metric_errors is None:
+        return
+    assert len(report1.metric_errors) == len(report2.metric_errors)
+    for utility1, utility2 in zip(report1.metric_errors, report2.metric_errors):
+        _merge_metric_utility(utility1, utility2)

--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -141,7 +141,7 @@ def _add_dataclasses_by_fields(dataclass1, dataclass2,
 
 
 def _multiply_float_dataclasses_field(dataclass, factor: float) -> None:
-    """Recursively multiply all float fields of the dataclass by given number.
+    """Recursively multiplies all float fields of the dataclass by given number.
 
     Warning: it modifies 'dataclass' argument.
     """

--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -180,7 +180,7 @@ def _merge_metric_utility(utility1: metrics.MetricUtility,
 
 
 def _merge_utility_reports(report1: metrics.UtilityReport,
-                           report2: metrics.UtilityReport):
+                           report2: metrics.UtilityReport) -> None:
     """Merges cross-partition utility reports.
 
     Warning: it modifies 'report1' argument.

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -331,7 +331,7 @@ class UtilityReport:
           PRIVACY_ID_COUNT).
         partition_selection_metrics: utility analysis of selected partition.
     """
-    input_aggregate_params: pipeline_dp.AggregateParams
+    input_aggregate_params: Optional[pipeline_dp.AggregateParams]
 
     metric_errors: Optional[List[MetricUtility]] = None
     partition_selection_metrics: Optional[


### PR DESCRIPTION
Merge is needed in order to aggregate cross-partition metrics over dataset