### PR TITLE
Add logic for finding `max_sum_per_partition` candidates

### DIFF
--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -32,9 +32,7 @@ def _sum_metrics_to_data_dropped(
     # 1. linf/l0 contribution bounding
     # Contribution bounding errors are negative, negate to keep data dropped
     # to be positive.
-    linf_dropped = -sum_metrics.clipping_to_max_error
-    if dp_metric == pipeline_dp.Metrics.SUM:
-        linf_dropped += sum_metrics.clipping_to_min_error
+    linf_dropped = sum_metrics.clipping_to_min_error - sum_metrics.clipping_to_max_error
     l0_dropped = -sum_metrics.expected_l0_bounding_error
 
     # 2. Partition selection (in case of private partition selection).

--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -25,8 +25,6 @@ def _sum_metrics_to_data_dropped(
         sum_metrics: metrics.SumMetrics, partition_keep_probability: float,
         dp_metric: pipeline_dp.Metric) -> metrics.DataDropInfo:
     """Finds Data drop information from per-partition metrics."""
-    # TODO(dvadym): implement for Sum
-    assert dp_metric != pipeline_dp.Metrics.SUM, "Cross-partition metrics are not implemented for SUM"
 
     # This function attributed the data that is dropped, to different reasons
     # how they are dropped.
@@ -34,7 +32,9 @@ def _sum_metrics_to_data_dropped(
     # 1. linf/l0 contribution bounding
     # Contribution bounding errors are negative, negate to keep data dropped
     # to be positive.
-    linf_dropped = -sum_metrics.clipping_to_max_error  # not correct for SUM
+    linf_dropped = -sum_metrics.clipping_to_max_error
+    if dp_metric == pipeline_dp.Metrics.SUM:
+        linf_dropped += sum_metrics.clipping_to_min_error
     l0_dropped = -sum_metrics.expected_l0_bounding_error
 
     # 2. Partition selection (in case of private partition selection).

--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -246,7 +246,7 @@ def _find_candidates_bins_max_values_subsample(
     ids = np.round(np.linspace(0, len(histogram.bins) - 1,
                                num=max_candidates)).astype(int)
     bin_maximums = np.fromiter(map(lambda bin: bin.max, histogram.bins),
-                               dtype=np.float)
+                               dtype=float)
     return bin_maximums[ids].tolist()
 
 

--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -401,7 +401,8 @@ def _check_tune_args(options: TuneOptions, is_public_partitions: bool):
             )
 
     if options.parameters_to_tune.min_sum_per_partition:
-        raise ValueError("Tuning of min_sum_per_partition is not supported yet")
+        raise ValueError(
+            "Tuning of min_sum_per_partition is not supported yet.")
 
     if options.function_to_minimize != MinimizingFunction.ABSOLUTE_ERROR:
         raise NotImplementedError(

--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -142,7 +142,8 @@ def _find_candidate_parameters(
     if calculate_l0_param and calculate_linf_param:
         l0_bounds, linf_bounds = _find_candidates_parameters_in_2d_grid(
             hist.l0_contributions_histogram, hist.linf_contributions_histogram,
-            _find_candidates_constant_relative_step, _find_candidates_constant_relative_step, max_candidates)
+            _find_candidates_constant_relative_step,
+            _find_candidates_constant_relative_step, max_candidates)
     elif calculate_l0_param and calculate_sum_per_partition_param:
         l0_bounds, max_sum_per_partition_bounds = _find_candidates_parameters_in_2d_grid(
             hist.l0_contributions_histogram,

--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import math
 from numbers import Number
 
@@ -116,7 +117,7 @@ def _find_candidate_parameters(
         parameters_to_tune: ParametersToTune,
         metric: Optional[pipeline_dp.Metric],
         max_candidates: int) -> analysis.MultiParameterConfiguration:
-    """Finds candidates for l0 and/or l_inf parameters.
+    """Finds candidates for l0, l_inf and max_sum_per_partition_bounds parameters.
 
     Args:
         hist: dataset contribution histogram.
@@ -128,10 +129,10 @@ def _find_candidate_parameters(
           heuristically chosen value, better to adjust it for your use-case.
     """
     calculate_l0_param = parameters_to_tune.max_partitions_contributed
-    generate_linf = metric == pipeline_dp.Metrics.COUNT
+    generate_linf_count = metric == pipeline_dp.Metrics.COUNT
     generate_max_sum_per_partition = metric == pipeline_dp.Metrics.SUM
-    calculate_linf_param = (parameters_to_tune.max_contributions_per_partition
-                            and generate_linf)
+    calculate_linf_count = (parameters_to_tune.max_contributions_per_partition
+                            and generate_linf_count)
     calculate_sum_per_partition_param = (
         parameters_to_tune.max_sum_per_partition and
         generate_max_sum_per_partition)
@@ -139,11 +140,12 @@ def _find_candidate_parameters(
     max_sum_per_partition_bounds = min_sum_per_partition_bounds = None
 
     if calculate_sum_per_partition_param:
-        assert not parameters_to_tune.min_sum_per_partition, "Tuning of min_sum_per_partition is not supported yet"
-        assert hist.linf_sum_contributions_histogram.bins[
-            0].lower >= 0, "max_sum_per_partition should not contain negative sums because min_sum_per_partition tuning is not supported yet and therefore tuning for max_sum_per_partition works only when linf_sum_contributions_histogram does not negative sums"
+        if hist.linf_sum_contributions_histogram.bins[0].lower >= 0:
+            logging.warning(
+                "max_sum_per_partition should not contain negative sums because min_sum_per_partition tuning is not supported yet and therefore tuning for max_sum_per_partition works only when linf_sum_contributions_histogram does not negative sums"
+            )
 
-    if calculate_l0_param and calculate_linf_param:
+    if calculate_l0_param and calculate_linf_count:
         l0_bounds, linf_bounds = _find_candidates_parameters_in_2d_grid(
             hist.l0_contributions_histogram, hist.linf_contributions_histogram,
             _find_candidates_constant_relative_step,
@@ -158,7 +160,7 @@ def _find_candidate_parameters(
     elif calculate_l0_param:
         l0_bounds = _find_candidates_constant_relative_step(
             hist.l0_contributions_histogram, max_candidates)
-    elif calculate_linf_param:
+    elif calculate_linf_count:
         linf_bounds = _find_candidates_constant_relative_step(
             hist.linf_contributions_histogram, max_candidates)
     elif calculate_sum_per_partition_param:
@@ -180,7 +182,29 @@ def _find_candidates_parameters_in_2d_grid(
         find_candidates_func1: Callable[[histograms.Histogram, int],
                                         Sequence[Number]],
         find_candidates_func2: Callable[[histograms.Histogram, int],
-                                        Sequence[Number]], max_candidates: int):
+                                        Sequence[Number]],
+        max_candidates: int) -> Tuple[Sequence[Number], Sequence[Number]]:
+    """Finds candidates for 2 parameters.
+
+    If we have 2 parameters to tune, then candidates for them form a 2
+    dimensional grid. If for one parameter there is less than
+    sqrt(max_candidates) candidates, we can add more candidates for the other
+    parameter. This function implements this logic.
+
+    Args:
+        hist1: histogram of the distribution of the first parameter.
+        hist2: histogram of the distribution of the second parameter.
+        find_candidates_func1: function that given hist1 and maximum of
+          candidates finds the candidates.
+        find_candidates_func2: function that given hist2 and maximum of
+          candidates finds the candidates.
+        max_candidates: maximum number of the candidates to produce.
+    Returns:
+        Two sequences which represent pairs of candidates for parameters 1 and
+          2. Sequences are of the same length and their lengths do not exceed
+          max_candidates.
+    """
+
     max_candidates_per_parameter = int(math.sqrt(max_candidates))
     param1_candidates = find_candidates_func1(hist1,
                                               max_candidates_per_parameter)
@@ -240,8 +264,7 @@ def _find_candidates_constant_relative_step(histogram: histograms.Histogram,
 
 def _find_candidates_bins_max_values_subsample(
         histogram: histograms.Histogram, max_candidates: int) -> List[float]:
-    """Takes max values of histogram bins with constant step between each other.
-    """
+    """Takes max values of histogram bins with constant step between each other."""
     max_candidates = min(max_candidates, len(histogram.bins))
     ids = np.round(np.linspace(0, len(histogram.bins) - 1,
                                num=max_candidates)).astype(int)
@@ -376,6 +399,9 @@ def _check_tune_args(options: TuneOptions, is_public_partitions: bool):
             raise ValueError(
                 f"Tuning is supported only for Count, Privacy id count and Sum, but {metrics[0]} given."
             )
+
+    if options.parameters_to_tune.min_sum_per_partition:
+        raise ValueError("Tuning of min_sum_per_partition is not supported yet")
 
     if options.function_to_minimize != MinimizingFunction.ABSOLUTE_ERROR:
         raise NotImplementedError(

--- a/analysis/tests/cross_partition_combiners_test.py
+++ b/analysis/tests/cross_partition_combiners_test.py
@@ -108,10 +108,14 @@ class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
         per_partition_utility = metrics.PerPartitionMetrics(
             partition_selection_probability_to_keep=0.2,
             raw_statistics=metrics.RawStatistics(privacy_id_count=10, count=15),
-            metric_errors=[_get_sum_metrics(),
-                           _get_sum_metrics()])
+            metric_errors=[
+                _get_sum_metrics(),
+                _get_sum_metrics(),
+                _get_sum_metrics()
+            ])
         dp_metrics = [
-            pipeline_dp.Metrics.PRIVACY_ID_COUNT, pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.SUM
+            pipeline_dp.Metrics.PRIVACY_ID_COUNT, pipeline_dp.Metrics.COUNT,
+            pipeline_dp.Metrics.SUM
         ]
         cross_partition_combiners._per_partition_to_utility_report(
             per_partition_utility,

--- a/analysis/tests/parameter_tuning_test.py
+++ b/analysis/tests/parameter_tuning_test.py
@@ -24,25 +24,36 @@ from analysis import metrics
 from analysis import parameter_tuning
 from pipeline_dp.dataset_histograms import histograms
 from pipeline_dp.dataset_histograms import computing_histograms
+from pipeline_dp.dataset_histograms.histograms import FrequencyBin
 
 
-def _get_aggregate_params():
-    # Limit contributions to 1 per partition, contribution error will be half of the count.
+def _get_aggregate_params(metrics: List[pipeline_dp.Metric]):
     return pipeline_dp.AggregateParams(
         noise_kind=pipeline_dp.NoiseKind.GAUSSIAN,
-        metrics=[pipeline_dp.Metrics.COUNT],
-        max_partitions_contributed=1,
-        max_contributions_per_partition=1)
+        metrics=metrics,
+        max_partitions_contributed=1,  # does not matter
+        max_contributions_per_partition=1,  # does not matter
+        min_value=0,  # does not matter
+        max_value=1)  # does not matter
 
 
-def _get_tune_options():
+def _get_tune_options(
+    metrics: List[pipeline_dp.Metric],
+    parameters_to_tune: parameter_tuning.ParametersToTune = parameter_tuning.
+    ParametersToTune(max_partitions_contributed=True,
+                     max_contributions_per_partition=True)
+) -> parameter_tuning.TuneOptions:
     return parameter_tuning.TuneOptions(
         epsilon=1,
         delta=1e-10,
-        aggregate_params=_get_aggregate_params(),
+        aggregate_params=_get_aggregate_params(metrics),
         function_to_minimize=parameter_tuning.MinimizingFunction.ABSOLUTE_ERROR,
-        parameters_to_tune=parameter_tuning.ParametersToTune(True, True),
+        parameters_to_tune=parameters_to_tune,
         number_of_parameter_candidates=3)
+
+
+def _frequency_bin(max_value: float = 0.0, lower: float = 0.0) -> FrequencyBin:
+    return FrequencyBin(max=max_value, lower=lower, count=None, sum=None)
 
 
 class ParameterTuning(parameterized.TestCase):
@@ -156,8 +167,8 @@ class ParameterTuning(parameterized.TestCase):
             max_candidates=5,
             # ceil(1000^(i / 4)), where i in [0, 1, 2, 3, 4]
             expected_candidates=[1, 6, 32, 178, 1000]))
-    def test_find_candidate_parameters(self, max_value, max_candidates,
-                                       expected_candidates):
+    def test_find_candidate_parameters_count(self, max_value, max_candidates,
+                                             expected_candidates):
         mock_l0_histogram = histograms.Histogram(None, None)
         mock_l0_histogram.max_value = mock.Mock(return_value=max_value)
 
@@ -177,6 +188,137 @@ class ParameterTuning(parameterized.TestCase):
                          candidates.max_partitions_contributed)
 
     @parameterized.named_parameters(
+        dict(testcase_name='bin_max_values=[1], returns [1]',
+             bins=[_frequency_bin(max_value=1)],
+             max_candidates=1000,
+             expected_candidates=[1]),
+        dict(testcase_name='max_candidates=1, returns max value of the first'
+             ' bin',
+             bins=[
+                 _frequency_bin(max_value=0.1),
+                 _frequency_bin(max_value=0.2),
+                 _frequency_bin(max_value=0.3)
+             ],
+             max_candidates=1,
+             expected_candidates=[0.1]),
+        dict(testcase_name='max_candidates=2, returns max values of the first'
+             ' and last bin',
+             bins=[
+                 _frequency_bin(max_value=0.1),
+                 _frequency_bin(max_value=0.2),
+                 _frequency_bin(max_value=0.3)
+             ],
+             max_candidates=2,
+             expected_candidates=[0.1, 0.3]),
+        dict(testcase_name='max_candidates is equal to number of bins, returns'
+             ' all bin max values as candidates',
+             bins=[
+                 _frequency_bin(max_value=0.1),
+                 _frequency_bin(max_value=0.2),
+                 _frequency_bin(max_value=0.3)
+             ],
+             max_candidates=3,
+             expected_candidates=[0.1, 0.2, 0.3]),
+        dict(testcase_name='max_candidates is larger than number of bins,'
+             ' returns all bin max values as candidates',
+             bins=[
+                 _frequency_bin(max_value=0.1),
+                 _frequency_bin(max_value=0.2),
+                 _frequency_bin(max_value=0.3)
+             ],
+             max_candidates=100,
+             expected_candidates=[0.1, 0.2, 0.3]),
+        dict(
+            testcase_name='max_candidates is smaller than number of bins,'
+            ' returns uniformly distributed subsample of bin'
+            ' max values',
+            bins=[_frequency_bin(max_value=i) for i in range(10)],
+            max_candidates=5,
+            # Takes each bin with step ((10 - 1) / (5 - 1) = 1.8), i.e.
+            # [0, 2.25, 4.5, 6.75, 9], then rounds it, i.e. we get
+            # [0, 2, 4, 7, 9] indices of bins to take, they equal to max
+            # values of these bins
+            expected_candidates=[0, 2, 4, 7, 9]),
+    )
+    def test_find_candidate_parameters_sum(self, bins, max_candidates,
+                                           expected_candidates):
+        mock_linf_sum_contributions_histogram = histograms.Histogram(None, bins)
+        mock_histograms = histograms.DatasetHistograms(
+            None, None, None, mock_linf_sum_contributions_histogram, None, None)
+        parameters_to_tune = parameter_tuning.ParametersToTune(
+            max_partitions_contributed=False,
+            min_sum_per_partition=False,
+            max_sum_per_partition=True)
+
+        candidates = parameter_tuning._find_candidate_parameters(
+            mock_histograms,
+            parameters_to_tune,
+            pipeline_dp.Metrics.SUM,
+            max_candidates=max_candidates)
+
+        self.assertEqual(expected_candidates, candidates.max_sum_per_partition)
+        self.assertEqual([0] * len(expected_candidates),
+                         candidates.min_sum_per_partition)
+
+    def test_find_candidate_parameters_min_sum_per_partition_is_not_supported(
+            self):
+        parameters_to_tune = parameter_tuning.ParametersToTune(
+            min_sum_per_partition=True, max_sum_per_partition=True)
+
+        with self.assertRaisesRegex(
+                AssertionError,
+                "Tuning of min_sum_per_partition is not supported yet"):
+            parameter_tuning._find_candidate_parameters(
+                hist=None,
+                parameters_to_tune=parameters_to_tune,
+                metric=pipeline_dp.Metrics.SUM,
+                max_candidates=0)
+
+    def test_find_candidate_parameters_sums_has_to_be_non_negative(self):
+        mock_linf_sum_contributions_histogram = histograms.Histogram(
+            None, [_frequency_bin(lower=-1.0)])
+        mock_histograms = histograms.DatasetHistograms(
+            None, None, None, mock_linf_sum_contributions_histogram, None, None)
+        parameters_to_tune = parameter_tuning.ParametersToTune(
+            min_sum_per_partition=False, max_sum_per_partition=True)
+
+        with self.assertRaisesRegex(
+                AssertionError,
+                "max_sum_per_partition should not contain negative sums"):
+            parameter_tuning._find_candidate_parameters(
+                hist=mock_histograms,
+                parameters_to_tune=parameters_to_tune,
+                metric=pipeline_dp.Metrics.SUM,
+                max_candidates=0)
+
+    def test_find_candidate_parameters_both_l0_and_linf_sum_to_be_tuned(self):
+        mock_l0_histogram = histograms.Histogram(None, None)
+        mock_l0_histogram.max_value = mock.Mock(return_value=6)
+        mock_linf_sum_contributions_histogram = histograms.Histogram(
+            None, [
+                _frequency_bin(max_value=1),
+                _frequency_bin(max_value=2),
+                _frequency_bin(max_value=3)
+            ])
+
+        mock_histograms = histograms.DatasetHistograms(
+            mock_l0_histogram, None, None,
+            mock_linf_sum_contributions_histogram, None, None)
+        parameters_to_tune = parameter_tuning.ParametersToTune(
+            max_partitions_contributed=True,
+            min_sum_per_partition=False,
+            max_sum_per_partition=True)
+
+        candidates = parameter_tuning._find_candidate_parameters(
+            mock_histograms,
+            parameters_to_tune,
+            pipeline_dp.Metrics.SUM,
+            max_candidates=5)
+        self.assertEqual([1, 1, 6, 6], candidates.max_partitions_contributed)
+        self.assertEqual([1, 3, 1, 3], candidates.max_sum_per_partition)
+        self.assertEqual([0, 0, 0, 0], candidates.min_sum_per_partition)
+
+    @parameterized.named_parameters(
         dict(
             testcase_name='COUNT',
             metric=pipeline_dp.Metrics.COUNT,
@@ -185,6 +327,11 @@ class ParameterTuning(parameterized.TestCase):
         dict(
             testcase_name='PRIVACY_ID_COUNT',
             metric=pipeline_dp.Metrics.PRIVACY_ID_COUNT,
+            expected_generate_linf=False,
+        ),
+        dict(
+            testcase_name='SUM',
+            metric=pipeline_dp.Metrics.SUM,
             expected_generate_linf=False,
         ),
         dict(
@@ -241,7 +388,11 @@ class ParameterTuning(parameterized.TestCase):
             computing_histograms.compute_dataset_histograms(
                 input, data_extractors, pipeline_dp.LocalBackend()))[0]
 
-        tune_options = _get_tune_options()
+        tune_options = _get_tune_options(
+            [pipeline_dp.Metrics.COUNT],
+            parameter_tuning.ParametersToTune(
+                max_partitions_contributed=True,
+                max_contributions_per_partition=True))
 
         # Act.
         result = parameter_tuning.tune(input, pipeline_dp.LocalBackend(),
@@ -265,6 +416,48 @@ class ParameterTuning(parameterized.TestCase):
         self.assertEqual(utility_reports[0].metric_errors[0].metric,
                          pipeline_dp.Metrics.COUNT)
 
+    def test_tune_sum(self):
+        # Arrange.
+        # Generate dataset, with 10 privacy units, each of them contribute to
+        # the same partition with value equal to its id.
+        input = [(i, f"pk0", i) for i in range(10)]
+        public_partitions = [f"pk{i}" for i in range(10)]
+        data_extractors = pipeline_dp.DataExtractors(
+            privacy_id_extractor=lambda x: x[0],
+            partition_extractor=lambda x: x[1],
+            value_extractor=lambda x: x[2])
+
+        contribution_histograms = list(
+            computing_histograms.compute_dataset_histograms(
+                input, data_extractors, pipeline_dp.LocalBackend()))[0]
+
+        tune_options = _get_tune_options([pipeline_dp.Metrics.SUM],
+                                         parameter_tuning.ParametersToTune(
+                                             max_partitions_contributed=True,
+                                             max_sum_per_partition=True))
+
+        # Act.
+        result = parameter_tuning.tune(input, pipeline_dp.LocalBackend(),
+                                       contribution_histograms, tune_options,
+                                       data_extractors, public_partitions)
+
+        # Assert.
+        tune_result, per_partition_utility_analysis = result
+        per_partition_utility_analysis = list(per_partition_utility_analysis)
+        self.assertLen(per_partition_utility_analysis, 10)
+
+        tune_result = list(tune_result)[0]
+
+        self.assertEqual(tune_options, tune_result.options)
+        self.assertEqual(contribution_histograms,
+                         tune_result.contribution_histograms)
+        utility_reports = tune_result.utility_reports
+        self.assertLen(utility_reports, 1)
+        self.assertIsInstance(utility_reports[0], metrics.UtilityReport)
+        self.assertLen(utility_reports[0].metric_errors, 1)
+        self.assertEqual(utility_reports[0].metric_errors[0].metric,
+                         pipeline_dp.Metrics.SUM)
+
     def test_select_partitions(self):
         # Arrange.
         # Generate dataset, with 10 privacy units, 5 of them contribute to
@@ -279,9 +472,7 @@ class ParameterTuning(parameterized.TestCase):
             computing_histograms.compute_dataset_histograms(
                 input, data_extractors, pipeline_dp.LocalBackend()))[0]
 
-        tune_options = _get_tune_options()
-        # Setting metrics to empty list makes running only partition selectoin.
-        tune_options.aggregate_params.metrics = []
+        tune_options = _get_tune_options(metrics=[])
 
         # Act.
         result = parameter_tuning.tune(input, pipeline_dp.LocalBackend(),
@@ -320,10 +511,9 @@ class ParameterTuning(parameterized.TestCase):
             computing_histograms.compute_dataset_histograms(
                 input, data_extractors, pipeline_dp.LocalBackend()))[0]
 
-        tune_options = _get_tune_options()
-        tune_options.aggregate_params.metrics = [
-            pipeline_dp.Metrics.PRIVACY_ID_COUNT
-        ]
+        tune_options = _get_tune_options(
+            [pipeline_dp.Metrics.PRIVACY_ID_COUNT],
+            parameter_tuning.ParametersToTune(max_partitions_contributed=True))
 
         # Act.
         result, _ = parameter_tuning.tune(input, pipeline_dp.LocalBackend(),
@@ -354,17 +544,16 @@ class ParameterTuning(parameterized.TestCase):
                  pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.PRIVACY_ID_COUNT
              ],
              is_public_partitions=True),
-        dict(
-            testcase_name="Mean is not supported",
-            error_msg="Tuning is supported only for Count and Privacy id count",
-            metrics=[pipeline_dp.Metrics.MEAN],
-            is_public_partitions=False),
+        dict(testcase_name="Mean is not supported",
+             error_msg=
+             "Tuning is supported only for Count, Privacy id count and Sum",
+             metrics=[pipeline_dp.Metrics.MEAN],
+             is_public_partitions=False),
     )
     def test_tune_params_validation(self, error_msg,
                                     metrics: List[pipeline_dp.Metric],
                                     is_public_partitions: bool):
-        tune_options = _get_tune_options()
-        tune_options.aggregate_params.metrics = metrics
+        tune_options = _get_tune_options(metrics)
         contribution_histograms = histograms.DatasetHistograms(
             None, None, None, None, None, None)
         data_extractors = pipeline_dp.DataExtractors(


### PR DESCRIPTION
Uses `linf_sum_contributions_histogram` to compute that, candidates are taken as max values of bins, bins are sampled uniformly.

min_sum_per_partition is not implemented and is always zero.

utility analysis for sum was not implemented, this PR also adds support for it modifying `_sum_metrics_to_data_dropped` method.