### PR TITLE
Renaming in UtilityReportBin

### DIFF
--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -254,11 +254,11 @@ class UtilityReportBin:
     was computed. The metric can be COUNT, PRIVACY_ID_COUNT, SUM.
 
      Attributes:
-        partition_sizefrom: lower bound of partitions size.
-        partition_sizeto: upper bound of partitions size.
+        partition_size_from: lower bound of partitions size.
+        partition_size_to: upper bound of partitions size.
         report: the result of utility analysis for partitions of size
-          [partition_sizefrom, partition_sizeto).
+          [partition_size_from, partition_size_to).
     """
-    partition_sizefrom: int
-    partition_sizeto: int
+    partition_size_from: int
+    partition_size_to: int
     report: UtilityReport

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -250,12 +250,15 @@ class UtilityReport:
 class UtilityReportBin:
     """Stores a bin for a histogram of UtilityReports by partition size.
 
+    The partition size is the non-DP value of the metric whose utility analysis
+    was computed. The metric can be COUNT, PRIVACY_ID_COUNT, SUM.
+
      Attributes:
-        size_from: lower bound of partitions size.
-        size_to: upper bound of partitions size.
+        partition_sizefrom: lower bound of partitions size.
+        partition_sizeto: upper bound of partitions size.
         report: the result of utility analysis for partitions of size
-          [size_from, size_to).
+          [partition_sizefrom, partition_sizeto).
     """
-    size_from: int
-    size_to: int
+    partition_sizefrom: int
+    partition_sizeto: int
     report: UtilityReport

--- a/analysis/tests/cross_partition_combiners_test.py
+++ b/analysis/tests/cross_partition_combiners_test.py
@@ -295,8 +295,8 @@ class CrossPartitionCombiner(parameterized.TestCase):
                          1)
         self.assertLen(utility_report.metric_errors, 1)
 
-    @patch("analysis.cross_partition_combiners._per_partition_to_utility_report"
-          )
+    @patch(
+        "analysis.cross_partition_combiners._per_partition_to_utility_report")
     def test_create_report_with_mocks(self,
                                       mock_per_partition_to_utility_report):
         combiner = self._create_combiner()

--- a/analysis/tests/utility_analysis_test.py
+++ b/analysis/tests/utility_analysis_test.py
@@ -176,8 +176,8 @@ class UtilityAnalysis(parameterized.TestCase):
             ])
         expected_copy = copy.deepcopy(expected)
         expected.utility_report_histogram = [
-            metrics.UtilityReportBin(size_from=20,
-                                     size_to=50,
+            metrics.UtilityReportBin(partition_sizefrom=20,
+                                     partition_sizeto=50,
                                      report=expected_copy)
         ]
         common.assert_dataclasses_are_equal(self, report, expected)

--- a/analysis/tests/utility_analysis_test.py
+++ b/analysis/tests/utility_analysis_test.py
@@ -176,8 +176,8 @@ class UtilityAnalysis(parameterized.TestCase):
             ])
         expected_copy = copy.deepcopy(expected)
         expected.utility_report_histogram = [
-            metrics.UtilityReportBin(partition_sizefrom=20,
-                                     partition_sizeto=50,
+            metrics.UtilityReportBin(partition_size_from=20,
+                                     partition_size_to=50,
                                      report=expected_copy)
         ]
         common.assert_dataclasses_are_equal(self, report, expected)

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -530,8 +530,7 @@ class DpEngineTest(parameterized.TestCase):
                                                     unittest.mock.ANY,
                                                     unittest.mock.ANY)
 
-    @patch(
-        'pipeline_dp.dp_engine.DPEngine._drop_partitions',)
+    @patch('pipeline_dp.dp_engine.DPEngine._drop_partitions',)
     def test_aggregate_no_partition_filtering_public_partitions(
             self, mock_drop_partitions):
         # Arrange


### PR DESCRIPTION
There are also 2 changes in reformatting, which is caused that yapf formatter was updated recently in Github continuous testing system.