### PR TITLE
Add noise in explain computation report

### DIFF
--- a/examples/movie_view_ratings/run_all_frameworks.py
+++ b/examples/movie_view_ratings/run_all_frameworks.py
@@ -73,10 +73,11 @@ def calc_dp_rating_metrics(movie_views, backend, public_partitions):
     dp_engine = pipeline_dp.DPEngine(budget_accountant, backend)
 
     params = pipeline_dp.AggregateParams(
-        noise_kind=pipeline_dp.NoiseKind.LAPLACE,
+        noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
         metrics=[
-            pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.SUM,
-            pipeline_dp.Metrics.MEAN, pipeline_dp.Metrics.VARIANCE
+            pipeline_dp.Metrics.COUNT,
+            pipeline_dp.Metrics.SUM,
+            # pipeline_dp.Metrics.MEAN, pipeline_dp.Metrics.VARIANCE
         ] + ([pipeline_dp.Metrics.PRIVACY_ID_COUNT]
              if not FLAGS.contribution_bounds_already_enforced else []),
         max_partitions_contributed=2,

--- a/examples/movie_view_ratings/run_all_frameworks.py
+++ b/examples/movie_view_ratings/run_all_frameworks.py
@@ -73,11 +73,10 @@ def calc_dp_rating_metrics(movie_views, backend, public_partitions):
     dp_engine = pipeline_dp.DPEngine(budget_accountant, backend)
 
     params = pipeline_dp.AggregateParams(
-        noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+        noise_kind=pipeline_dp.NoiseKind.LAPLACE,
         metrics=[
-            pipeline_dp.Metrics.COUNT,
-            pipeline_dp.Metrics.SUM,
-            # pipeline_dp.Metrics.MEAN, pipeline_dp.Metrics.VARIANCE
+            pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.SUM,
+            pipeline_dp.Metrics.MEAN, pipeline_dp.Metrics.VARIANCE
         ] + ([pipeline_dp.Metrics.PRIVACY_ID_COUNT]
              if not FLAGS.contribution_bounds_already_enforced else []),
         max_partitions_contributed=2,

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -235,8 +235,12 @@ class CountCombiner(Combiner, MechanismContainerMixin):
         return ['count']
 
     def explain_computation(self) -> ExplainComputationReport:
-        # TODO: add information in this and others combiners about amount of noise.
-        return lambda: f"Computed count with (eps={self._mechanism_spec.eps} delta={self._mechanism_spec.delta})"
+
+        def explain_computation_fn():
+            return (f"Computed DP count with:\n"
+                    f"    {self.get_mechanism().describe()}")
+
+        return explain_computation_fn
 
     def mechanism_spec(self) -> budget_accounting.MechanismSpec:
         return self._mechanism_spec
@@ -272,7 +276,12 @@ class PrivacyIdCountCombiner(Combiner, MechanismContainerMixin):
         return ['privacy_id_count']
 
     def explain_computation(self) -> ExplainComputationReport:
-        return lambda: f"Computed privacy id count with (eps={self._mechanism_spec.eps} delta={self._mechanism_spec.delta})"
+
+        def explain_computation_fn():
+            return (f"Computed DP privacy_id_count with:\n"
+                    f"    {self.get_mechanism().describe()}")
+
+        return explain_computation_fn
 
     def mechanism_spec(self) -> budget_accounting.MechanismSpec:
         return self._mechanism_spec
@@ -319,7 +328,12 @@ class SumCombiner(Combiner, MechanismContainerMixin):
         return ['sum']
 
     def explain_computation(self) -> ExplainComputationReport:
-        return lambda: f"Computed sum with (eps={self._mechanism_spec.eps} delta={self._mechanism_spec.delta})"
+
+        def explain_computation_fn():
+            return (f"Computed DP sum with:\n"
+                    f"    {self.get_mechanism().describe()}")
+
+        return explain_computation_fn
 
     def mechanism_spec(self) -> budget_accounting.MechanismSpec:
         return self._mechanism_spec

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -237,8 +237,8 @@ class CountCombiner(Combiner, MechanismContainerMixin):
     def explain_computation(self) -> ExplainComputationReport:
 
         def explain_computation_fn():
-            return (f"Computed DP count with:\n"
-                    f"    {self.get_mechanism().describe()}")
+            return (f"Computed DP count with\n"
+                    f"     {self.get_mechanism().describe()}")
 
         return explain_computation_fn
 
@@ -278,8 +278,8 @@ class PrivacyIdCountCombiner(Combiner, MechanismContainerMixin):
     def explain_computation(self) -> ExplainComputationReport:
 
         def explain_computation_fn():
-            return (f"Computed DP privacy_id_count with:\n"
-                    f"    {self.get_mechanism().describe()}")
+            return (f"Computed DP privacy_id_count with\n"
+                    f"     {self.get_mechanism().describe()}")
 
         return explain_computation_fn
 
@@ -330,8 +330,8 @@ class SumCombiner(Combiner, MechanismContainerMixin):
     def explain_computation(self) -> ExplainComputationReport:
 
         def explain_computation_fn():
-            return (f"Computed DP sum with:\n"
-                    f"    {self.get_mechanism().describe()}")
+            return (f"Computed DP sum with\n"
+                    f"     {self.get_mechanism().describe()}")
 
         return explain_computation_fn
 

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -547,6 +547,10 @@ class LaplaceMechanism(AdditiveMechanism):
     def sensitivity(self) -> float:
         return self._mechanism.sensitivity
 
+    def describe(self) -> str:
+        return (f"Laplace mechanism:  parameter={self.noise_parameter}  eps="
+                f"{self._mechanism.epsilon}  l1_sensitivity={self.sensitivity}")
+
 
 class GaussianMechanism(AdditiveMechanism):
 
@@ -573,6 +577,11 @@ class GaussianMechanism(AdditiveMechanism):
     @property
     def sensitivity(self) -> float:
         return self._mechanism.l2_sensitivity
+
+    def describe(self) -> str:
+        return (f"Gaussian mechanism:  parameter={self.noise_parameter}  eps="
+                f"{self._mechanism.epsilon}  delta={self._mechanism.delta}  "
+                f"l2_sensitivity={self.sensitivity}")
 
 
 @dataclass

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -224,6 +224,12 @@ class CountCombinerTest(parameterized.TestCase):
                                expected_noise_param,
                                delta=1e-3)
 
+    def test_explain_computation(self):
+        combiner = self._create_combiner(no_noise=False)
+        expected = ("Computed DP count.*\n.*Gaussian mechanism:  "
+                    "parameter=15.8.*eps=1.0  delta=1e-05.*l2_sensitivity=4.2")
+        self.assertRegex(combiner.explain_computation()(), expected)
+
 
 class PrivacyIdCountCombinerTest(parameterized.TestCase):
 
@@ -289,6 +295,12 @@ class PrivacyIdCountCombinerTest(parameterized.TestCase):
         self.assertAlmostEqual(mechanism.noise_parameter,
                                expected_noise_param,
                                delta=1e-3)
+
+    def test_explain_computation(self):
+        combiner = self._create_combiner(no_noise=False)
+        expected = ("Computed DP privacy_id_count.*\n.*Gaussian mechanism:  "
+                    "parameter=5.2.*eps=1.0  delta=1e-05.*l2_sensitivity=1.4")
+        self.assertRegex(combiner.explain_computation()(), expected)
 
 
 class SumCombinerTest(parameterized.TestCase):
@@ -400,6 +412,13 @@ class SumCombinerTest(parameterized.TestCase):
         self.assertAlmostEqual(mechanism.noise_parameter,
                                expected_noise_param,
                                delta=1e-3)
+
+    def test_explain_computation(self):
+        combiner = self._create_combiner(no_noise=False,
+                                         per_partition_bound=False)
+        expected = ("Computed DP sum.*\n.*Gaussian mechanism:  "
+                    "parameter=15.*eps=1.0  delta=1e-05.*l2_sensitivity=4.2")
+        self.assertRegex(combiner.explain_computation()(), expected)
 
 
 class MeanCombinerTest(parameterized.TestCase):

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -720,6 +720,14 @@ class AdditiveMechanismTests(parameterized.TestCase):
         res = stats.ks_1samp(noised_values, expected_cdf)
         self.assertGreater(res.pvalue, 1e-4)
 
+    def test_gaussian_mechanism_describe(self):
+        mechanism = dp_computations.GaussianMechanism(epsilon=1.0,
+                                                      delta=1e-10,
+                                                      l2_sensitivity=15)
+        expected = ("Gaussian mechanism:  parameter=88.06640625  eps=1.0  "
+                    "delta=1e-10  l2_sensitivity=15.0")
+        self.assertEqual(mechanism.describe(), expected)
+
     @parameterized.parameters(
         dict(epsilon=2,
              delta=1e-15,
@@ -774,6 +782,13 @@ class AdditiveMechanismTests(parameterized.TestCase):
 
         res = stats.ks_1samp(noised_values, expected_cdf)
         self.assertGreater(res.pvalue, 1e-4)
+
+    def test_laplace_mechanism_describe(self):
+        mechanism = dp_computations.LaplaceMechanism(epsilon=2.0,
+                                                     l1_sensitivity=25)
+        expected = ("Laplace mechanism:  parameter=12.5  eps=2.0  "
+                    "l1_sensitivity=25.0")
+        self.assertEqual(mechanism.describe(), expected)
 
     @parameterized.parameters(
         dict(l0_sensitivity=-2,


### PR DESCRIPTION
This PR extends explain computation report by adding noise kind and noise parameters for count/privacy_id_count/sum. For other aggregation it will be added later

Now it looks like

5. Computed DP count with
     Gaussian mechanism:  parameter=17.64452389929557  eps=0.3333333333333333  delta=3.333333333333333e-07  l2_sensitivity=1.4142135623730951
 6. Computed DP sum with
     Gaussian mechanism:  parameter=88.22261949647785  eps=0.3333333333333333  delta=3.333333333333333e-07  l2_sensitivity=7.0710678118654755
 7. Computed DP privacy_id_count with
     Gaussian mechanism:  parameter=17.64452389929557  eps=0.3333333333333333  delta=3.333333333333333e-07  l2_sensitivity=1.4142135623730951