### PR TITLE
Implement pure logarithmic grid for candidates search.

### DIFF
--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -41,7 +41,7 @@ class ParametersSearchStrategy(Enum):
     # Picks up candidates that correspond tp a predefined list of quantiles.
     QUANTILES = 1
     # Candidates are a sequence starting from 1 where relative difference
-    # between two neighbouring elements is (almost) the same.
+    # between two neighbouring elements is the same.
     CONSTANT_RELATIVE_STEP = 2
 
 
@@ -190,22 +190,28 @@ def _find_candidates_constant_relative_step(histogram: histograms.Histogram,
                                             max_candidates: int) -> List[int]:
     """Implementation of CONSTANT_RELATIVE_STEP strategy."""
     max_value = histogram.max_value
-    # relative step varies from 1% to 0.1%
-    # because generate_possible_contribution_bounds generate bounds by changing
-    # only up to first 3 digits, for example 100000, 101000, 102000... Then
-    # relative step between neighbouring elements
-    # varies (101000 - 100000) / 100000 = 0.01 and
-    # (1000000 - 999000) / 999000 ~= 0.001.
-    candidates = private_contribution_bounds.generate_possible_contribution_bounds(
-        max_value)
-    n_max_without_max_value = max_candidates - 1
-    if len(candidates) > n_max_without_max_value:
-        delta = len(candidates) / n_max_without_max_value
-        candidates = [
-            candidates[int(i * delta)] for i in range(n_max_without_max_value)
-        ]
-    if candidates[-1] != max_value:
-        candidates.append(max_value)
+    if max_value < 1:
+        raise Exception("max_value has to be >= 1.")
+    max_candidates = min(max_candidates, max_value)
+    if max_candidates <= 0:
+        raise Exception("max_candidates have to be positive")
+    elif max_candidates == 1:
+        return [1]
+    step = pow(max_value, 1 / (max_candidates - 1))
+    candidates = [1]
+    accumulated = candidates[-1]
+    for i in range(1, max_candidates):
+        previous_candidate = candidates[-1]
+        if previous_candidate >= max_value:
+            break
+        accumulated = accumulated * step
+        next_candidate = math.ceil(accumulated)
+        if next_candidate <= previous_candidate:
+            next_candidate = previous_candidate + 1
+        candidates.append(next_candidate)
+    # float calculations might be not precise enough but the last candidate has
+    # to be always max_value
+    candidates[-1] = max_value
     return candidates
 
 


### PR DESCRIPTION
Now we construct candidates set based on generate_possible_contribution_bounds method that generates numbers that have 3 left-most digits non-zero and others are zero. I.e., it will be [1, 2, 3, ..., 999, 1000, 1010, 1020, ..., 9990, 10000, 10100, 10200.
This is not a pure logarithmic scale, it keeps relative difference between neighbouring almost the same across the candidates set (it varies from 0.1% to 1%). Such solution has a problem that beginning of the sequence can become very scarce due to sampling (we do sampling such sequence contains more than max_candidates values). It is bad because density in the beginning of the sequence should be higher, we need more elements there because a change there in absolute values affects the result much more than change in the right side of the sequence where values are big. For example, difference in result between l_0 = 1 and l_0 = 2 is much bigger than difference between l_0 = 1000 and l_0 = 1001.

Therefore in this PR we implement pure logarithmic grid. The code generates a sequence a_i, where a_i = max_value^(i / (max_candidates - 1)), i in [0..(max_candidates - 1)]