### PR TITLE
Type annotation polishings

### DIFF
--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -23,7 +23,7 @@ import math
 
 def _sum_metrics_to_data_dropped(
         sum_metrics: metrics.SumMetrics, partition_keep_probability: float,
-        dp_metric: pipeline_dp.Metrics) -> metrics.DataDropInfo:
+        dp_metric: pipeline_dp.Metric) -> metrics.DataDropInfo:
     """Finds Data drop information from per-partition metrics."""
     # TODO(dvadym): implement for Sum
     assert dp_metric != pipeline_dp.Metrics.SUM, "Cross-partition metrics are not implemented for SUM"
@@ -92,7 +92,7 @@ def _sum_metrics_to_value_error(sum_metrics: metrics.SumMetrics,
 
 
 def _sum_metrics_to_metric_utility(
-        sum_metrics: metrics.SumMetrics, dp_metric: pipeline_dp.Metrics,
+        sum_metrics: metrics.SumMetrics, dp_metric: pipeline_dp.Metric,
         partition_keep_probability: float) -> metrics.MetricUtility:
     """Creates cross-partition MetricUtility from 1 partition utility.
 
@@ -192,7 +192,7 @@ def _multiply_float_dataclasses_field(dataclass,
 
 def _per_partition_to_utility_report(
         per_partition_utility: metrics.PerPartitionMetrics,
-        dp_metrics: List[pipeline_dp.Metrics],
+        dp_metrics: List[pipeline_dp.Metric],
         public_partitions: bool) -> metrics.UtilityReport:
     """Converts per-partition metrics to cross-partition utility report."""
     # Fill partition selection metrics.

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -202,7 +202,7 @@ class MetricUtility:
         absolute_error: error in terms of (dp_value - actual_value).
         relative_error: error in terms of (dp_value - actual_value)/actual_value.
     """
-    metric: pipeline_dp.Metrics
+    metric: pipeline_dp.Metric
 
     # Noise information.
     noise_std: float

--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -130,7 +130,7 @@ class TuneResult:
 def _find_candidate_parameters(
         hist: histograms.DatasetHistograms,
         parameters_to_tune: ParametersToTune,
-        metric: Optional[pipeline_dp.Metrics],
+        metric: Optional[pipeline_dp.Metric],
         strategy: ParametersSearchStrategy,
         max_candidates: int) -> analysis.MultiParameterConfiguration:
     """Finds candidates for l0 and/or l_inf parameters.

--- a/pipeline_dp/dataset_histograms/histogram_error_estimator.py
+++ b/pipeline_dp/dataset_histograms/histogram_error_estimator.py
@@ -29,7 +29,7 @@ class CountErrorEstimator:
     bounding and noise error are taken into consideration.
     """
 
-    def __init__(self, base_std: float, metric: pipeline_dp.Metrics,
+    def __init__(self, base_std: float, metric: pipeline_dp.Metric,
                  noise: pipeline_dp.NoiseKind,
                  l0_ratios_dropped: Sequence[Tuple[int, float]],
                  linf_ratios_dropped: Sequence[Tuple[int, float]],

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -21,6 +21,7 @@ import numpy as np
 from typing import Any, Optional, Tuple, Union
 
 import pipeline_dp
+from pipeline_dp import budget_accounting
 from dataclasses import dataclass
 from pydp.algorithms import numerical_mechanisms as dp_mechanisms
 
@@ -195,7 +196,7 @@ class AdditiveVectorNoiseParams:
 
 
 def _clip_vector(vec: np.ndarray, max_norm: float,
-                 norm_kind: pipeline_dp.aggregate_params.NormKind):
+                 norm_kind: pipeline_dp.NormKind):
     norm_kind = norm_kind.value  # type: str
     if norm_kind == "linf":
         return np.clip(vec, -max_norm, max_norm)
@@ -571,7 +572,7 @@ class Sensitivities:
 
 
 def create_additive_mechanism(
-        mechanism_spec: pipeline_dp.budget_accounting.MechanismSpec,
+        mechanism_spec: budget_accounting.MechanismSpec,
         sensitivities: Sensitivities) -> AdditiveMechanism:
     """Creates AdditiveMechanism from a mechanism spec and sensitivities."""
     noise_kind = mechanism_spec.mechanism_type.to_noise_kind()
@@ -592,10 +593,9 @@ def create_additive_mechanism(
 
 
 def create_mean_mechanism(
-        range_middle: float,
-        count_spec: pipeline_dp.budget_accounting.MechanismSpec,
+        range_middle: float, count_spec: budget_accounting.MechanismSpec,
         count_sensitivities: Sensitivities,
-        normalized_sum_spec: pipeline_dp.budget_accounting.MechanismSpec,
+        normalized_sum_spec: budget_accounting.MechanismSpec,
         normalized_sum_sensitivities: Sensitivities) -> MeanMechanism:
     """Creates MeanMechanism from a mechanism specs and sensitivities."""
     count_mechanism = create_additive_mechanism(count_spec, count_sensitivities)

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -16,6 +16,7 @@ import functools
 from typing import Any, Optional, Tuple
 
 import pipeline_dp
+from pipeline_dp import budget_accounting
 from pipeline_dp import combiners
 from pipeline_dp import contribution_bounders
 from pipeline_dp import partition_selection
@@ -490,7 +491,7 @@ class DPEngine:
             _check_data_extractors(data_extractors)
 
     def _annotate(self, col, params: pipeline_dp.SelectPartitionsParams,
-                  budget: pipeline_dp.budget_accounting.Budget):
+                  budget: budget_accounting.Budget):
         return self._backend.annotate(col,
                                       "annotation",
                                       params=params,


### PR DESCRIPTION
This PR contains the following changes:
1. Replacement `pipeline_dp.Metrics` -> `pipeline.Metric` (the difference: the type of metrics is `pipeline.Metric`, `pipeline_dp.Metrics` is a storage of of different metrics).
2. Replacement `pipeline_dp.budget_accountant.MechanismSpec` -> `budget_accountant.MechanismSpec` (because the former doesn't work in Colab)