### PR TITLE
Add support to compute linf sum contributions histogram

### DIFF
--- a/analysis/tests/parameter_tuning_test.py
+++ b/analysis/tests/parameter_tuning_test.py
@@ -72,7 +72,7 @@ class ParameterTuning(parameterized.TestCase):
 
         mock_histograms = histograms.DatasetHistograms(mock_l0_histogram, None,
                                                        mock_linf_histogram,
-                                                       None, None)
+                                                       None, None, None)
         parameters_to_tune = parameter_tuning.ParametersToTune(
             max_partitions_contributed=tune_max_partitions_contributed,
             max_contributions_per_partition=tune_max_contributions_per_partition
@@ -100,7 +100,7 @@ class ParameterTuning(parameterized.TestCase):
 
         mock_histograms = histograms.DatasetHistograms(mock_l0_histogram, None,
                                                        mock_linf_histogram,
-                                                       None, None)
+                                                       None, None, None)
         parameters_to_tune = parameter_tuning.ParametersToTune(
             max_partitions_contributed=True,
             max_contributions_per_partition=True)
@@ -126,7 +126,7 @@ class ParameterTuning(parameterized.TestCase):
 
         mock_histograms = histograms.DatasetHistograms(mock_l0_histogram, None,
                                                        mock_linf_histogram,
-                                                       None, None)
+                                                       None, None, None)
         parameters_to_tune = parameter_tuning.ParametersToTune(
             max_partitions_contributed=True,
             max_contributions_per_partition=True)
@@ -157,7 +157,7 @@ class ParameterTuning(parameterized.TestCase):
 
         mock_histograms = histograms.DatasetHistograms(mock_l0_histogram, None,
                                                        mock_linf_histogram,
-                                                       None, None)
+                                                       None, None, None)
         parameters_to_tune = parameter_tuning.ParametersToTune(
             max_partitions_contributed=True,
             max_contributions_per_partition=True)
@@ -213,7 +213,7 @@ class ParameterTuning(parameterized.TestCase):
         mock_l0_histogram.max_value = mock.Mock(return_value=max_value)
 
         mock_histograms = histograms.DatasetHistograms(mock_l0_histogram, None,
-                                                       None, None, None)
+                                                       None, None, None, None)
         parameters_to_tune = parameter_tuning.ParametersToTune(
             max_partitions_contributed=True,
             max_contributions_per_partition=False)
@@ -254,7 +254,7 @@ class ParameterTuning(parameterized.TestCase):
             histograms.HistogramType.LINF_CONTRIBUTIONS, None)
         mock_histograms = histograms.DatasetHistograms(mock_l0_histogram, None,
                                                        mock_linf_histogram,
-                                                       None, None)
+                                                       None, None, None)
 
         mock_find_candidate_from_histogram.return_value = [1, 2]
 
@@ -365,12 +365,12 @@ class ParameterTuning(parameterized.TestCase):
 
     def test_tune_privacy_id_count(self):
         # Arrange.
-        input = [(i % 10, f"pk{i/10}") for i in range(10)]
+        input = [(i % 10, f"pk{i/10}", i) for i in range(10)]
         public_partitions = [f"pk{i}" for i in range(10)]
         data_extractors = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x[0],
             partition_extractor=lambda x: x[1],
