### PR TITLE
Do not sample per partition when min/max_sum_per_partitions is set

### DIFF
--- a/analysis/utility_analysis_engine.py
+++ b/analysis/utility_analysis_engine.py
@@ -86,7 +86,8 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
         return result
 
     def _create_contribution_bounder(
-        self, params: pipeline_dp.AggregateParams
+        self, params: pipeline_dp.AggregateParams,
+        expects_per_partition_sampling: bool
     ) -> contribution_bounders.ContributionBounder:
         """Creates ContributionBounder for utility analysis."""
         if self._options.pre_aggregated_data:

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -18,7 +18,7 @@ import logging
 import math
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Iterable, Sequence, Callable, Union, Optional, List
+from typing import Any, Sequence, Callable, Optional, List
 
 import numpy as np
 

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -733,14 +733,7 @@ class CompoundCombiner(Combiner):
         return [combiner.explain_computation() for combiner in self._combiners]
 
     def expects_per_partition_sampling(self) -> bool:
-        per_partition_sampling = [
-            c.expects_per_partition_sampling() for c in self._combiners
-        ]
-        if min(per_partition_sampling) != max(per_partition_sampling):
-            raise ValueError(
-                "All custom combiners must return the same value from "
-                "expects_per_partition_sampling()")
-        return self._combiners[0].expects_per_partition_sampling()
+        return any(c.expects_per_partition_sampling() for c in self._combiners)
 
 
 class VectorSumCombiner(Combiner):

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -127,6 +127,20 @@ class CustomCombiner(Combiner, abc.ABC):
         """
         return self.__class__.__name__
 
+    def expects_per_partition_sampling(self) -> bool:
+        """Whether this combiner expects sampled data per partition.
+
+        If this method returns True, the framework samples data per partition
+        up to aggregate_params.max_contributions_per_partition elements before
+        calling self.create_accumulator(). Otherwise all elements per
+        (privacy_id, partition_key) are passed to create_accumulator() and it
+        is fully the responsibility of the combiner to bound sensitivity.
+
+        Warning: This method is expected to return value the same value for all
+        instances of the same class.
+        """
+        return True
+
 
 class CombinerParams:
     """Parameters for a combiner.

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -320,6 +320,9 @@ class PrivacyIdCountCombiner(Combiner, AdditiveMechanismMixin):
     def sensitivities(self) -> dp_computations.Sensitivities:
         return self._sensitivities
 
