### PR TITLE
Fix custom combiners

### DIFF
--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -799,7 +799,7 @@ def create_compound_combiner_with_custom_combiners(
         budget_accountant: budget_accounting.BudgetAccountant,
         custom_combiners: Iterable[CustomCombiner]) -> CompoundCombiner:
     for combiner in custom_combiners:
-        combiner.request_budget(budget_accountant)
         combiner.set_aggregate_params(aggregate_params)
+        combiner.request_budget(budget_accountant)
 
     return CompoundCombiner(custom_combiners, return_named_tuple=False)


### PR DESCRIPTION
This PR changes order in which custom_combiner gets aggregate_params and budget_accountant. It's more logical in order
1.`AggregateParams`
2.`BudgetAccountant`
Since the budget request might depend on `AggregateParams`