-            value_extractor=lambda x: None)
+            value_extractor=lambda x: x[2])
 
         contribution_histograms = list(
             computing_histograms.compute_dataset_histograms(
@@ -422,7 +422,7 @@ class ParameterTuning(parameterized.TestCase):
         tune_options = _get_tune_options()
         tune_options.aggregate_params.metrics = metrics
         contribution_histograms = histograms.DatasetHistograms(
-            None, None, None, None, None)
+            None, None, None, None, None, None)
         data_extractors = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda _: 0, partition_extractor=lambda _: 0)
         public_partitions = [1] if is_public_partitions else None

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -322,7 +322,7 @@ def _compute_linf_sum_contributions_histogram(
     lowers = backend.flatten(lowers, "Flatten lowers")
 
     return _compute_frequency_histogram_helper_with_lowers(
-        col, backend, hist.HistogramType.LINF_CONTRIBUTIONS, lowers)
+        backend, col, hist.HistogramType.LINF_CONTRIBUTIONS, lowers)
 
 
 def _compute_partition_count_histogram(

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -322,7 +322,7 @@ def _compute_linf_sum_contributions_histogram(
     lowers = backend.flatten(lowers, "Flatten lowers")
 
     return _compute_frequency_histogram_helper_with_lowers(
-        backend, col, hist.HistogramType.LINF_CONTRIBUTIONS, lowers)
+        backend, col, hist.HistogramType.LINF_SUM_CONTRIBUTIONS, lowers)
 
 
 def _compute_partition_count_histogram(

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -66,7 +66,7 @@ def _compute_frequency_histogram(col, backend: pipeline_backend.PipelineBackend,
 
     # Combiner elements to histogram buckets of increasing sizes. Having buckets
     # of width = 1 is not scalable.
-    return _compute_frequency_histogram_helper(backend, col, name)
+    return _compute_frequency_histogram_helper(col, backend, name)
 
 
 def _compute_weighted_frequency_histogram(
@@ -90,11 +90,11 @@ def _compute_weighted_frequency_histogram(
 
     # Combiner elements to histogram buckets of increasing sizes. Having buckets
     # of width = 1 is not scalable.
-    return _compute_frequency_histogram_helper(backend, col, name)
+    return _compute_frequency_histogram_helper(col, backend, name)
 
 
 def _compute_frequency_histogram_helper(
-        backend: pipeline_backend.PipelineBackend, col,
+        col, backend: pipeline_backend.PipelineBackend,
         name: hist.HistogramType):
     """Computes histogram of element frequencies in collection.
 
@@ -119,11 +119,11 @@ def _compute_frequency_histogram_helper(
 
     col = backend.map_tuple(col, _map_to_frequency_bin, "To FrequencyBin")
     # (lower_bin_value, hist.FrequencyBin)
-    return _convert_frequency_bins_into_histogram(backend, col, name)
+    return _convert_frequency_bins_into_histogram(col, backend, name)
 
 
 def _compute_frequency_histogram_helper_with_lowers(
-        backend: pipeline_backend.PipelineBackend, col,
+        col, backend: pipeline_backend.PipelineBackend,
         name: hist.HistogramType, lowers_col):
     """Computes histogram of element frequencies in collection.
 
@@ -154,11 +154,11 @@ def _compute_frequency_histogram_helper_with_lowers(
                                        (lowers_col,), "To FrequencyBin")
     # (lower_bin_value, hist.FrequencyBin)
 
-    return _convert_frequency_bins_into_histogram(backend, col, name)
+    return _convert_frequency_bins_into_histogram(col, backend, name)
 
 
 def _convert_frequency_bins_into_histogram(
-        backend: pipeline_backend.PipelineBackend, col, name):
+        col, backend: pipeline_backend.PipelineBackend, name):
     """Converts (lower_bin_value, hist.FrequencyBin) into histogram.
 
     The input collection is not expected to have frequency bins reduced per
@@ -320,7 +320,7 @@ def _compute_linf_sum_contributions_histogram(
         col, NUMBER_OF_BUCKETS_IN_LINF_SUM_CONTRIBUTIONS_HISTOGRAM, backend)
 
     return _compute_frequency_histogram_helper_with_lowers(
-        backend, col, hist.HistogramType.LINF_SUM_CONTRIBUTIONS, lowers)
+        col, backend, hist.HistogramType.LINF_SUM_CONTRIBUTIONS, lowers)
 
 
 def _min_max_lowers(col, number_of_buckets,
@@ -567,7 +567,7 @@ def _compute_linf_sum_contributions_histogram_on_preaggregated_data(
     # generated histogram.
 
     return _compute_frequency_histogram_helper_with_lowers(
-        backend, col, hist.HistogramType.LINF_SUM_CONTRIBUTIONS, lowers)
+        col, backend, hist.HistogramType.LINF_SUM_CONTRIBUTIONS, lowers)
 
 
 def _compute_partition_count_histogram_on_preaggregated_data(

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -140,16 +140,19 @@ def _compute_frequency_histogram_helper_with_lowers(
     """
 
     def _map_to_frequency_bin(
-            value: float, frequency: int,
+            value: float,
             lowers: List[float]) -> Tuple[float, hist.FrequencyBin]:
         bin_lower = _to_bin_lower_with_lowers(lowers, value)
         return bin_lower, hist.FrequencyBin(lower=bin_lower,
-                                            count=frequency,
-                                            sum=frequency * value,
+                                            count=1,
+                                            sum=value,
                                             max=value)
 
+    col = list(col)
+    lowers_col = list(lowers_col)
     col = backend.map_tuple_with_side_inputs(col, _map_to_frequency_bin,
                                              (lowers_col,), "To FrequencyBin")
+    col = list(col)
     # (lower_bin_value, hist.FrequencyBin)
 
     return _convert_frequency_bins_into_histogram(backend, col, name)
@@ -313,6 +316,7 @@ def _compute_linf_sum_contributions_histogram(
     # col: ((pid, pk), sum_per_key)
     col = backend.values(col, "Drop keys")
     # col: (float)
+    col = backend.to_multi_transformable_collection(col)
     min_max_values = pipeline_functions.min_max_elements(
         backend, col, "Min and max value in dataset")
     lowers = backend.map(

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -339,6 +339,7 @@ def _min_max_lowers(col, number_of_buckets,
     """
     min_max_values = pipeline_functions.min_max_elements(
         backend, col, "Min and max value in dataset")
+    # min_max_values: 1 element collection with a pair (min, max)
     return backend.map(
         min_max_values,
         lambda min_max: numpy.linspace(min_max[0], min_max[1],
@@ -562,6 +563,8 @@ def _compute_linf_sum_contributions_histogram_on_preaggregated_data(
     col = backend.to_multi_transformable_collection(col)
     lowers = _min_max_lowers(
         col, NUMBER_OF_BUCKETS_IN_LINF_SUM_CONTRIBUTIONS_HISTOGRAM, backend)
+    # lowers: (float,) where each value defines a lower of a bin in the
+    # generated histogram.
 
     return _compute_frequency_histogram_helper_with_lowers(
         backend, col, hist.HistogramType.LINF_SUM_CONTRIBUTIONS, lowers)

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -150,8 +150,8 @@ def _compute_frequency_histogram_helper_with_lowers(
 
     col = list(col)
     lowers_col = list(lowers_col)
-    col = backend.map_tuple_with_side_inputs(col, _map_to_frequency_bin,
-                                             (lowers_col,), "To FrequencyBin")
+    col = backend.map_with_side_inputs(col, _map_to_frequency_bin,
+                                       (lowers_col,), "To FrequencyBin")
     col = list(col)
     # (lower_bin_value, hist.FrequencyBin)
 

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -340,12 +340,11 @@ def _min_max_lowers(col, number_of_buckets,
     """
     min_max_values = pipeline_functions.min_max_elements(
         backend, col, "Min and max value in dataset")
-    lowers = backend.map(
+    return backend.flat_map(
         min_max_values,
         lambda min_max: numpy.linspace(min_max[0], min_max[1],
                                        (number_of_buckets + 1))[:-1],
-        "Map to lowers")
-    return backend.flatten(lowers, "Flatten lowers")
+        "flatMap to lowers")
 
 
 def _compute_partition_count_histogram(

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -43,7 +43,7 @@ def _to_bin_lower_logarithmic(value: int) -> int:
     return value // round_base * round_base
 
 
-def _to_bin_lower_with_lowers(lowers: [float], value: float) -> float:
+def _to_bin_lower_with_lowers(lowers: List[float], value: float) -> float:
     """Finds the lower bound of the histogram bin which contains the given number."""
     bin_lower_idx = bisect.bisect_right(lowers, value) - 1
     assert bin_lower_idx >= 0
@@ -140,8 +140,10 @@ def _compute_frequency_histogram_helper_with_lowers(
     """
 
     def _map_to_frequency_bin(
-            value: float,
-            lowers: List[float]) -> Tuple[float, hist.FrequencyBin]:
+            value: float, lowers_container: List[List[float]]
+    ) -> Tuple[float, hist.FrequencyBin]:
+        # lowers_container is a list with one element that contains lowers list.
+        lowers = lowers_container[0]
         bin_lower = _to_bin_lower_with_lowers(lowers, value)
         return bin_lower, hist.FrequencyBin(lower=bin_lower,
                                             count=1,
@@ -337,11 +339,11 @@ def _min_max_lowers(col, number_of_buckets,
     """
     min_max_values = pipeline_functions.min_max_elements(
         backend, col, "Min and max value in dataset")
-    return backend.flat_map(
+    return backend.map(
         min_max_values,
         lambda min_max: numpy.linspace(min_max[0], min_max[1],
                                        (number_of_buckets + 1))[:-1],
-        "flatMap to lowers")
+        "map to lowers")
 
 
 def _compute_partition_count_histogram(

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -299,7 +299,8 @@ def _compute_linf_sum_contributions_histogram(
 
     This histogram contains: the number of (privacy id, partition_key)-pairs
     which have sum of values X_1, X_2, ..., X_n, where X_1 = min_sum,
-    X_n = one before max sum and n is a constant hardcoded in code.
+    X_n = one before max sum and n is equal to
+    NUMBER_OF_BUCKETS_IN_LINF_SUM_CONTRIBUTIONS_HISTOGRAM.
 
     Args:
         col: collection with elements (privacy_id, partition_key, value).

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -148,11 +148,8 @@ def _compute_frequency_histogram_helper_with_lowers(
                                             sum=value,
                                             max=value)
 
-    col = list(col)
-    lowers_col = list(lowers_col)
     col = backend.map_with_side_inputs(col, _map_to_frequency_bin,
                                        (lowers_col,), "To FrequencyBin")
-    col = list(col)
     # (lower_bin_value, hist.FrequencyBin)
 
     return _convert_frequency_bins_into_histogram(backend, col, name)

--- a/pipeline_dp/dataset_histograms/histograms.py
+++ b/pipeline_dp/dataset_histograms/histograms.py
@@ -34,8 +34,8 @@ class FrequencyBin:
     """
     lower: Union[int, float]
     count: int
-    sum: int
-    max: int
+    sum: Union[int, float]
+    max: Union[int, float]
 
     def __add__(self, other: 'FrequencyBin') -> 'FrequencyBin':
         return FrequencyBin(self.lower, self.count + other.count,
@@ -59,7 +59,7 @@ class HistogramType(enum.Enum):
     # with [lower, next_lower) contributions.
     # 'sum' is the total number of contributions for these pairs.
     LINF_CONTRIBUTIONS = 'linf_contributions'
-    LINF_SUM_CONTRIBUTIONS = 'lin_sum_contributions'
+    LINF_SUM_CONTRIBUTIONS = 'linf_sum_contributions'
     COUNT_PER_PARTITION = 'count_per_partition'
     COUNT_PRIVACY_ID_PER_PARTITION = 'privacy_id_per_partition_count'
 

--- a/pipeline_dp/dataset_histograms/histograms.py
+++ b/pipeline_dp/dataset_histograms/histograms.py
@@ -162,5 +162,6 @@ class DatasetHistograms:
     l0_contributions_histogram: Histogram
     l1_contributions_histogram: Histogram
     linf_contributions_histogram: Histogram
+    linf_sum_contributions_histogram: Histogram
     count_per_partition_histogram: Histogram
     count_privacy_id_per_partition: Histogram

--- a/pipeline_dp/dataset_histograms/histograms.py
+++ b/pipeline_dp/dataset_histograms/histograms.py
@@ -15,7 +15,7 @@
 
 from dataclasses import dataclass
 import enum
-from typing import List, Sequence, Tuple
+from typing import List, Sequence, Tuple, Union
 
 
 @dataclass
@@ -32,7 +32,7 @@ class FrequencyBin:
       max: the maximum element in the bin, which is smaller or equal to the
        upper-1.
     """
-    lower: int
+    lower: Union[int, float]
     count: int
     sum: int
     max: int
@@ -59,6 +59,7 @@ class HistogramType(enum.Enum):
     # with [lower, next_lower) contributions.
     # 'sum' is the total number of contributions for these pairs.
     LINF_CONTRIBUTIONS = 'linf_contributions'
+    LINF_SUM_CONTRIBUTIONS = 'lin_sum_contributions'
     COUNT_PER_PARTITION = 'count_per_partition'
     COUNT_PRIVACY_ID_PER_PARTITION = 'privacy_id_per_partition_count'
 

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -489,7 +489,8 @@ class LocalBackend(PipelineBackend):
                              fn,
                              side_input_cols,
                              stage_name: str = None):
-        return map(lambda x: fn(x, *side_input_cols), col)
+        side_inputs = [list(side_input) for side_input in side_input_cols]
+        return map(lambda x: fn(x, *side_inputs), col)
 
     def flat_map(self, col, fn, stage_name: str = None):
         return (x for el in col for x in fn(el))

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -733,7 +733,8 @@ class MultiProcLocalBackend(PipelineBackend):
                              fn,
                              side_input_cols,
                              stage_name: typing.Optional[str] = None):
-        return self.map(col, lambda row: fn(row, *side_input_cols), stage_name)
+        side_inputs = [list(side_input) for side_input in side_input_cols]
+        return self.map(col, lambda row: fn(row, *side_inputs), stage_name)
 
     def flat_map(self, col, fn, stage_name: typing.Optional[str] = None):
         return (e for x in self.map(col, fn, stage_name) for e in x)

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -78,6 +78,11 @@ class PipelineBackend(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def map_tuple_with_side_inputs(self, col, fn, side_input_cols,
+                                   stage_name: str):
+        pass
+
+    @abc.abstractmethod
     def map_values(self, col, fn, stage_name: str):
         pass
 
@@ -469,6 +474,13 @@ class LocalBackend(PipelineBackend):
 
     def map_tuple(self, col, fn, stage_name: str = None):
         return map(lambda x: fn(*x), col)
+
+    def map_tuple_with_side_inputs(self,
+                                   col,
+                                   fn,
+                                   side_input_cols,
+                                   stage_name: str = None):
+        return map(lambda x: fn(*x, *side_input_cols), col)
 
     def map_values(self, col, fn, stage_name: typing.Optional[str] = None):
         return ((k, fn(v)) for k, v in col)

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -249,8 +249,7 @@ class BeamBackend(PipelineBackend):
             beam.pvalue.AsList(side_input_col)
             for side_input_col in side_input_cols
         ]
-        return col | self._ulg.unique(stage_name) >> beam.Map(
-            lambda x: fn(x), side_inputs[0])
+        return col | self._ulg.unique(stage_name) >> beam.Map(fn, *side_inputs)
 
     def flat_map(self, col, fn, stage_name: str):
         return col | self._ulg.unique(stage_name) >> beam.FlatMap(fn)

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -250,7 +250,7 @@ class BeamBackend(PipelineBackend):
             for side_input_col in side_input_cols
         ]
         return col | self._ulg.unique(stage_name) >> beam.Map(
-            lambda x: fn(x), *side_inputs)
+            lambda x: fn(x), side_inputs[0])
 
     def flat_map(self, col, fn, stage_name: str):
         return col | self._ulg.unique(stage_name) >> beam.FlatMap(fn)

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -250,7 +250,7 @@ class BeamBackend(PipelineBackend):
             for side_input_col in side_input_cols
         ]
         return col | self._ulg.unique(stage_name) >> beam.Map(
-            lambda x: fn(*x), *side_inputs)
+            lambda x: fn(x), *side_inputs)
 
     def flat_map(self, col, fn, stage_name: str):
         return col | self._ulg.unique(stage_name) >> beam.FlatMap(fn)
@@ -732,7 +732,7 @@ class MultiProcLocalBackend(PipelineBackend):
                              fn,
                              side_input_cols,
                              stage_name: typing.Optional[str] = None):
-        return self.map(col, lambda row: fn(*row, *side_input_cols), stage_name)
+        return self.map(col, lambda row: fn(row, *side_input_cols), stage_name)
 
     def flat_map(self, col, fn, stage_name: typing.Optional[str] = None):
         return (e for x in self.map(col, fn, stage_name) for e in x)

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -400,7 +400,7 @@ class SparkRDDBackend(PipelineBackend):
     def map_tuple(self, rdd, fn, stage_name: str = None):
         return rdd.map(lambda x: fn(*x))
 
-    def map_tuple_with_side_inputs(self, col, fn, side_input_cols,
+    def map_tuple_with_side_inputs(self, rdd, fn, side_input_cols,
                                    stage_name: str):
         raise NotImplementedError("map_tuple_with_side_inputs "
                                   "is not implement in SparkBackend.")

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -400,6 +400,11 @@ class SparkRDDBackend(PipelineBackend):
     def map_tuple(self, rdd, fn, stage_name: str = None):
         return rdd.map(lambda x: fn(*x))
 
+    def map_tuple_with_side_inputs(self, col, fn, side_input_cols,
+                                   stage_name: str):
+        raise NotImplementedError("map_tuple_with_side_inputs "
+                                  "is not implement in SparkBackend.")
+
     def map_values(self, rdd, fn, stage_name: str = None):
         return rdd.mapValues(fn)
 

--- a/pipeline_dp/pipeline_functions.py
+++ b/pipeline_dp/pipeline_functions.py
@@ -101,12 +101,9 @@ def collect_to_container(backend: pipeline_backend.PipelineBackend,
 
 def min_max_elements(backend: pipeline_backend.PipelineBackend, col,
                      stage_name: str):
-    col = backend.map(
-        col, lambda x: (None, (x, x)),
-        f"{stage_name}: key all elements by the same fictional key"
-    )  # None is dummy key
+    col = backend.map(col, lambda x: (None, (x, x)),
+                      f"{stage_name}: key by dummy key")  # None is dummy key
     col = backend.reduce_per_key(
         col, lambda x, y: (min(x[0], y[0]), max(x[1], y[1])),
-        f"{stage_name}: reduce by the fictional key choosing min and max elements of the collection"
-    )
+        f"{stage_name}: reduce to compute min, max")
     return backend.values(col, "Drop keys")

--- a/pipeline_dp/pipeline_functions.py
+++ b/pipeline_dp/pipeline_functions.py
@@ -109,4 +109,4 @@ def min_max_elements(backend: pipeline_backend.PipelineBackend, col,
         col, lambda x, y: (min(x[0], y[0]), max(x[1], y[1])),
         f"{stage_name}: reduce by the fictional key choosing min and max elements of the collection"
     )
-    return backend.values(col)
+    return backend.values(col, "Drop keys")

--- a/pipeline_dp/pipeline_functions.py
+++ b/pipeline_dp/pipeline_functions.py
@@ -99,24 +99,14 @@ def collect_to_container(backend: pipeline_backend.PipelineBackend,
                        f"{stage_name}: construct container class from inputs")
 
 
-def max_element(backend: pipeline_backend.PipelineBackend, col,
-                stage_name: str):
-    return choose_element(backend, col, max, stage_name)
-
-
-def min_element(backend: pipeline_backend.PipelineBackend, col,
-                stage_name: str):
-    return choose_element(backend, col, min, stage_name)
-
-
-T = TypeVar('T')
-
-
-def choose_element(backend: pipeline_backend.PipelineBackend, col,
-                   choosing_function: Callable[[T, T], T], stage_name: str):
-    return backend.values(
-        backend.reduce_per_key(
-            backend.map_tuple(col, lambda el: (1, el),
-                              f"{stage_name}: key by fictional element"),
-            lambda el1, el2: choosing_function(el1, el2),
-            f"{stage_name}: choose element between two"))
+def min_max_elements(backend: pipeline_backend.PipelineBackend, col,
+                     stage_name: str):
+    col = backend.map(
+        col, lambda x: (None, (x, x)),
+        f"{stage_name}: key all elements by the same fictional key"
+    )  # None is dummy key
+    col = backend.reduce_per_key(
+        col, lambda x, y: (min(x[0], y[0]), max(x[1], y[1])),
+        f"{stage_name}: reduce by the fictional key choosing min and max elements of the collection"
+    )
+    return col

--- a/pipeline_dp/pipeline_functions.py
+++ b/pipeline_dp/pipeline_functions.py
@@ -109,4 +109,4 @@ def min_max_elements(backend: pipeline_backend.PipelineBackend, col,
         col, lambda x, y: (min(x[0], y[0]), max(x[1], y[1])),
         f"{stage_name}: reduce by the fictional key choosing min and max elements of the collection"
     )
-    return col
+    return backend.values(col)

--- a/tests/dataset_histograms/computing_histograms_test.py
+++ b/tests/dataset_histograms/computing_histograms_test.py
@@ -385,11 +385,9 @@ class ComputingHistogramsTest(parameterized.TestCase):
                     privacy_id_extractor=lambda x: x[0][0],
                     partition_extractor=lambda x: x[0][1],
                     value_extractor=lambda x: x[1]))
-            compute_histograms = \
-                computing_histograms._compute_linf_sum_contributions_histogram_on_preaggregated_data
+            compute_histograms = computing_histograms._compute_linf_sum_contributions_histogram_on_preaggregated_data
         else:
-            compute_histograms = \
-                computing_histograms._compute_linf_sum_contributions_histogram
+            compute_histograms = computing_histograms._compute_linf_sum_contributions_histogram
         histogram = list(compute_histograms(input, backend))
         self.assertLen(histogram, 1)
         histogram = histogram[0]

--- a/tests/dataset_histograms/computing_histograms_test.py
+++ b/tests/dataset_histograms/computing_histograms_test.py
@@ -372,7 +372,7 @@ class ComputingHistogramsTest(parameterized.TestCase):
                     hist.FrequencyBin(lower=0.9998, count=15, sum=15, max=1),
                 ]),
         ),
