### PR TITLE
Add partition selection strategy for UtilityReport

### DIFF
--- a/analysis/data_structures.py
+++ b/analysis/data_structures.py
@@ -15,7 +15,7 @@
 
 import copy
 import dataclasses
-from typing import Iterable, Optional, Sequence
+from typing import Iterable, Optional, Sequence, Union
 
 import pipeline_dp
 from pipeline_dp import input_validators
@@ -132,3 +132,10 @@ def get_aggregate_params(
         for i in range(multi_param_configuration.size):
             yield multi_param_configuration.get_aggregate_params(
                 options.aggregate_params, i)
+
+
+def get_partition_selection_strategy(
+    options: UtilityAnalysisOptions
+) -> Union[pipeline_dp.PartitionSelectionStrategy,
+           Iterable[pipeline_dp.PartitionSelectionStrategy]]:
+    pass

--- a/analysis/data_structures.py
+++ b/analysis/data_structures.py
@@ -136,6 +136,16 @@ def get_aggregate_params(
 
 def get_partition_selection_strategy(
     options: UtilityAnalysisOptions
-) -> Union[pipeline_dp.PartitionSelectionStrategy,
-           Iterable[pipeline_dp.PartitionSelectionStrategy]]:
-    pass
+) -> Sequence[pipeline_dp.PartitionSelectionStrategy]:
+    """Returns partition selection strategies for different configurations."""
+    multi_configuration = options.multi_param_configuration
+    n_configurations = 1
+    if multi_configuration is not None:
+        if multi_configuration.partition_selection_strategy is not None:
+            # Different parameter configurations have different partition
+            # selection strategies.
+            return multi_configuration.partition_selection_strategy
+        n_configurations = multi_configuration.size
+    # The same partition selection strategy for all configuration.
+    return [options.aggregate_params.partition_selection_strategy
+           ] * n_configurations

--- a/analysis/tests/utility_analysis_test.py
+++ b/analysis/tests/utility_analysis_test.py
@@ -110,7 +110,8 @@ class UtilityAnalysis(parameterized.TestCase):
                 num_dataset_partitions=10,
                 num_non_public_partitions=None,
                 num_empty_partitions=None,
-                strategy=None,
+                strategy=pipeline_dp.PartitionSelectionStrategy.
+                TRUNCATED_GEOMETRIC,
                 kept_partitions=metrics.MeanVariance(mean=3.51622411,
                                                      var=2.2798409)),
             metric_errors=[


### PR DESCRIPTION
`UtilityReport` is the result of utility analysis. `peform_utility_analysis` can compute utlity analysis for different partition selection strategies, so it's needed to return partition selection strategy as  a part of `UtilityReport`