### PR TITLE
Remove not needed validation on privacy_id_extractor

### DIFF
--- a/examples/movie_view_ratings/run_all_frameworks.py
+++ b/examples/movie_view_ratings/run_all_frameworks.py
@@ -103,8 +103,7 @@ def calc_dp_rating_metrics(movie_views, backend, public_partitions):
     # element of movie view collection.
     data_extractors = pipeline_dp.DataExtractors(
         partition_extractor=lambda mv: mv.movie_id,
-        privacy_id_extractor=(lambda mv: mv.user_id)
-        if not FLAGS.contribution_bounds_already_enforced else None,
+        privacy_id_extractor=lambda mv: mv.user_id,
         value_extractor=value_extractor)
 
     # Run aggregation.

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -420,10 +420,6 @@ class DPEngine:
         if check_data_extractors:
             _check_data_extractors(data_extractors)
         if params.contribution_bounds_already_enforced:
-            if data_extractors.privacy_id_extractor:
-                raise ValueError(
-                    "privacy_id_extractor should be set iff "
-                    "contribution_bounds_already_enforced is False")
             if pipeline_dp.Metrics.PRIVACY_ID_COUNT in params.metrics:
                 raise ValueError(
                     "PRIVACY_ID_COUNT cannot be computed when "


### PR DESCRIPTION
When `contribution_bounds_already_enforced = True` then PipelineDP does no contribution bounding. As a privacy id is not needed. The current validation requires `privacy_id_extractor` to be None, but there is no problem if privacy id extractor is set up. But it's pretty confusing for users why `privacy_id_extractor` has to be `None`. Let's drop this validation for simplicity