### PR TITLE
(Polishing) Dropping return_per_partition argument

### DIFF
--- a/analysis/tests/parameter_tuning_test.py
+++ b/analysis/tests/parameter_tuning_test.py
@@ -209,7 +209,8 @@ class ParameterTuning(parameterized.TestCase):
 
         # Assert.
         tune_result, per_partition_utility_analysis = result
-        self.assertLen(per_partition_utility_analysis, 10)
+        per_partition_utility_analysis = list(per_partition_utility_analysis)
+        self.assertLen(per_partition_utility_analysis, 40)
 
         tune_result = list(tune_result)[0]
 

--- a/analysis/tests/parameter_tuning_test.py
+++ b/analysis/tests/parameter_tuning_test.py
@@ -187,8 +187,7 @@ class ParameterTuning(parameterized.TestCase):
         self.assertEqual(list(range(1, 51)),
                          candidates.max_contributions_per_partition)
 
-    @parameterized.parameters(False, True)
-    def test_tune_count_new(self, return_utility_analysis_per_partition: bool):
+    def test_tune_count_new(self):
         # Arrange.
         input = [(i % 10, f"pk{i/10}") for i in range(10)]
         public_partitions = [f"pk{i}" for i in range(10)]
@@ -206,15 +205,12 @@ class ParameterTuning(parameterized.TestCase):
         # Act.
         result = parameter_tuning.tune(input, pipeline_dp.LocalBackend(),
                                        contribution_histograms, tune_options,
-                                       data_extractors, public_partitions,
-                                       return_utility_analysis_per_partition)
+                                       data_extractors, public_partitions)
 
         # Assert.
-        if return_utility_analysis_per_partition:
-            tune_result, per_partition_utility_analysis = result
-            self.assertLen(per_partition_utility_analysis, 10)
-        else:
-            tune_result = result
+        tune_result, per_partition_utility_analysis = result
+        self.assertLen(per_partition_utility_analysis, 10)
+
         tune_result = list(tune_result)[0]
 
         self.assertEqual(tune_options, tune_result.options)
@@ -246,9 +242,9 @@ class ParameterTuning(parameterized.TestCase):
         ]
 
         # Act.
-        result = parameter_tuning.tune(input, pipeline_dp.LocalBackend(),
-                                       contribution_histograms, tune_options,
-                                       data_extractors, public_partitions)
+        result, _ = parameter_tuning.tune(input, pipeline_dp.LocalBackend(),
+                                          contribution_histograms, tune_options,
+                                          data_extractors, public_partitions)
 
         # Assert.
         result = list(result)[0]

--- a/analysis/tests/utility_analysis_test.py
+++ b/analysis/tests/utility_analysis_test.py
@@ -83,7 +83,7 @@ class UtilityAnalysis(parameterized.TestCase):
                 partition_extractor=lambda x: f"pk{x[0]}",
                 preaggregate_extractor=lambda x: x[1])
 
-        col = analysis.perform_utility_analysis(
+        col, per_partition_result = analysis.perform_utility_analysis(
             col=col,
             backend=pipeline_dp.LocalBackend(),
             options=analysis.UtilityAnalysisOptions(
@@ -94,6 +94,7 @@ class UtilityAnalysis(parameterized.TestCase):
             data_extractors=data_extractors)
 
         col = list(col)
+        per_partition_result = list(per_partition_result)
 
         # Assert
         self.assertLen(col, 1)
@@ -182,6 +183,7 @@ class UtilityAnalysis(parameterized.TestCase):
                                      report=expected_copy)
         ]
         common.assert_dataclasses_are_equal(self, report, expected)
+        self.assertLen(per_partition_result, 10)
 
     @parameterized.named_parameters(
         dict(testcase_name="Gaussian noise",
@@ -211,7 +213,7 @@ class UtilityAnalysis(parameterized.TestCase):
             partition_extractor=lambda x: f"pk{x}",
             value_extractor=lambda x: 0)
 
-        col = analysis.perform_utility_analysis(
+        col, _ = analysis.perform_utility_analysis(
             col=col,
             backend=pipeline_dp.LocalBackend(),
             options=analysis.UtilityAnalysisOptions(
@@ -252,7 +254,7 @@ class UtilityAnalysis(parameterized.TestCase):
 
         public_partitions = ["pk0", "pk1"]
 
-        output = analysis.perform_utility_analysis(
+        output, _ = analysis.perform_utility_analysis(
             col=input,
             backend=pipeline_dp.LocalBackend(),
             options=analysis.UtilityAnalysisOptions(

--- a/analysis/utility_analysis.py
+++ b/analysis/utility_analysis.py
@@ -44,8 +44,7 @@ def perform_utility_analysis(
         options: analysis.UtilityAnalysisOptions,
         data_extractors: Union[pipeline_dp.DataExtractors,
                                pipeline_dp.PreAggregateExtractors],
-        public_partitions=None,
-        return_per_partition: bool = False):
+        public_partitions=None):
     """Performs utility analysis for DP aggregations.
 
     Args:
@@ -59,16 +58,11 @@ def perform_utility_analysis(
       public_partitions: A collection of partition keys that will be present
         in the result. If not provided, the utility analysis with private
         partition selection will be performed.
-      return_per_partition: if true, in addition it returns utility analysis per
-        partitions as a 2nd element.
     Returns:
-         if return_per_partition == False:
-            returns collections which contains metrics.UtilityReport with
-            one report per each input configuration
-         else:
-            returns a tuple, with the 1st element as in first 'if' clause and
-            the 2nd a collection with elements
-            (partition_key, [metrics.PerPartitionMetrics]).
+        returns a tuple, with the 1st element is a collection which contains
+          metrics.UtilityReport with one report per each input configuration and
+          the 2nd a collection with elements
+          (partition_key, [metrics.PerPartitionMetrics]).
     """
     budget_accountant = pipeline_dp.NaiveBudgetAccountant(
         total_epsilon=options.epsilon, total_delta=options.delta)
@@ -126,9 +120,7 @@ def perform_utility_analysis(
                                "Group utility reports")
     # result: (UtilityReport)
 
-    if return_per_partition:
-        return result, per_partition_result
-    return result
+    return result, per_partition_result
 
 
 def _pack_per_partition_metrics(

--- a/examples/restaurant_visits/run_without_frameworks_tuning.py
+++ b/examples/restaurant_visits/run_without_frameworks_tuning.py
@@ -147,20 +147,11 @@ def tune_parameters():
         parameters_to_tune=parameters_to_tune,
         pre_aggregated_data=FLAGS.run_on_preaggregated_data)
 
+    result, per_partition = parameter_tuning.tune(input, backend, hist,
+                                                  tune_options, data_extractors,
+                                                  public_partitions)
     if FLAGS.output_file_per_partition_analysis:
-        result, per_partition = parameter_tuning.tune(
-            input,
-            backend,
-            hist,
-            tune_options,
-            data_extractors,
-            public_partitions,
-            return_utility_analysis_per_partition=True)
         write_to_file(per_partition, FLAGS.output_file_per_partition_analysis)
-    else:
-        result = parameter_tuning.tune(restaurant_visits_rows, backend, hist,
-                                       tune_options, data_extractors,
-                                       public_partitions, False)
 
     # Here's where the lazy iterator initiates computations and gets transformed
     # into actual results


### PR DESCRIPTION
This argumen just adds complexity, let's return always per_partition results