### PR TITLE
Update supported Python versions and PyDP version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7]
+        python-version: [3.8]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ on Apache Beam:
 
 `pip install pipeline-dp apache-beam`.
 
-Supported Python version >= 3.7.
+Supported Python version >= 3.8.
 
 **Note for Apple Silicon users:** PipelineDP pip package is currently available only 
 for x86 architecture. The reason is that [PyDP](https://github.com/OpenMined/PyDP) does not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Chinmay Shah <chinmayshah3899@gmail.com>", "Vadym Doroshenko <dvadym
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = "^3.7, < 3.11"
+python = "^3.8, < 3.11"
 python-dp = "^1.1.3rc4"
 numpy = "^1.20.1"
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,4 +11,4 @@ pytest-timeout
 pylint
 yapf
 dp-accounting==0.4.0
-python-dp==1.1.3rc2
+python-dp==1.1.4rc1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup_kwargs = {
     'packages': packages,
     'package_data': package_data,
     'install_requires': install_requires,
-    'python_requires': '>=3.7,<3.11',
+    'python_requires': '>=3.8,<3.11',
     'long_description': read("README.md"),
     'long_description_content_type': 'text/markdown',
     'license': "Apache-2.0",

--- a/tests/partition_selection_test.py
+++ b/tests/partition_selection_test.py
@@ -58,8 +58,6 @@ class PartitionSelectionTest(parameterized.TestCase):
         mock_method.assert_called_once_with("gaussian", eps, delta,
                                             max_partitions)
 
-    @unittest.skip("pydp is not yet released with support of pre-thresholding")
-    # TODO(dvadym): enable this test when pydp is released
     @patch("pydp.algorithms.partition_selection.create_partition_strategy")
     def test_truncated_pre_thresholding(self, mock_method):
         eps, delta, max_partitions, pre_threshold = 1, 1e-5, 20, 42


### PR DESCRIPTION
This PR contains:
1. Updating Python suported versions from Python 3.7-3.9 to Python 3.8-3.10, since 3.7 is already deprecated
2. Updating PyDP to the newest version
3. Enabling one test, which was disabled because of missing PyDP new features

Unfortunetely Windows builds fail, because PyDP failes to be built on Windows. This will be fixed soon.