-        pre_aggregated=(False,))  # TODO: put True here
+        pre_aggregated=(False, True))
     def test_compute_linf_sum_contributions_histogram(self, testcase_name,
                                                       input, expected,
                                                       pre_aggregated):
@@ -382,11 +382,11 @@ class ComputingHistogramsTest(parameterized.TestCase):
                 input,
                 backend,
                 data_extractors=pipeline_dp.DataExtractors(
-                    privacy_id_extractor=lambda x: x[0],
-                    partition_extractor=lambda x: x[1],
-                    value_extractor=lambda x: 0))
+                    privacy_id_extractor=lambda x: x[0][0],
+                    partition_extractor=lambda x: x[0][1],
+                    value_extractor=lambda x: x[1]))
             compute_histograms = \
-                computing_histograms._compute_linf_contributions_histogram_on_preaggregated_data
+                computing_histograms._compute_linf_sum_contributions_histogram_on_preaggregated_data
         else:
             compute_histograms = \
                 computing_histograms._compute_linf_sum_contributions_histogram
@@ -617,7 +617,7 @@ class ComputingHistogramsTest(parameterized.TestCase):
                     hist.FrequencyBin(lower=2.0, count=4, sum=8, max=2),
                 ],
             )),
-        pre_aggregated=(False,))  # TODO: put True back here
+        pre_aggregated=(False, True))
     def test_compute_contribution_histograms(self, testcase_name, input,
                                              expected_cross_partition,
                                              expected_per_partition,

--- a/tests/dataset_histograms/computing_histograms_test.py
+++ b/tests/dataset_histograms/computing_histograms_test.py
@@ -24,8 +24,8 @@ from analysis import pre_aggregation
 
 class ComputingHistogramsTest(parameterized.TestCase):
 
-    def test_to_bin_lower(self):
-        to_bin_lower = computing_histograms._to_bin_lower
+    def test_to_bin_lower_logarithmic(self):
+        to_bin_lower = computing_histograms._to_bin_lower_logarithmic
         self.assertEqual(to_bin_lower(1), 1)
         self.assertEqual(to_bin_lower(999), 999)
         self.assertEqual(to_bin_lower(1000), 1000)
@@ -34,6 +34,18 @@ class ComputingHistogramsTest(parameterized.TestCase):
         self.assertEqual(to_bin_lower(2022), 2020)
         self.assertEqual(to_bin_lower(12522), 12500)
         self.assertEqual(to_bin_lower(10**9 + 10**7 + 1234), 10**9 + 10**7)
+
+    def test_to_bin_lower_with_lowers(self):
+        lowers = [0.5, 1.2, 3.6]
+        to_bin_lower = computing_histograms._to_bin_lower_with_lowers
+        with self.assertRaises(AssertionError):
+            to_bin_lower(lowers, 0.3)
+        self.assertEqual(to_bin_lower(lowers, 0.5), 0.5)
+        self.assertEqual(to_bin_lower(lowers, 1), 0.5)
+        self.assertEqual(to_bin_lower(lowers, 1.2), 1.2)
+        self.assertEqual(to_bin_lower(lowers, 1.3), 1.2)
+        self.assertEqual(to_bin_lower(lowers, 3.6), 3.6)
+        self.assertEqual(to_bin_lower(lowers, 100), 3.6)
 
     @parameterized.named_parameters(
         dict(testcase_name='empty', input=[], expected=[]),

--- a/tests/dataset_histograms/computing_histograms_test.py
+++ b/tests/dataset_histograms/computing_histograms_test.py
@@ -80,17 +80,23 @@ class ComputingHistogramsTest(parameterized.TestCase):
         histogram1 = hist.Histogram(hist.HistogramType.L0_CONTRIBUTIONS, None)
         histogram2 = hist.Histogram(hist.HistogramType.L1_CONTRIBUTIONS, None)
         histogram3 = hist.Histogram(hist.HistogramType.LINF_CONTRIBUTIONS, None)
-        histogram4 = hist.Histogram(hist.HistogramType.COUNT_PER_PARTITION,
+        histogram4 = hist.Histogram(hist.HistogramType.LINF_SUM_CONTRIBUTIONS,
                                     None)
-        histogram5 = hist.Histogram(
+        histogram5 = hist.Histogram(hist.HistogramType.COUNT_PER_PARTITION,
+                                    None)
+        histogram6 = hist.Histogram(
             hist.HistogramType.COUNT_PRIVACY_ID_PER_PARTITION, None)
-        histograms = computing_histograms._list_to_contribution_histograms(
-            [histogram2, histogram1, histogram3, histogram5, histogram4])
+        histograms = computing_histograms._list_to_contribution_histograms([
+            histogram2, histogram1, histogram3, histogram4, histogram6,
+            histogram5
+        ])
         self.assertEqual(histogram1, histograms.l0_contributions_histogram)
         self.assertEqual(histogram2, histograms.l1_contributions_histogram)
         self.assertEqual(histogram3, histograms.linf_contributions_histogram)
-        self.assertEqual(histogram4, histograms.count_per_partition_histogram)
-        self.assertEqual(histogram5, histograms.count_privacy_id_per_partition)
+        self.assertEqual(histogram4,
+                         histograms.linf_sum_contributions_histogram)
+        self.assertEqual(histogram5, histograms.count_per_partition_histogram)
+        self.assertEqual(histogram6, histograms.count_privacy_id_per_partition)
 
     @parameterized.product(
         (
@@ -287,6 +293,115 @@ class ComputingHistogramsTest(parameterized.TestCase):
             dict(testcase_name='empty', input=[], expected=[]),
             dict(
                 testcase_name='small_histogram',
+                input=[((1, 1), 0.5), ((1, 2), 1.5), ((2, 1), -2.5),
+                       ((1, 1), 0.5)],  # ((privacy_id, partition), value)
+                expected=[
+                    # ((2, 1), -2.5)
+                    hist.FrequencyBin(lower=-2.5, count=1, sum=-2.5, max=-2.5),
+                    # 2 times ((1, 1), 0.5), they are summed up and put into a
+                    # bin as one.
+                    hist.FrequencyBin(lower=1.0, count=1, sum=1.0, max=1.0),
+                    # ((1, 1, 1.5), 1.5 is max and not included,
+                    # step is (1.5 - (-2.5)) / 1e4 = 0.0004,
+                    # therefore 1.5 - 0.0004 = 1.4996.
+                    hist.FrequencyBin(lower=1.4996, count=1, sum=1.5, max=1.5),
+                ]),
+            dict(
+                testcase_name='Different privacy ids, 1 equal contribution',
+                input=[((i, i), 1) for i in range(100)],
+                # ((privacy_id, partition), value)
+                expected=[
+                    hist.FrequencyBin(lower=1, count=100, sum=100, max=1),
+                ]),
+            dict(
+                testcase_name='Different privacy ids, 1 different contribution',
+                input=[((i, i), i) for i in range(10001)],
+                # ((privacy_id, partition), value)
+                # step is 1e4 / 1e4 = 1, therefore 1e4 - 1 = 9999.
+                expected=[
+                    hist.FrequencyBin(lower=float(i), count=1, sum=i, max=i)
+                    for i in range(9999)
+                ] +
+                [hist.FrequencyBin(lower=9999, count=2, sum=19999, max=10000)]),
+            dict(
+                testcase_name='1 privacy id many contributions to 1 '
+                'partition',
+                input=[((0, 0), 1.0)] * 100,  # ((privacy_id, partition), value)
+                expected=[
+                    hist.FrequencyBin(
+                        lower=100.0, count=1, sum=100.0, max=100.0),
+                ]),
+            dict(
+                testcase_name=
+                '1 privacy id many equal contributions to many partition',
+                input=[((0, i), 1.0) for i in range(1234)],
+                # ((privacy_id, partition), value)
+                expected=[
+                    hist.FrequencyBin(lower=1.0, count=1234, sum=1234.0, max=1),
+                ]),
+            dict(
+                testcase_name=
+                '1 privacy id many different contributions to many partition',
+                input=[((0, i), i) for i in range(10001)],
+                # ((privacy_id, partition), value)
+                # step is 1e4 / 1e4 = 1, therefore 1e4 - 1 = 9999.
+                expected=[
+                    hist.FrequencyBin(lower=float(i), count=1, sum=i, max=i)
+                    for i in range(9999)
+                ] +
+                [hist.FrequencyBin(lower=9999, count=2, sum=19999, max=10000)]),
+            dict(
+                testcase_name=
+                '2 privacy ids, same partitions equally contributed',
+                input=[((0, i), 1.0) for i in range(15)] +
+                [((1, i), 1.0) for i in range(10, 25)],
+                # ((privacy_id, partition), value)
+                expected=[
+                    hist.FrequencyBin(lower=1.0, count=30, sum=30, max=1),
+                ]),
+            dict(
+                testcase_name='2 privacy ids, same partitions differently '
+                'contributed',
+                input=[((0, i), -1.0) for i in range(15)] +
+                [((1, i), 1.0) for i in range(10, 25)],
+                # ((privacy_id, partition), value)
+                # step = (1 - (-1)) / 1e4 = 0.0002,
+                # therefore last lower is 1 - 0.0002 = 0.9998.
+                expected=[
+                    hist.FrequencyBin(lower=-1.0, count=15, sum=-15, max=-1),
+                    hist.FrequencyBin(lower=0.9998, count=15, sum=15, max=1),
+                ]),
+        ),
+        pre_aggregated=(False,))  # TODO: put True here
+    def test_compute_linf_sum_contributions_histogram(self, testcase_name,
+                                                      input, expected,
+                                                      pre_aggregated):
+        backend = pipeline_dp.LocalBackend()
+        if pre_aggregated:
+            input = pre_aggregation.preaggregate(
+                input,
+                backend,
+                data_extractors=pipeline_dp.DataExtractors(
+                    privacy_id_extractor=lambda x: x[0],
+                    partition_extractor=lambda x: x[1],
+                    value_extractor=lambda x: 0))
+            compute_histograms = \
+                computing_histograms._compute_linf_contributions_histogram_on_preaggregated_data
+        else:
+            compute_histograms = \
+                computing_histograms._compute_linf_sum_contributions_histogram
+        histogram = list(compute_histograms(input, backend))
+        self.assertLen(histogram, 1)
+        histogram = histogram[0]
+        self.assertEqual(hist.HistogramType.LINF_SUM_CONTRIBUTIONS,
+                         histogram.name)
+        self.assertListEqual(expected, histogram.bins)
+
+    @parameterized.product(
+        (
+            dict(testcase_name='empty', input=[], expected=[]),
+            dict(
+                testcase_name='small_histogram',
                 input=[(1, 1), (1, 2), (2, 1),
                        (1, 1)],  # (privacy_id, partition)
                 expected=[
@@ -401,14 +516,17 @@ class ComputingHistogramsTest(parameterized.TestCase):
 
     @parameterized.product(
         (
-            dict(testcase_name='empty',
-                 input=[],
-                 expected_cross_partition=[],
-                 expected_per_partition=[]),
+            dict(
+                testcase_name='empty',
+                input=[],
+                expected_cross_partition=[],
+                expected_per_partition=[],
+                expected_sum_per_partition=[],
+            ),
             dict(
                 testcase_name='small_histogram',
-                input=[(1, 1), (1, 2), (2, 1),
-                       (1, 1)],  # (privacy_id, partition)
+                input=[(1, 1, 0.5), (1, 2, 1.5), (2, 1, -2.5),
+                       (1, 1, 0.5)],  # (privacy_id, partition, value)
                 expected_cross_partition=[
                     hist.FrequencyBin(lower=1, count=1, sum=1, max=1),
                     hist.FrequencyBin(lower=2, count=1, sum=2, max=2)
@@ -416,49 +534,77 @@ class ComputingHistogramsTest(parameterized.TestCase):
                 expected_per_partition=[
                     hist.FrequencyBin(lower=1, count=2, sum=2, max=1),
                     hist.FrequencyBin(lower=2, count=1, sum=2, max=2)
+                ],
+                expected_sum_per_partition=[
+                    # see for explanation why these values
+                    # test_compute_linf_sum_contributions_histogram.
+                    hist.FrequencyBin(lower=-2.5, count=1, sum=-2.5, max=-2.5),
+                    hist.FrequencyBin(lower=1.0, count=1, sum=1.0, max=1.0),
+                    hist.FrequencyBin(lower=1.4996, count=1, sum=1.5, max=1.5),
                 ]),
             dict(
                 testcase_name='Each privacy id, 1 contribution',
-                input=[(i, i) for i in range(100)],  # (privacy_id, partition)
+                input=[(i, i, 1.0) for i in range(100)
+                      ],  # (privacy_id, partition, value)
                 expected_cross_partition=[
                     hist.FrequencyBin(lower=1, count=100, sum=100, max=1),
                 ],
                 expected_per_partition=[
                     hist.FrequencyBin(lower=1, count=100, sum=100, max=1),
-                ]),
+                ],
+                expected_sum_per_partition=[
+                    hist.FrequencyBin(lower=1, count=100, sum=100, max=1),
+                ],
+            ),
             dict(
                 testcase_name='1 privacy id many contributions to 1 partition',
-                input=[(0, 0)] * 100,  # (privacy_id, partition)
+                input=[(0, 0, 1.0)] * 100,  # (privacy_id, partition, value)
                 expected_cross_partition=[
                     hist.FrequencyBin(lower=1, count=1, sum=1, max=1),
                 ],
                 expected_per_partition=[
                     hist.FrequencyBin(lower=100, count=1, sum=100, max=100),
-                ]),
+                ],
+                expected_sum_per_partition=[
+                    hist.FrequencyBin(
+                        lower=100.0, count=1, sum=100.0, max=100.0),
+                ],
+            ),
             dict(
                 testcase_name=
                 '1 privacy id many contributions to many partition',
-                input=[(0, i) for i in range(1234)],  # (privacy_id, partition)
+                input=[(0, i, 1.0) for i in range(1234)
+                      ],  # (privacy_id, partition, value)
                 expected_cross_partition=[
                     hist.FrequencyBin(lower=1230, count=1, sum=1234, max=1234),
                 ],
                 expected_per_partition=[
                     hist.FrequencyBin(lower=1, count=1234, sum=1234, max=1),
-                ]),
+                ],
+                expected_sum_per_partition=[
+                    hist.FrequencyBin(lower=1.0, count=1234, sum=1234.0, max=1),
+                ],
+            ),
             dict(
                 testcase_name='2 privacy ids, same partitions contributed',
-                input=[(0, i) for i in range(15)] +
-                [(1, i) for i in range(10, 25)],  # (privacy_id, partition)
+                input=[(0, i, 1.0) for i in range(15)] + [
+                    (1, i, 1.0) for i in range(10, 25)
+                ],  # (privacy_id, partition, value)
                 expected_cross_partition=[
                     hist.FrequencyBin(lower=15, count=2, sum=30, max=15),
                 ],
                 expected_per_partition=[
                     hist.FrequencyBin(lower=1, count=30, sum=30, max=1),
-                ]),
+                ],
+                expected_sum_per_partition=[
+                    hist.FrequencyBin(lower=1.0, count=30, sum=30, max=1),
+                ],
+            ),
             dict(
                 testcase_name='2 privacy ids',
-                input=[(0, 0), (0, 0), (0, 1), (1, 0), (1, 0), (1, 0),
-                       (1, 2)],  # (privacy_id, partition)
+                input=[(0, 0, 1.0), (0, 0, 1.0), (0, 1, 2.0), (1, 0, 0.0),
+                       (1, 0, 1.3), (1, 0, 0.7),
+                       (1, 2, 2.0)],  # (privacy_id, partition, value)
                 expected_cross_partition=[
                     hist.FrequencyBin(lower=2, count=2, sum=4, max=2),
                 ],
@@ -466,16 +612,21 @@ class ComputingHistogramsTest(parameterized.TestCase):
                     hist.FrequencyBin(lower=1, count=2, sum=2, max=1),
                     hist.FrequencyBin(lower=2, count=1, sum=2, max=2),
                     hist.FrequencyBin(lower=3, count=1, sum=3, max=3),
-                ])),
-        pre_aggregated=(False, True))
+                ],
+                expected_sum_per_partition=[
+                    hist.FrequencyBin(lower=2.0, count=4, sum=8, max=2),
+                ],
+            )),
+        pre_aggregated=(False,))  # TODO: put True back here
     def test_compute_contribution_histograms(self, testcase_name, input,
                                              expected_cross_partition,
                                              expected_per_partition,
+                                             expected_sum_per_partition,
                                              pre_aggregated):
         data_extractors = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x[0],
             partition_extractor=lambda x: x[1],
