### PR TITLE
Compute Sensitivities for COUNT, SUM, PRIVACY_ID_COUNT

### DIFF
--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -262,7 +262,7 @@ class AggregateParams:
                     "both max_partitions_contributed and "
                     "max_contributions_per_partition must be set.")
             elif n_not_none == 1:
-                raise ValueError("AggregateParams: either none or both from "
+                raise ValueError("AggregateParams: either none or both "
                                  "max_partitions_contributed and "
                                  "max_contributions_per_partition must be set.")
             _check_is_positive_int(self.max_partitions_contributed,

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -147,10 +147,10 @@ class AggregateParams:
     budget_weight: float = 1
     low: float = None  # deprecated
     high: float = None  # deprecated
-    min_value: float = None
-    max_value: float = None
-    min_sum_per_partition: float = None
-    max_sum_per_partition: float = None
+    min_value: Optional[float] = None
+    max_value: Optional[float] = None
+    min_sum_per_partition: Optional[float] = None
+    max_sum_per_partition: Optional[float] = None
     public_partitions: Any = None  # deprecated
     custom_combiners: Sequence['CustomCombiner'] = None
     vector_norm_kind: Optional[NormKind] = None
@@ -262,10 +262,9 @@ class AggregateParams:
                     "both max_partitions_contributed and "
                     "max_contributions_per_partition must be set.")
             elif n_not_none == 1:
-                raise ValueError(
-                    "AggregateParams: either none or both from "
-                    "max_partitions_contributed and "
-                    " max_contributions_per_partition must be set.")
+                raise ValueError("AggregateParams: either none or both from "
+                                 "max_partitions_contributed and "
+                                 "max_contributions_per_partition must be set.")
             _check_is_positive_int(self.max_partitions_contributed,
                                    "max_partitions_contributed")
             _check_is_positive_int(self.max_contributions_per_partition,

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -641,3 +641,28 @@ def create_additive_mechanism(
         return GaussianMechanism(spec.epsilon, spec.delta, sensitivities.l2)
 
     assert False, f"{spec.noise_kind} not supported."
+
+
+def compute_sensitivities_for_count(
+        params: pipeline_dp.AggregateParams) -> Sensitivities:
+    return Sensitivities(l0=params.max_partitions_contributed,
+                         linf=params.max_contributions_per_partition)
+
+
+def compute_sensitivities_for_privacy_id_count(
+        params: pipeline_dp.AggregateParams) -> Sensitivities:
+    return Sensitivities(l0=params.max_partitions_contributed, linf=1)
+
+
+def compute_sensitivities_for_sum(
+        params: pipeline_dp.AggregateParams) -> Sensitivities:
+    l0_sensitivity = params.max_partitions_contributed
+    max_abs_values = lambda x, y: max(abs(x), abs(y))
+    if params.bounds_per_contribution_are_set:
+        linf_sensitivity = max_abs_values(
+            params.min_value,
+            params.max_value) * params.max_contributions_per_partition
+    else:
+        linf_sensitivity = max_abs_values(params.min_sum_per_partition,
+                                          params.max_sum_per_partition)
+    return Sensitivities(l0=l0_sensitivity, linf=linf_sensitivity)


### PR DESCRIPTION
This is the part of the refactoring for making adding noise more OOP. This refactoring is for supporting PLD and l1 sensitivities in future.