### PR TITLE
Refactor analysis output metrics: part 7 Cross-partition metrics combiner

### DIFF
--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -92,11 +92,11 @@ def _sum_metrics_to_metric_utility(
 
 
 def _partition_metrics_public_partitions(
-        is_empty_partition: bool) -> metrics.PartitionMetrics:
-    result = metrics.PartitionMetrics(public_partitions=True,
-                                      num_dataset_partitions=0,
-                                      num_non_public_partitions=0,
-                                      num_empty_partitions=0)
+        is_empty_partition: bool) -> metrics.PartitionsInfo:
+    result = metrics.PartitionsInfo(public_partitions=True,
+                                    num_dataset_partitions=0,
+                                    num_non_public_partitions=0,
+                                    num_empty_partitions=0)
     if is_empty_partition:
         result.num_empty_partitions = 1
     else:
@@ -105,12 +105,12 @@ def _partition_metrics_public_partitions(
 
 
 def _partition_metrics_private_partitions(
-        prob_keep: float) -> metrics.PartitionMetrics:
+        prob_keep: float) -> metrics.PartitionsInfo:
     kept_partitions = metrics.MeanVariance(mean=prob_keep,
                                            var=prob_keep * (1 - prob_keep))
-    return metrics.PartitionMetrics(public_partitions=False,
-                                    num_dataset_partitions=1,
-                                    kept_partitions=kept_partitions)
+    return metrics.PartitionsInfo(public_partitions=False,
+                                  num_dataset_partitions=1,
+                                  kept_partitions=kept_partitions)
 
 
 def _add_dataclasses_by_fields(dataclass1, dataclass2,
@@ -192,8 +192,8 @@ def _per_partition_to_utility_report(
                                  metric_errors=metric_errors)
 
 
-def _merge_partition_metrics(metrics1: metrics.PartitionMetrics,
-                             metrics2: metrics.PartitionMetrics) -> None:
+def _merge_partition_metrics(metrics1: metrics.PartitionsInfo,
+                             metrics2: metrics.PartitionsInfo) -> None:
     """Merges cross-partition utility metrics.
 
     Warning: it modifies 'metrics1' argument.

--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -97,10 +97,15 @@ def _sum_metrics_to_metric_utility(
 
 def _create_partition_metrics_for_public_partitions(
         is_empty_partition: bool) -> metrics.PartitionMetrics:
-    return metrics.PartitionMetrics(public_partitions=True,
-                                    num_dataset_partitions=0,
-                                    num_non_public_partitions=0,
-                                    num_empty_partitions=0)
+    result = metrics.PartitionMetrics(public_partitions=True,
+                                      num_dataset_partitions=0,
+                                      num_non_public_partitions=0,
+                                      num_empty_partitions=0)
+    if is_empty_partition:
+        result.num_empty_partitions = 1
+    else:
+        result.num_dataset_partitions = 1
+    return result
 
 
 def _create_partition_metrics_for_private_partitions(

--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -83,16 +83,12 @@ def _sum_metrics_to_metric_utility(
         sum_metrics, keep_prob=partition_keep_probability)
     relative_error = absolute_error.to_relative(sum_metrics.sum)
 
-    return metrics.MetricUtility(
-        metric=dp_metric,
-        num_dataset_partitions=1,
-        num_non_public_partitions=0,  # todo(dvadym): to implement it.
-        num_empty_partitions=1 if is_empty_public else 0,
-        noise_std=sum_metrics.std_noise,
-        noise_kind=sum_metrics.noise_kind,
-        ratio_data_dropped=data_dropped,
-        absolute_error=absolute_error,
-        relative_error=relative_error)
+    return metrics.UtilityReport(metric=dp_metric,
+                                 noise_std=sum_metrics.std_noise,
+                                 noise_kind=sum_metrics.noise_kind,
+                                 ratio_data_dropped=data_dropped,
+                                 absolute_error=absolute_error,
+                                 relative_error=relative_error)
 
 
 def _create_partition_metrics_for_public_partitions(

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -170,8 +170,6 @@ class ContributionBoundingErrors:
         l0: max_partition_contributed (aka l0) bounding error. The output of l0
           bounding is a random variable for each partition. Its distribution is
           close to normal when number of contribution per partition is large.
-        linf: per partition (aka linf) bounding error. The output of linf
-          bounding is deterministic for each partition.
         linf_min & linf_max: represents error due to min & max contribution
           bounding, respectively (only populated for Sum metrics). It is
           deterministic for each partition.
@@ -303,7 +301,7 @@ class MetricUtility:
 
 
 @dataclass
-class PartitionMetrics:
+class PartitionsInfo:
     """Stores aggregate metrics about partitions and partition selection.
 
     Attributes:
@@ -338,11 +336,11 @@ class UtilityReport:
     Attributes:
         input_aggregate_params: input parameters for which this utility analysis
           was computed.
-        partition_selection_metrics: utility analysis of selected partition.
+        partition_metrics: utility analysis of selected partition.
         metric_errors: utility analysis of metrics (e.g. COUNT, SUM,
           PRIVACY_ID_COUNT).
     """
     input_aggregate_params: Optional[pipeline_dp.AggregateParams]
 
-    partition_metrics: PartitionMetrics
+    partition_metrics: PartitionsInfo
     metric_errors: Optional[List[MetricUtility]] = None

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -50,7 +50,7 @@ class SumMetrics:
 
 @dataclass
 class PerPartitionMetrics:
-    probability_to_keep: float  # todo: add comment
+    partition_selection_probability_to_keep: float
     metric_errors: Optional[List[SumMetrics]] = None
 
 
@@ -282,11 +282,6 @@ class MetricUtility:
 
     Attributes:
         metric: DP metric for which this analysis was performed.
-        num_dataset_partitions: the number of partitions in dataset.
-        num_non_public_partitions: the number of partitions dropped because
-          of public partitions.
-        num_empty_partitions: the number of empty partitions added because of
-          public partitions.
         noise_std: the standard deviation of added noise.
         noise_kind: the noise kind (Laplace or Gaussian)
         ratio_data_dropped: the information about dropped data.
@@ -294,9 +289,6 @@ class MetricUtility:
         relative_error: error in terms of (dp_value - actual_value)/actual_value.
     """
     metric: pipeline_dp.Metrics
-    num_dataset_partitions: int
-    num_non_public_partitions: int
-    num_empty_partitions: int
 
     # Noise information.
     noise_std: float
@@ -312,7 +304,19 @@ class MetricUtility:
 
 @dataclass
 class PartitionMetrics:
-    """Stores aggregate metrics about partition selection."""
+    """Stores aggregate metrics about partitions ans partition selection.
+
+    Attributes:
+        public_partitions: true if public partitinos are used.
+        num_dataset_partitions: the number of partitions in dataset.
+        num_non_public_partitions: the number of partitions dropped because
+          of public partitions.
+        num_empty_partitions: the number of empty partitions added because of
+          public partitions.
+        strategy: Private partition selection strategy. None if public
+          partitions are used.
+        kept_partitions: Mean and Variance of the number of kept partitions.
+    """
     public_partitions: bool
 
     # Common

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -304,7 +304,7 @@ class MetricUtility:
 
 @dataclass
 class PartitionMetrics:
-    """Stores aggregate metrics about partitions ans partition selection.
+    """Stores aggregate metrics about partitions and partition selection.
 
     Attributes:
         public_partitions: true if public partitinos are used.

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -50,7 +50,7 @@ class SumMetrics:
 
 @dataclass
 class PerPartitionMetrics:
-    partition_selection_probability_to_keep: float
+    probability_to_keep: float  # todo: add comment
     metric_errors: Optional[List[SumMetrics]] = None
 
 
@@ -311,13 +311,20 @@ class MetricUtility:
 
 
 @dataclass
-class PrivatePartitionSelectionMetrics:
+class PartitionMetrics:
     """Stores aggregate metrics about partition selection."""
+    public_partitions: bool
 
-    strategy: Optional[pipeline_dp.PartitionSelectionStrategy]
-    num_partitions: int
-    dropped_partitions: MeanVariance
-    ratio_dropped_data: float
+    # Common
+    num_dataset_partitions: int
+
+    # Public partitions
+    num_non_public_partitions: Optional[int] = None
+    num_empty_partitions: Optional[int] = None
+
+    # Private partition selection
+    strategy: Optional[pipeline_dp.PartitionSelectionStrategy] = None
+    kept_partitions: Optional[MeanVariance] = None
 
 
 @dataclass
@@ -333,5 +340,5 @@ class UtilityReport:
     """
     input_aggregate_params: Optional[pipeline_dp.AggregateParams]
 
-    partition_selection: Optional[PrivatePartitionSelectionMetrics] = None
+    partition_metrics: PartitionMetrics
     metric_errors: Optional[List[MetricUtility]] = None

--- a/analysis/tests/cross_partition_combiners_test.py
+++ b/analysis/tests/cross_partition_combiners_test.py
@@ -93,7 +93,7 @@ class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
         dp_metrics = [
             pipeline_dp.Metrics.PRIVACY_ID_COUNT, pipeline_dp.Metrics.COUNT
         ]
-        cross_partition_combiners._per_partition_to_cross_partition_utility(
+        cross_partition_combiners._per_partition_to_cross_partition_metrics(
             per_partition_utility, dp_metrics, public_partitions)
         if public_partitions:
             mock_partition_selection_per_to_cross_partition.assert_not_called()
@@ -112,7 +112,7 @@ class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
             mock_partition_selection_per_to_cross_partition):
         per_partition_utility = metrics.PerPartitionMetrics(0.5,
                                                             metric_errors=None)
-        output = cross_partition_combiners._per_partition_to_cross_partition_utility(
+        output = cross_partition_combiners._per_partition_to_cross_partition_metrics(
             per_partition_utility, [], public_partitions=False)
 
         self.assertIsNone(output.metric_errors)
@@ -216,8 +216,7 @@ class MergeMetricsTests(parameterized.TestCase):
         utility1 = self.get_partition_selection_metrics(coef=1)
         utility2 = self.get_partition_selection_metrics(coef=2)
         expected_utility = self.get_partition_selection_metrics(coef=3)
-        cross_partition_combiners._merge_partition_selection_metrics(
-            utility1, utility2)
+        cross_partition_combiners._merge_partition_metrics(utility1, utility2)
         self.assertEqual(utility1, expected_utility)
 
     def test_merge_metric_utility(self):

--- a/analysis/tests/cross_partition_combiners_test.py
+++ b/analysis/tests/cross_partition_combiners_test.py
@@ -66,7 +66,7 @@ class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
     @parameterized.parameters(False, True)
     def test_create_partition_metrics_for_public_partitions(
             self, is_empty_partition):
-        output: metrics.PartitionMetrics = cross_partition_combiners._partition_metrics_public_partitions(
+        output: metrics.PartitionsInfo = cross_partition_combiners._partition_metrics_public_partitions(
             is_empty_partition)
         self.assertTrue(output.public_partitions)
         self.assertEqual(output.num_non_public_partitions, 0)
@@ -175,13 +175,13 @@ class DataclassHelpersTests(parameterized.TestCase):
         self.assertEqual(dataclass_object, exptected_output)
 
 
-def _get_partition_metrics(coef: int) -> metrics.PartitionMetrics:
-    return metrics.PartitionMetrics(public_partitions=False,
-                                    num_dataset_partitions=coef,
-                                    num_non_public_partitions=2 * coef,
-                                    num_empty_partitions=3 * coef,
-                                    kept_partitions=metrics.MeanVariance(
-                                        10 * coef, 11 * coef))
+def _get_partition_metrics(coef: int) -> metrics.PartitionsInfo:
+    return metrics.PartitionsInfo(public_partitions=False,
+                                  num_dataset_partitions=coef,
+                                  num_non_public_partitions=2 * coef,
+                                  num_empty_partitions=3 * coef,
+                                  kept_partitions=metrics.MeanVariance(
+                                      10 * coef, 11 * coef))
 
 
 def _get_metric_utility(coef: int) -> metrics.MetricUtility:

--- a/analysis/tests/cross_partition_combiners_test.py
+++ b/analysis/tests/cross_partition_combiners_test.py
@@ -72,6 +72,15 @@ class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
             input, pipeline_dp.Metrics.COUNT, partition_keep_probability=1.0)
         self.assertEqual(output.num_empty_partitions, 1)
 
+    @parameterized.parameters(False, True)
+    def test_create_partition_metrics_for_public_partitions(
+            self, is_empty_partition):
+        output: metrics.PartitionMetrics = cross_partition_combiners._create_partition_metrics_for_public_partitions(
+            is_empty_partition)
+        self.assertTrue(output.public_partitions)
+        self.assertEqual(output.num_non_public_partitions, 0)
+        self.assertEqual(output.num_dataset_partitions, 0)
+
     def test_partition_selection_per_to_cross_partition(self):
         output = cross_partition_combiners._partition_selection_per_to_cross_partition(
             0.25)

--- a/analysis/tests/cross_partition_combiners_test.py
+++ b/analysis/tests/cross_partition_combiners_test.py
@@ -24,20 +24,20 @@ from analysis import cross_partition_combiners
 import pipeline_dp
 
 
+def _get_sum_metrics():
+    return metrics.SumMetrics(sum=10.0,
+                              per_partition_error_min=3.0,
+                              per_partition_error_max=-5.0,
+                              expected_cross_partition_error=-2.0,
+                              std_cross_partition_error=3.0,
+                              std_noise=4.0,
+                              noise_kind=pipeline_dp.NoiseKind.LAPLACE)
+
+
 class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
 
-    @staticmethod
-    def get_sum_metrics():
-        return metrics.SumMetrics(sum=10.0,
-                                  per_partition_error_min=3.0,
-                                  per_partition_error_max=-5.0,
-                                  expected_cross_partition_error=-2.0,
-                                  std_cross_partition_error=3.0,
-                                  std_noise=4.0,
-                                  noise_kind=pipeline_dp.NoiseKind.LAPLACE)
-
     def test_metric_utility_count(self):
-        input = self.get_sum_metrics()
+        input = _get_sum_metrics()
         output: metrics.MetricUtility = cross_partition_combiners._sum_metrics_to_metric_utility(
             input, pipeline_dp.Metrics.COUNT, partition_keep_probability=1.0)
 
@@ -96,8 +96,8 @@ class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
             mock_create_for_private_partitions,
             mock_create_for_public_partitions):
         per_partition_utility = metrics.PerPartitionMetrics(
-            0.2, metric_errors=[self.get_sum_metrics(),
-                                self.get_sum_metrics()])
+            0.2, metric_errors=[_get_sum_metrics(),
+                                _get_sum_metrics()])
         dp_metrics = [
             pipeline_dp.Metrics.PRIVACY_ID_COUNT, pipeline_dp.Metrics.COUNT
         ]
@@ -175,75 +175,121 @@ class DataclassHelpersTests(parameterized.TestCase):
         self.assertEqual(dataclass_object, exptected_output)
 
 
+def _get_partition_metrics(coef: int) -> metrics.PartitionMetrics:
+    return metrics.PartitionMetrics(public_partitions=False,
+                                    num_dataset_partitions=coef,
+                                    num_non_public_partitions=2 * coef,
+                                    num_empty_partitions=3 * coef,
+                                    kept_partitions=metrics.MeanVariance(
+                                        10 * coef, 11 * coef))
+
+
+def _get_metric_utility(coef: int) -> metrics.MetricUtility:
+    """Returns MetricUtility with numerical fields proportional to 'coef'"""
+    get_mean_var = lambda: metrics.MeanVariance(coef, 2 * coef)
+    get_bounding_errors = lambda: metrics.ContributionBoundingErrors(
+        l0=get_mean_var(), linf_min=3 * coef, linf_max=4 * coef)
+    get_value_errors = lambda: metrics.ValueErrors(
+        bounding_errors=get_bounding_errors(),
+        mean=5 * coef,
+        variance=6 * coef,
+        rmse=7 * coef,
+        l1=8 * coef,
+        rmse_with_dropped_partitions=9 * coef,
+        l1_with_dropped_partitions=10 * coef)
+    noise_std = 1000  # it's not merged, that's why not multiplied by coef.
+    return metrics.MetricUtility(
+        metric=pipeline_dp.Metrics.COUNT,
+        noise_std=noise_std,
+        noise_kind=pipeline_dp.NoiseKind.LAPLACE,
+        ratio_data_dropped=None,
+        absolute_error=get_value_errors(),
+        relative_error=get_value_errors().to_relative(10.0))
+
+
+def _get_utility_report(coef: int) -> metrics.UtilityReport:
+    return metrics.UtilityReport(
+        input_aggregate_params=None,
+        metric_errors=[
+            _get_metric_utility(coef=coef),
+            _get_metric_utility(coef=2 * coef)
+        ],
+        partition_metrics=_get_partition_metrics(coef=3 * coef))
+
+
 class MergeMetricsTests(parameterized.TestCase):
 
-    @classmethod
-    def get_partition_metrics(cls, coef: int) -> metrics.PartitionMetrics:
-        return metrics.PartitionMetrics(public_partitions=False,
-                                        num_dataset_partitions=coef,
-                                        num_non_public_partitions=2 * coef,
-                                        num_empty_partitions=3 * coef,
-                                        kept_partitions=metrics.MeanVariance(
-                                            4 * coef, 5 * coef))
-
-    @classmethod
-    def get_metric_utility(cls, coef: int) -> metrics.MetricUtility:
-        """Returns MetricUtility with numerical fields proportional to 'coef'"""
-        get_mean_var = lambda: metrics.MeanVariance(coef, 2 * coef)
-        get_bounding_errors = lambda: metrics.ContributionBoundingErrors(
-            l0=get_mean_var(), linf_min=3 * coef, linf_max=4 * coef)
-        get_value_errors = lambda: metrics.ValueErrors(
-            bounding_errors=get_bounding_errors(),
-            mean=5 * coef,
-            variance=6 * coef,
-            rmse=7 * coef,
-            l1=8 * coef,
-            rmse_with_dropped_partitions=9 * coef,
-            l1_with_dropped_partitions=10 * coef)
-        noise_std = 1000  # it's not merged, that's why not multiplied by coef.
-        return metrics.MetricUtility(
-            metric=pipeline_dp.Metrics.COUNT,
-            noise_std=noise_std,
-            noise_kind=pipeline_dp.NoiseKind.LAPLACE,
-            ratio_data_dropped=None,
-            absolute_error=get_value_errors(),
-            relative_error=get_value_errors().to_relative(10.0))
-
-    @classmethod
-    def get_utility_report(cls, coef: int) -> metrics.UtilityReport:
-        return metrics.UtilityReport(
-            input_aggregate_params=None,
-            metric_errors=[
-                cls.get_metric_utility(coef=coef),
-                cls.get_metric_utility(coef=2 * coef)
-            ],
-            partition_metrics=cls.get_partition_metrics(coef=3 * coef))
-
     def test_merge_partition_selection_utilities(self):
-        metrics1 = self.get_partition_metrics(coef=1)
-        metrics2 = self.get_partition_metrics(coef=2)
-        expected_utility = self.get_partition_metrics(coef=3)
+        metrics1 = _get_partition_metrics(coef=1)
+        metrics2 = _get_partition_metrics(coef=2)
+        expected_utility = _get_partition_metrics(coef=3)
         cross_partition_combiners._merge_partition_metrics(metrics1, metrics2)
         self.assertEqual(metrics1, expected_utility)
 
     def test_merge_metric_utility(self):
-        utility1 = self.get_metric_utility(coef=2)
-        utility2 = self.get_metric_utility(coef=3)
-        expected = self.get_metric_utility(coef=5)
+        utility1 = _get_metric_utility(coef=2)
+        utility2 = _get_metric_utility(coef=3)
+        expected = _get_metric_utility(coef=5)
         cross_partition_combiners._merge_metric_utility(utility1, utility2)
         self.assertEqual(utility1, expected)
 
     def test_merge_utility_reports(self):
-        report1 = self.get_utility_report(coef=2)
-        report2 = self.get_utility_report(coef=5)
-        expected_report = self.get_utility_report(coef=7)
+        report1 = _get_utility_report(coef=2)
+        report2 = _get_utility_report(coef=5)
+        expected_report = _get_utility_report(coef=7)
         cross_partition_combiners._merge_utility_reports(report1, report2)
         self.assertEqual(report1, expected_report)
 
 
+class CrossPartitionCombiner(parameterized.TestCase):
+
+    def _create_combiner(self, public_partitions=False):
+        return cross_partition_combiners.CrossPartitionCombiner(
+            dp_metrics=[pipeline_dp.Metrics.COUNT],
+            public_partitions=public_partitions)
+
+    def test_create_report_wo_mocks(self):
+        combiner = self._create_combiner()
+        per_partition_metrics = metrics.PerPartitionMetrics(
+            0.2, metric_errors=[_get_sum_metrics()])
+        utility_report = combiner.create_accumulator(per_partition_metrics)
+        self.assertEqual(
+            utility_report.partition_metrics.num_dataset_partitions, 1)
+        self.assertLen(utility_report.metric_errors, 1)
+
+    @patch(
+        "analysis.cross_partition_combiners._per_partition_to_cross_partition_metrics"
+    )
+    def test_create_report_with_mocks(
+            self, mock_per_partition_to_cross_partition_metrics):
+        combiner = self._create_combiner()
+        per_partition_metrics = metrics.PerPartitionMetrics(
+            0.2, metric_errors=[_get_sum_metrics()])
+        combiner.create_accumulator(per_partition_metrics)
+        expected_metrics = [pipeline_dp.Metrics.COUNT]
+        expected_public_partitions = False
+        mock_per_partition_to_cross_partition_metrics.assert_called_once_with(
+            per_partition_metrics, expected_metrics, expected_public_partitions)
+
+    def test_create_accumulator(self):
+        combiner = self._create_combiner()
+        report1 = _get_utility_report(coef=2)
+        report2 = _get_utility_report(coef=5)
+        expected_report = _get_utility_report(coef=7)
+        self.assertEqual(combiner.merge_accumulators(report1, report2),
+                         expected_report)
+
+    @parameterized.parameters(False, True)
+    @patch("analysis.cross_partition_combiners._normalize_utility_report")
+    def test_compute_metrics(self, public_partitions,
+                             mock_normalize_utility_report):
+        combiner = self._create_combiner(public_partitions)
+        report = _get_utility_report(coef=1)
+        combiner.compute_metrics(report)
+        expeced_num_output_partitions = 12 if public_partitions else 30
+        mock_normalize_utility_report.assert_called_once_with(
+            report, expeced_num_output_partitions)
+
+
 if __name__ == '__main__':
     absltest.main()
-
-#
-# self.assertEqual(output.num_dataset_partitions, 1)
-# self.assertEqual(output.num_empty_partitions, 0)


### PR DESCRIPTION
This PR
1. Introduces CrossPartitionCombiner for computing utility global (i.e. cross-partition) analysis metrics 
2. All information about partitions (incl. partition selection) is now in `PartitionMetrics` (previously `PrivatePartitionSelectionMetrics` ), which addresses one of the inconsitencies previosly that Count Metrics contain information about partitions