-            value_extractor=lambda x: 0)
+            value_extractor=lambda x: x[2])
         backend = pipeline_dp.LocalBackend()
         if pre_aggregated:
             input = pre_aggregation.preaggregate(input, backend,
@@ -501,6 +652,10 @@ class ComputingHistogramsTest(parameterized.TestCase):
                          histograms.linf_contributions_histogram.name)
         self.assertListEqual(expected_per_partition,
                              histograms.linf_contributions_histogram.bins)
+        self.assertEqual(hist.HistogramType.LINF_SUM_CONTRIBUTIONS,
+                         histograms.linf_sum_contributions_histogram.name)
+        self.assertListEqual(expected_sum_per_partition,
+                             histograms.linf_sum_contributions_histogram.bins)
 
 
 if __name__ == '__main__':

--- a/tests/dataset_histograms/histogram_error_estimator_test.py
+++ b/tests/dataset_histograms/histogram_error_estimator_test.py
@@ -28,13 +28,14 @@ class HistogramErrorEstimatorTest(parameterized.TestCase):
         # Generate dataset
         dataset = []
         # 1st privacy unit contributes to 10 partitions once
-        dataset.extend([(1, i) for i in range(10)])
+        dataset.extend([(1, i, 1.0) for i in range(10)])
         # 2nd privacy unit contributes to 1 partition 20 times.
