### PR TITLE
(Refactoring) Drop AdditiveMechanismSpec, use MechanismSpec instead

### DIFF
--- a/analysis/tests/parameter_tuning_test.py
+++ b/analysis/tests/parameter_tuning_test.py
@@ -245,7 +245,7 @@ class ParameterTuning(parameterized.TestCase):
         self.assertEqual(list(range(1, 51)),
                          candidates.max_contributions_per_partition)
 
-    def test_tune_count_new(self):
+    def test_tune_count(self):
         # Arrange.
         input = [(i % 10, f"pk{i/10}") for i in range(10)]
         public_partitions = [f"pk{i}" for i in range(10)]
@@ -282,7 +282,7 @@ class ParameterTuning(parameterized.TestCase):
         self.assertEqual(utility_reports[0].metric_errors[0].metric,
                          pipeline_dp.Metrics.COUNT)
 
-    def test_tune_privacy_id_count_new(self):
+    def test_tune_privacy_id_count(self):
         # Arrange.
         input = [(i % 10, f"pk{i/10}") for i in range(10)]
         public_partitions = [f"pk{i}" for i in range(10)]

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -216,8 +216,7 @@ class AdditiveMechanismMixin(MechanismContainerMixin):
 
     def create_mechanism(self) -> dp_computations.AdditiveMechanism:
         return dp_computations.create_additive_mechanism(
-            dp_computations.to_additive_mechanism_spec(self.mechanism_spec()),
-            self.sensitivities())
+            self.mechanism_spec(), self.sensitivities())
 
     @abc.abstractmethod
     def sensitivities(self) -> dp_computations.Sensitivities:
@@ -432,13 +431,10 @@ class MeanCombiner(Combiner, MechanismContainerMixin):
     def create_mechanism(self) -> dp_computations.MeanMechanism:
         range_middle = dp_computations.compute_middle(self._min_value,
                                                       self._max_value)
-
-        count_spec = dp_computations.to_additive_mechanism_spec(
-            self._count_spec)
-        sum_spec = dp_computations.to_additive_mechanism_spec(self._sum_spec)
-        return dp_computations.create_mean_mechanism(range_middle, count_spec,
+        return dp_computations.create_mean_mechanism(range_middle,
+                                                     self._count_spec,
                                                      self._count_sensitivities,
-                                                     sum_spec,
+                                                     self._sum_spec,
                                                      self._sum_sensitivities)
 
     def mechanism_spec(

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -533,7 +533,7 @@ class VarianceCombinerTest(parameterized.TestCase):
         self.assertGreater(np.var(noisy_counts), 1)  # check that noise is added
 
         noisy_sums = [noisy_value['sum'] for noisy_value in noisy_values]
-        self.assertAlmostEqual(sum_, np.mean(noisy_sums), delta=10)
+        self.assertAlmostEqual(sum_, np.mean(noisy_sums), delta=20)
         self.assertGreater(np.var(noisy_sums), 1)  # check that noise is added
 
         noisy_means = [noisy_value['mean'] for noisy_value in noisy_values]

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -24,6 +24,8 @@ from unittest.mock import MagicMock
 import pipeline_dp
 import pipeline_dp.dp_computations as dp_computations
 from pipeline_dp.aggregate_params import NoiseKind
+from pipeline_dp import aggregate_params
+from pipeline_dp import budget_accounting
 
 N_ITERATIONS = 200000
 DUMMY_MIN_VALUE = 2.0
@@ -607,8 +609,9 @@ class AdditiveMechanismTests(parameterized.TestCase):
     def test_create_laplace_mechanism(self, epsilon, l0_sensitivity,
                                       linf_sensitivity, l1_sensitivity,
                                       expected_noise_parameter):
-        spec = dp_computations.AdditiveMechanismSpec(
-            epsilon, delta=0, noise_kind=pipeline_dp.NoiseKind.LAPLACE)
+        spec = budget_accounting.MechanismSpec(
+            aggregate_params.MechanismType.LAPLACE)
+        spec.set_eps_delta(epsilon, delta=0)
         sensitivities = dp_computations.Sensitivities(l0=l0_sensitivity,
                                                       linf=linf_sensitivity,
                                                       l1=l1_sensitivity)
@@ -632,8 +635,9 @@ class AdditiveMechanismTests(parameterized.TestCase):
     )
     def test_create_gaussian_mechanism(self, epsilon, delta, l2_sensitivity,
                                        expected_noise_parameter):
-        spec = dp_computations.AdditiveMechanismSpec(
-            epsilon, delta=delta, noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
+        spec = budget_accounting.MechanismSpec(
+            aggregate_params.MechanismType.GAUSSIAN)
+        spec.set_eps_delta(epsilon, delta)
         sensitivities = dp_computations.Sensitivities(l2=l2_sensitivity)
 
         mechanism = dp_computations.create_additive_mechanism(
@@ -715,11 +719,13 @@ class AdditiveMechanismTests(parameterized.TestCase):
 class MeanMechanismTests(parameterized.TestCase):
 
     def create_mean_mechanism(self) -> dp_computations.MeanMechanism:
-        count_spec = dp_computations.AdditiveMechanismSpec(
-            1.0, delta=1e-5, noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
+        count_spec = budget_accounting.MechanismSpec(
+            aggregate_params.MechanismType.GAUSSIAN)
+        count_spec.set_eps_delta(eps=1.0, delta=1e-5)
         count_sensitivities = dp_computations.Sensitivities(l0=4, linf=10)
-        sum_spec = dp_computations.AdditiveMechanismSpec(
-            2.0, delta=1e-7, noise_kind=pipeline_dp.NoiseKind.LAPLACE)
+        sum_spec = budget_accounting.MechanismSpec(
+            aggregate_params.MechanismType.LAPLACE)
+        sum_spec.set_eps_delta(eps=2.0, delta=1e-7)
         sum_sensitivities = dp_computations.Sensitivities(l0=3, linf=5)
         return dp_computations.create_mean_mechanism(5, count_spec,
                                                      count_sensitivities,


### PR DESCRIPTION
Having 2 very similar classes `AdditiveMechanismSpec` and `MechanismSpec` adds confusions and complexity, while doesn't add any benefits. Let's drop the former and let's use  `MechanismSpec`.

Also it contains
1. test renaming, dropping "_new", which is leftover from `tune_new` (which was renamed to `tune`).
2. increase acceptance range for a stat tests (in tests/combiners_test.py).