### PR TITLE
Removing old DP mean computation code

### DIFF
--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -303,53 +303,6 @@ def _compute_mean_for_normalized_sum(
     return dp_normalized_sum / dp_count_clamped
 
 
-def compute_dp_mean(count: int, normalized_sum: float,
-                    dp_params: ScalarNoiseParams):
-    """Computes DP mean.
-
-    Args:
-        count: Non-DP count.
-        normalized_sum: Non-DP normalized sum.
-        dp_params: The parameters used at computing the noise.
-
-    Raises:
-        ValueError: The noise kind is invalid.
-
-    Returns:
-        The tuple of anonymized count, sum and mean.
-    """
-    # Splits the budget equally between the two mechanisms.
-    (count_eps, count_delta), (sum_eps, sum_delta) = equally_split_budget(
-        dp_params.eps, dp_params.delta, 2)
-    l0_sensitivity = dp_params.l0_sensitivity()
-
-    dp_count = _add_random_noise(
-        count,
-        count_eps,
-        count_delta,
-        l0_sensitivity,
-        dp_params.max_contributions_per_partition,
-        dp_params.noise_kind,
-    )
-
-    dp_mean = _compute_mean_for_normalized_sum(
-        dp_count,
-        normalized_sum,
-        dp_params.min_value,
-        dp_params.max_value,
-        sum_eps,
-        sum_delta,
-        l0_sensitivity,
-        dp_params.max_contributions_per_partition,
-        dp_params.noise_kind,
-    )
-
-    if dp_params.min_value != dp_params.max_value:
-        dp_mean += compute_middle(dp_params.min_value, dp_params.max_value)
-
-    return dp_count, dp_mean * dp_count, dp_mean
-
-
 def compute_dp_var(count: int, normalized_sum: float,
                    normalized_sum_squares: float, dp_params: ScalarNoiseParams):
     """Computes DP variance.

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -110,19 +110,18 @@ class DPComputationsTest(parameterized.TestCase):
             elif minus_two_std <= x <= plus_two_std:
                 num_results_one_to_two_stds += 1
 
-        # 99% confidence interval
+        # 99.993% confidence interval (probability normal 4 sigma from mean).
         # https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval
-        # http://www.sjsu.edu/faculty/gerstman/EpiInfo/z-table.htm
         num_trials_double = 1.0 * num_trials
         self.assertAlmostEqual(
             num_results_within_one_std / num_trials_double,
             prob_mass_within_one_std,
-            delta=2.4 * math.sqrt(prob_mass_within_one_std *
+            delta=4.0 * math.sqrt(prob_mass_within_one_std *
                                   (1 - prob_mass_within_one_std) / num_trials))
         self.assertAlmostEqual(
             num_results_one_to_two_stds / num_trials_double,
             prob_mass_one_to_two_stds,
-            delta=2.4 * math.sqrt(prob_mass_one_to_two_stds *
+            delta=4.0 * math.sqrt(prob_mass_one_to_two_stds *
                                   (1 - prob_mass_one_to_two_stds) / num_trials))
         return 0
 


### PR DESCRIPTION
The new code for DP mean was implemented in [PR](https://github.com/OpenMined/PipelineDP/pull/445).

Also flakiness for test distribution was decreased by changing consts.