-        dataset.extend([(2, 0) for i in range(20)])
+        dataset.extend([(2, 0, 2.0) for i in range(20)])
 
         data_extractors = pipeline_dp.DataExtractors(
             privacy_id_extractor=lambda x: x[0],
-            partition_extractor=lambda x: x[1])
+            partition_extractor=lambda x: x[1],
+            value_extractor=lambda x: x[2])
         return list(
             computing_histograms.compute_dataset_histograms(
                 dataset, data_extractors, pipeline_dp.LocalBackend()))[0]

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -160,7 +160,7 @@ class DpEngineTest(parameterized.TestCase):
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: x[0],
             privacy_id_extractor=lambda x: x[1],
-            value_extractor=lambda _: None,
+            value_extractor=lambda _: 1,
         )
         partitions = ["pk0", "pk1"]
 
@@ -193,7 +193,7 @@ class DpEngineTest(parameterized.TestCase):
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: x[0],
             privacy_id_extractor=lambda x: x[1],
-            value_extractor=lambda _: None,
+            value_extractor=lambda _: 1,
         )
         partitions = ["pk0", "pk1"]
 
@@ -231,7 +231,7 @@ class DpEngineTest(parameterized.TestCase):
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: x[0],
             privacy_id_extractor=lambda x: x[1],
