### PR TITLE
Precomputation of histogram tails

### DIFF
--- a/pipeline_dp/histograms.py
+++ b/pipeline_dp/histograms.py
@@ -98,6 +98,18 @@ class Histogram:
         return result[::-1]
 
 
+def histogram_precomputed_tails(hist: Histogram):
+    result = [None] * len(hist.bins)
+    accumulated_weight = 0
+    accumulated_count = 0
+    for i in range(1, len(hist.bins) + 1):
+        b = hist.bins[-i]
+        accumulated_weight += b.lower * b.count
+        accumulated_count += b.count
+        result[-i] = (b.lower, (accumulated_weight, accumulated_count))
+    return result
+
+
 @dataclass
 class DatasetHistograms:
     """Contains histograms useful for parameter tuning."""


### PR DESCRIPTION
## Description
A histogram has a sequence of bins. In many situations it is useful to be able to have some aggregated statistics given a bin.lower (aka bin id). In this cl we will introduce aggregations over the tail. For example, given bin.lower = k, what is the total sum of counts from bins with bin.lower >= k.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
