### PR TITLE
Refactor analysis output metrics, part 9: tune using perform_utility_analysis_new

### DIFF
--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -184,6 +184,10 @@ def _convert_utility_analysis_to_tune_result(
                       utility_reports=[])
 
 
+############# Deprected code #################
+# TODO(dvadym):
+#  1. Drop tune.
+#  2. Rename tune_new to tune.
 def tune(col,
          backend: pipeline_backend.PipelineBackend,
          contribution_histograms: histograms.DatasetHistograms,
@@ -257,6 +261,8 @@ def tune(col,
     return utility_analysis_result
 
 
+################# New code  ##################
+# tune_new will be renamed to tune.
 def tune_new(col,
              backend: pipeline_backend.PipelineBackend,
              contribution_histograms: histograms.DatasetHistograms,

--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -252,6 +252,79 @@ def tune(col,
     return utility_analysis_result
 
 
+def tune_new(col,
+             backend: pipeline_backend.PipelineBackend,
+             contribution_histograms: histograms.DatasetHistograms,
+             options: TuneOptions,
+             data_extractors: Union[pipeline_dp.DataExtractors,
+                                    analysis.PreAggregateExtractors],
+             public_partitions=None,
+             return_utility_analysis_per_partition: bool = False):
+    """Tunes parameters.
+
+    It works in the following way:
+        1. Based on quantiles of privacy id contributions, candidates for
+        contribution bounding parameters chosen.
+        2. Utility analysis run for those parameters.
+        3. The best parameter set is chosen according to
+          options.minimizing_function.
+
+    The result contains output metrics for all utility analysis which were
+    performed.
+
+    Args:
+        col: collection where all elements are of the same type.
+          contribution_histograms:
+        backend: PipelineBackend with which the utility analysis will be run.
+        contribution_histograms: contribution histograms that should be
+         computed with compute_contribution_histograms().
+        options: options for tuning.
+        data_extractors: functions that extract needed pieces of information
+          from elements of 'col'. In case if the analysis performed on
+          pre-aggregated data, it should have type PreAggregateExtractors
+          otherwise DataExtractors.
+        public_partitions: A collection of partition keys that will be present
+          in the result. If not provided, tuning will be performed assuming
+          private partition selection is used.
+        return_per_partition: if true, it returns tuple, with the 2nd element
+          utility analysis per partitions.
+    Returns:
+        if return_per_partition == False:
+            returns 1 element collection which contains TuneResult
+        else returns tuple (1 element collection which contains TuneResult,
+        a collection which contains utility analysis results per partition).
+    """
+    _check_tune_args(options)
+
+    candidates = _find_candidate_parameters(contribution_histograms,
+                                            options.parameters_to_tune,
+                                            options.aggregate_params.metrics[0])
+
+    utility_analysis_options = analysis.UtilityAnalysisOptions(
+        epsilon=options.epsilon,
+        delta=options.delta,
+        aggregate_params=options.aggregate_params,
+        multi_param_configuration=candidates,
+        partitions_sampling_prob=options.partitions_sampling_prob,
+        pre_aggregated_data=options.pre_aggregated_data)
+    result = utility_analysis.perform_utility_analysis_new(
+        col, backend, utility_analysis_options, data_extractors,
+        public_partitions, return_utility_analysis_per_partition)
+    if return_utility_analysis_per_partition:
+        utility_analysis_result, utility_analysis_result_per_partition = result
+    else:
+        utility_analysis_result = result
+    use_public_partitions = public_partitions is not None
+    utility_analysis_result = backend.map(
+        utility_analysis_result,
+        lambda result: _convert_utility_analysis_to_tune_result(
+            result, options, candidates, use_public_partitions,
+            contribution_histograms), "To Tune result")
+    if return_utility_analysis_per_partition:
+        return utility_analysis_result, utility_analysis_result_per_partition
+    return utility_analysis_result
+
+
 def _check_tune_args(options: TuneOptions):
     # Check metrics to tune.
     metrics = options.aggregate_params.metrics

--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -184,10 +184,8 @@ def _convert_utility_analysis_to_tune_result(
                       utility_reports=[])
 
 
-############# Deprected code #################
-# TODO(dvadym):
-#  1. Drop tune.
-#  2. Rename tune_new to tune.
+############# Deprecated code #################
+# TODO(dvadym): Rename tune_new to tune
 def tune(col,
          backend: pipeline_backend.PipelineBackend,
          contribution_histograms: histograms.DatasetHistograms,
@@ -325,7 +323,7 @@ def tune_new(col,
         utility_result, per_partition_utility_result = result
     else:
         utility_result = result
-    # utility_result: (UtilityReport,)
+    # utility_result: (UtilityReport)
     # per_partition_utility_result: (pk, (PerPartitionMetrics))
     use_public_partitions = public_partitions is not None
 
@@ -357,7 +355,7 @@ def _convert_utility_analysis_to_tune_result_new(
     utility_reports.sort(key=lambda e: e.configuration_index)
 
     index_best = -1  # not found
-    # Find best index if there are metrics to compute. Absence metrics to
+    # Find best index if there are metrics to compute. Absence of metrics to
     # compute means that this is SelectPartition analysis.
     if tune_options.aggregate_params.metrics:
         rmse = [

--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -147,8 +147,8 @@ def tune_parameters():
         parameters_to_tune=parameters_to_tune,
         pre_aggregated_data=FLAGS.run_on_preaggregated_data)
 
-    if FLAGS.output_file_per_partition_analysis:
-        result, per_partition = parameter_tuning.tune(
+    if True:  # FLAGS.output_file_per_partition_analysis:
+        result, per_partition = parameter_tuning.tune_new(
             input,
             backend,
             hist,
@@ -158,9 +158,9 @@ def tune_parameters():
             return_utility_analysis_per_partition=True)
         write_to_file(per_partition, FLAGS.output_file_per_partition_analysis)
     else:
-        result = parameter_tuning.tune(restaurant_visits_rows, backend, hist,
-                                       tune_options, data_extractors,
-                                       public_partitions, False)
+        result = parameter_tuning.tune_new(restaurant_visits_rows, backend,
+                                           hist, tune_options, data_extractors,
+                                           public_partitions, False)
 
     # Here's where the lazy iterator initiates computations and gets transformed
     # into actual results

--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -147,7 +147,7 @@ def tune_parameters():
         parameters_to_tune=parameters_to_tune,
         pre_aggregated_data=FLAGS.run_on_preaggregated_data)
 
-    if True:  # FLAGS.output_file_per_partition_analysis:
+    if FLAGS.output_file_per_partition_analysis:
         result, per_partition = parameter_tuning.tune_new(
             input,
             backend,


### PR DESCRIPTION
This PR implements `tune_new` which uses `perform_utility_analysis_new` and returns new the result in new dataclasses.

Note: after migrating old code, the old `tune` will be dropped and `tune_new` will be renamed to `tune`