-            value_extractor=lambda _: None,
+            value_extractor=lambda _: 1,
         )
         partitions = ["pk0"]
 
@@ -268,7 +268,7 @@ class DpEngineTest(parameterized.TestCase):
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: x[0],
             privacy_id_extractor=lambda x: x[1],
-            value_extractor=lambda _: None,
+            value_extractor=lambda _: 1,
         )
         partitions = ["pk0", "pk1"]
 
@@ -305,7 +305,7 @@ class DpEngineTest(parameterized.TestCase):
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: x[0],
             privacy_id_extractor=lambda x: x[1],
-            value_extractor=lambda _: None,
+            value_extractor=lambda _: 1,
         )
         partitions = ["pk0", "pk1"]
 
@@ -337,7 +337,7 @@ class DpEngineTest(parameterized.TestCase):
         data_extractors = pipeline_dp.DataExtractors(
             partition_extractor=lambda x: x[0],
             privacy_id_extractor=lambda x: x[1],
-            value_extractor=lambda _: None,
+            value_extractor=lambda _: 1,
         )
         partitions = ["pk0", "pk1"]
 

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -252,38 +252,38 @@ class DpEngineTest(parameterized.TestCase):
             pipeline_dp.PrivateContributionBounds(max_partitions_contributed=1))
 
     def test_calculate_private_contribution_works_on_beam(self):