+    def expects_per_partition_sampling(self) -> bool:
+        return False
+
 
 class SumCombiner(Combiner, AdditiveMechanismMixin):
     """Combiner for computing dp sum.

--- a/pipeline_dp/contribution_bounders.py
+++ b/pipeline_dp/contribution_bounders.py
@@ -174,7 +174,8 @@ class SamplingCrossPartitionContributionBounder(ContributionBounder):
         # Bound cross partition contributions with sampling.
         sample = sampling_utils.choose_from_list_without_replacement
         sample_size = params.max_partitions_contributed
-        col = backend.map_values(col, lambda a: sample(a, sample_size))
+        col = backend.map_values(col, lambda a: sample(a, sample_size),
+                                 "Sample")
 
         # (privacy_id, [partition_key, [value]])
 

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -120,7 +120,8 @@ class DPEngine:
             self._add_report_stage(
                 f"Public partition selection: dropped non public partitions")
         if not params.contribution_bounds_already_enforced:
-            contribution_bounder = self._create_contribution_bounder(params)
+            contribution_bounder = self._create_contribution_bounder(
+                params, combiner.expects_per_partition_sampling())
             col = contribution_bounder.bound_contributions(
                 col, params, self._backend, self._current_report_generator,
                 combiner.create_accumulator)
@@ -364,13 +365,17 @@ class DPEngine:
                                                   self._budget_accountant)
 
     def _create_contribution_bounder(
-        self, params: pipeline_dp.AggregateParams
+        self, params: pipeline_dp.AggregateParams,
+        expects_per_partition_sampling: bool
     ) -> contribution_bounders.ContributionBounder:
         """Creates ContributionBounder based on aggregation parameters."""
         if params.max_contributions:
             return \
                 contribution_bounders.SamplingPerPrivacyIdContributionBounder(
                 )
+        elif expects_per_partition_sampling:
+            return contribution_bounders.SamplingCrossPartitionContributionBounder(
+            )
         else:
             return \
                 contribution_bounders.SamplingCrossAndPerPartitionContributionBounder(

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -373,13 +373,10 @@ class DPEngine:
             return \
                 contribution_bounders.SamplingPerPrivacyIdContributionBounder(
                 )
-        elif expects_per_partition_sampling:
-            return contribution_bounders.SamplingCrossPartitionContributionBounder(
+        if expects_per_partition_sampling:
+            contribution_bounders.SamplingCrossAndPerPartitionContributionBounder(
             )
-        else:
-            return \
-                contribution_bounders.SamplingCrossAndPerPartitionContributionBounder(
-                )
+        return contribution_bounders.SamplingCrossPartitionContributionBounder()
 
     def _extract_columns(self, col,
                          data_extractors: pipeline_dp.DataExtractors):

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -377,7 +377,7 @@ class DPEngine:
                 contribution_bounders.SamplingPerPrivacyIdContributionBounder(
                 )
         if expects_per_partition_sampling:
-            contribution_bounders.SamplingCrossAndPerPartitionContributionBounder(
+            return contribution_bounders.SamplingCrossAndPerPartitionContributionBounder(
             )
         return contribution_bounders.SamplingCrossPartitionContributionBounder()
 

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -509,37 +509,50 @@ class DpEngineTest(parameterized.TestCase):
     @patch(
         'pipeline_dp.contribution_bounders'
         '.SamplingCrossAndPerPartitionContributionBounder.bound_contributions')
-    def test_aggregate_computation_graph(self, mock_bound_contributions):
+    def test_aggregate_computation_graph_per_contribution_bounding(
+            self, mock_bound_contributions):
         # Arrange
-        aggregate_params = pipeline_dp.AggregateParams(
-            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
-            metrics=[agg.Metrics.COUNT],
-            max_partitions_contributed=5,
-            max_contributions_per_partition=3)
-        budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
-                                                  total_delta=1e-10)
+        aggregate_params, _ = self._create_params_default()
+        aggregate_params.metrics = [pipeline_dp.Metrics.COUNT]
 
-        col = [[1], [2], [3], [3]]
-        data_extractor = pipeline_dp.DataExtractors(
-            privacy_id_extractor=lambda x: f"pid{x}",
-            partition_extractor=lambda x: f"pk{x}",
-            value_extractor=lambda x: x)
+        engine = self._create_dp_engine_default()
+        mock_bound_contributions.return_value = []
 
-        mock_bound_contributions.return_value = [
-            [("pid1", "pk1"), (1, [1])],
-            [("pid2", "pk2"), (1, [1])],
-            [("pid3", "pk3"), (1, [2])],
-        ]
-
-        backend = pipeline_dp.LocalBackend()
-        engine = pipeline_dp.DPEngine(budget_accountant, backend)
-        engine.aggregate(col=col,
+        engine.aggregate(col=[0],
                          params=aggregate_params,
-                         data_extractors=data_extractor)
+                         data_extractors=self._get_default_extractors())
 
         # Assert
         mock_bound_contributions.assert_called_with(unittest.mock.ANY,
-                                                    aggregate_params, backend,
+                                                    aggregate_params,
+                                                    unittest.mock.ANY,
+                                                    unittest.mock.ANY,
+                                                    unittest.mock.ANY)
+
+    @patch('pipeline_dp.contribution_bounders'
+           '.SamplingCrossPartitionContributionBounder.bound_contributions')
+    def test_aggregate_computation_graph_per_partition_bounding(
+            self, mock_bound_contributions):
+        # Arrange
+        aggregate_params = pipeline_dp.AggregateParams(
+            noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
+            metrics=[pipeline_dp.Metrics.SUM],
+            min_sum_per_partition=0,
+            max_sum_per_partition=1,
+            max_partitions_contributed=1,
+            max_contributions_per_partition=1)
+
+        engine = self._create_dp_engine_default()
+        mock_bound_contributions.return_value = []
+
+        engine.aggregate(col=[0],
+                         params=aggregate_params,
+                         data_extractors=self._get_default_extractors())
+
+        # Assert
+        mock_bound_contributions.assert_called_with(unittest.mock.ANY,
+                                                    aggregate_params,
+                                                    unittest.mock.ANY,
                                                     unittest.mock.ANY,
                                                     unittest.mock.ANY)
 


### PR DESCRIPTION
This PR introduces `combiner.expects_per_partition_sampling()` method.

If at least one combiner returns true from `expects_per_partition_sampling()`, sampling per partition is performed. Sampling in partition is required for `Mean/Variance/Quantiles`. On other hand, when SUM is computed with `min/max_sum_per_partition` contribution bounding, there should be no sampling, since SumCombiner at first sums per partition contributions and clips to `min/max_sum_per_partition`.