-        # Arrange
-        engine = pipeline_dp.DPEngine(budget_accountant=None,
-                                      backend=pipeline_dp.BeamBackend())
-        params = pipeline_dp.CalculatePrivateContributionBoundsParams(
-            aggregation_eps=0.9,
-            aggregation_delta=0.001,
-            calculation_eps=0.1,
-            aggregation_noise_kind=pipeline_dp.NoiseKind.LAPLACE,
-            max_partitions_contributed_upper_bound=2)
-        # user 0 contributes only 1 partitions, others contribute to both
-        data = [("pk0", 0)]
-        for i in range(10000):
-            data += [("pk0", i + 1), ("pk1", i + 1)]
-        data_extractors = pipeline_dp.DataExtractors(
-            partition_extractor=lambda x: x[0],
-            privacy_id_extractor=lambda x: x[1],
-            value_extractor=lambda _: 1,
-        )
-        partitions = ["pk0", "pk1"]
+        with test_pipeline.TestPipeline() as p:
+            # Arrange
+            engine = pipeline_dp.DPEngine(budget_accountant=None,
+                                          backend=pipeline_dp.BeamBackend())
+            params = pipeline_dp.CalculatePrivateContributionBoundsParams(
+                aggregation_eps=0.9,
+                aggregation_delta=0.001,
+                calculation_eps=0.1,
+                aggregation_noise_kind=pipeline_dp.NoiseKind.LAPLACE,
+                max_partitions_contributed_upper_bound=2)
+            # user 0 contributes only 1 partitions, others contribute to both
+            data = [("pk0", 0)]
+            for i in range(10000):
+                data += [("pk0", i + 1), ("pk1", i + 1)]
+            col = p | "Create input" >> beam.Create(data)
+            data_extractors = pipeline_dp.DataExtractors(
+                partition_extractor=lambda x: x[0],
+                privacy_id_extractor=lambda x: x[1],
+                value_extractor=lambda _: 1,
+            )
+            partitions = ["pk0", "pk1"]
 
-        # Act
-        result = engine.calculate_private_contribution_bounds(
-            data, params, data_extractors, partitions)
-        result = list(result)[0]
+            # Act
+            result = engine.calculate_private_contribution_bounds(
+                col, params, data_extractors, partitions)
 
-        # Assert
-        # Almost all users contributed to 2 partitions, so it has to be chosen.
-        # The probability of 1 to be chosen has to be very close to 0
-        # and therefore 1 should never be chosen.
-        self.assertEqual(
-            result,
-            pipeline_dp.PrivateContributionBounds(max_partitions_contributed=2))
+            beam_util.assert_that(
+                result,
+                beam_util.equal_to([
+                    pipeline_dp.PrivateContributionBounds(
+                        max_partitions_contributed=2)
+                ]))
 
     def test_calculate_private_contribution_does_not_work_on_multi_proc_local_due_to_unsupported_operations(
             self):

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -52,24 +52,24 @@ class BeamBackendTest(parameterized.TestCase):
 
     def test_map_with_side_inputs(self):
         with test_pipeline.TestPipeline() as p:
-            data = [(1, 2), (3, 4)]
+            data = [1, 2]
             col = p | "Create col PCollection" >> beam.Create(data)
-            list_side_input = [5, 6, 7]
+            list_side_input = [3, 4, 5]
             list_side_input_col = p | "Create list_side_input PCollection" >>\
                                   beam.Create(
                 list_side_input)
-            one_element_side_input = [8]
+            one_element_side_input = [6]
             one_element_side_input_col = p | "Create one_element_side_input " \
                                              "PCollection" >> beam.Create(
                 one_element_side_input)
-            join_lists_fn = lambda x, y, l1, l2: [x] + [y] + l1 + l2
+            join_lists_fn = lambda x, l1, l2: [x] + [y] + l1 + l2
 
             result = self.backend.map_with_side_inputs(
                 col, join_lists_fn,
                 [list_side_input_col, one_element_side_input_col],
                 "map_with_side_inputs")
 
-            expected_result = [[1, 2, 5, 6, 7, 8], [3, 4, 5, 6, 7, 8]]
+            expected_result = [[1, 3, 4, 5, 6], [2, 3, 4, 5, 6]]
             beam_util.assert_that(result, beam_util.equal_to(expected_result))
 
     def test_filter_by_key_must_not_be_none(self):
@@ -439,17 +439,17 @@ class LocalBackendTest(unittest.TestCase):
                          [0, 1, 4, 9, 16])
 
     def test_local_map_with_side_inputs(self):
-        col = [(1, 2), (3, 4)]
-        list_side_input_col = [5, 6, 7]
-        one_element_side_input_col = [8]
-        join_lists_fn = lambda x, y, l1, l2: [x] + [y] + l1 + l2
+        col = [1, 2]
+        list_side_input_col = [3, 4, 5]
+        one_element_side_input_col = [6]
+        join_lists_fn = lambda x, l1, l2: [x] + l1 + l2
 
         result = self.backend.map_with_side_inputs(
             col, join_lists_fn,
             [list_side_input_col, one_element_side_input_col],
             "map_with_side_inputs")
 
-        expected_result = [[1, 2, 5, 6, 7, 8], [3, 4, 5, 6, 7, 8]]
+        expected_result = [[1, 3, 4, 5, 6], [2, 3, 4, 5, 6]]
         self.assertEqual(list(result), expected_result)
 
     def test_local_map_tuple(self):
@@ -729,17 +729,17 @@ class MultiProcLocalBackendTest(unittest.TestCase):
 
     @pytest.mark.timeout(10)
     def test_multiproc_map_with_side_inputs(self):
-        col = [(1, 2), (3, 4)]
-        list_side_input_col = [5, 6, 7]
-        one_element_side_input_col = [8]
-        join_lists_fn = lambda x, y, l1, l2: [x] + [y] + l1 + l2
+        col = [1, 2]
+        list_side_input_col = [3, 4, 5]
+        one_element_side_input_col = [6]
+        join_lists_fn = lambda x, l1, l2: [x] + [y] + l1 + l2
 
         result = self.backend.map_with_side_inputs(
             col, join_lists_fn,
             [list_side_input_col, one_element_side_input_col],
             "map_with_side_inputs")
 
-        expected_result = [[1, 2, 5, 6, 7, 8], [3, 4, 5, 6, 7, 8]]
+        expected_result = [[1, 3, 4, 5, 6], [2, 3, 4, 5, 6]]
         self.assertDatasetsEqual(list(result), expected_result)
 
     @pytest.mark.timeout(10)

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -62,7 +62,7 @@ class BeamBackendTest(parameterized.TestCase):
             one_element_side_input_col = p | "Create one_element_side_input " \
                                              "PCollection" >> beam.Create(
                 one_element_side_input)
-            join_lists_fn = lambda x, l1, l2: [x] + [y] + l1 + l2
+            join_lists_fn = lambda x, l1, l2: [x] + l1 + l2
 
             result = self.backend.map_with_side_inputs(
                 col, join_lists_fn,
@@ -732,7 +732,7 @@ class MultiProcLocalBackendTest(unittest.TestCase):
         col = [1, 2]
         list_side_input_col = [3, 4, 5]
         one_element_side_input_col = [6]
-        join_lists_fn = lambda x, l1, l2: [x] + [y] + l1 + l2
+        join_lists_fn = lambda x, l1, l2: [x] + l1 + l2
 
         result = self.backend.map_with_side_inputs(
             col, join_lists_fn,

--- a/tests/private_contribution_bounds_test.py
+++ b/tests/private_contribution_bounds_test.py
@@ -233,6 +233,7 @@ class PrivateL0CalculatorTest(unittest.TestCase):
             hist.DatasetHistograms(l0_histogram,
                                    l1_contributions_histogram=None,
                                    linf_contributions_histogram=None,
+                                   linf_sum_contributions_histogram=None,
                                    count_per_partition_histogram=None,
                                    count_privacy_id_per_partition=None)
         ]
@@ -270,6 +271,7 @@ class PrivateL0CalculatorTest(unittest.TestCase):
             hist.DatasetHistograms(l0_histogram,
                                    l1_contributions_histogram=None,
                                    linf_contributions_histogram=None,
+                                   linf_sum_contributions_histogram=None,
                                    count_per_partition_histogram=None,
                                    count_privacy_id_per_partition=None)
         ]


### PR DESCRIPTION
Linf sum contributions histogram is a histogram where bins (lowers) are X_1, X_2, ..., X_n, where X_i is sum of values that have same (pid, pk)-pair (rounded to the bucket). Count of such histogram is number of (pid, pk) that have this sum. Sum of such histogram is sum of all sums in this bucket.