### PR TITLE
Implement mean in DataFrame API

### DIFF
--- a/examples/restaurant_visits/run_on_dataframes.py
+++ b/examples/restaurant_visits/run_on_dataframes.py
@@ -78,7 +78,10 @@ def compute_private_result(
                                      max_contributions_per_group=1).count().sum(
                                          'spent_money',
                                          min_value=0,
-                                         max_value=100).build_query()
+                                         max_value=100).mean(
+                                             'spent_money',
+                                             min_value=0,
+                                             max_value=100).build_query()
     result_df = query.run_query(dataframes.Budget(epsilon=1, delta=1e-10),
                                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
     return result_df

--- a/examples/restaurant_visits/run_on_dataframes.py
+++ b/examples/restaurant_visits/run_on_dataframes.py
@@ -73,15 +73,12 @@ def compute_private_result(
     df: Union[pd.DataFrame, BeamDataFrame, SparkDataFrame]
 ) -> Union[pd.DataFrame, BeamDataFrame, SparkDataFrame]:
     dp_query_builder = dataframes.QueryBuilder(df, 'visitor_id')
-    query = dp_query_builder.groupby('day',
-                                     max_groups_contributed=3,
-                                     max_contributions_per_group=1).count().sum(
-                                         'spent_money',
-                                         min_value=0,
-                                         max_value=100).mean(
-                                             'spent_money',
-                                             min_value=0,
-                                             max_value=100).build_query()
+    query = dp_query_builder\
+      .groupby('day', max_groups_contributed=3, max_contributions_per_group=1)\
+      .count()\
+      .sum('spent_money', min_value=0, max_value=100)\
+      .mean('spent_money')\
+      .build_query()
     result_df = query.run_query(dataframes.Budget(epsilon=1, delta=1e-10),
                                 noise_kind=pipeline_dp.NoiseKind.GAUSSIAN)
     return result_df

--- a/pipeline_dp/dataframes.py
+++ b/pipeline_dp/dataframes.py
@@ -374,7 +374,7 @@ class QueryBuilder:
         # Validation.
         if not self._aggregations_specs:
             raise ValueError(
-                "No aggregations in the query. Call for example count")
+                "No aggregations in the query. Call count, sum, mean etc")
         # 1. Not more than 1 value column
         input_columns = [
             spec.input_column
@@ -383,10 +383,10 @@ class QueryBuilder:
         ]
         if len(set(input_columns)) > 1:
             raise NotImplementedError(
-                f"Aggregation of only 1 column is supported, but {input_columns} given"
+                f"Aggregation of only one column is supported, but {input_columns} given"
             )
         input_column = input_columns[0] if input_columns else None
-        # 2. Each metric only once
+        # 2. Each metric was added only once
         metrics = [spec.metric for spec in self._aggregations_specs]
         if len(set(metrics)) != len(metrics):
             raise ValueError("Each aggregation can be added only once.")
@@ -435,7 +435,7 @@ class QueryBuilder:
             if spec.max_value is not None
         ]
         if not min_values or not max_values:
-            raise ValueError("min_value and max_value should be given at least "
+            raise ValueError("min_value and max_value must be given at least "
                              "once as arguments of sum or mean")
 
         def all_values_equal(a: list) -> bool:

--- a/pipeline_dp/dataframes.py
+++ b/pipeline_dp/dataframes.py
@@ -376,16 +376,16 @@ class QueryBuilder:
             raise ValueError(
                 "No aggregations in the query. Call for example count")
         # 1. Not more than 1 value column
-        value_columns = [
+        input_columns = [
             spec.input_column
             for spec in self._aggregations_specs
             if spec.input_column is not None
         ]
-        if len(set(value_columns)) > 1:
+        if len(set(input_columns)) > 1:
             raise NotImplementedError(
-                f"Aggregation of only 1 column is supported, but {value_columns} given"
+                f"Aggregation of only 1 column is supported, but {input_columns} given"
             )
-        value_column = value_columns[0] if value_columns else None
+        input_column = input_columns[0] if input_columns else None
         # 2. Each metric only once
         metrics = [spec.metric for spec in self._aggregations_specs]
         if len(set(metrics)) != len(metrics):
@@ -406,7 +406,7 @@ class QueryBuilder:
 
         return Query(self._df,
                      Columns(self._privacy_unit_column, self._by,
-                             value_column), metric_to_output_column,
+                             input_column), metric_to_output_column,
                      contribution_bounds, self._public_keys)
 
     def _add_aggregation(self,
@@ -417,7 +417,7 @@ class QueryBuilder:
         self._aggregations_specs.append(aggregation_spec)
         return self
 
-    def _get_value_caps(self) -> Tuple[float, float]:
+    def _get_value_caps(self) -> Tuple[Optional[float], Optional[float]]:
         metrics = set([spec.metric for spec in self._aggregations_specs])
         # COUNT, PPRIVACY_ID_COUNT do not require caps.
         metrics_which_need_caps = metrics.difference(

--- a/tests/dataframes_test.py
+++ b/tests/dataframes_test.py
@@ -28,7 +28,8 @@ def get_pandas_df() -> pd.DataFrame:
     return pd.DataFrame({
         "privacy_key": [0, 1, 1],
         "group_key": ["key1", "key2", "key1"],
-        "value": [5.0, 2.5, -2]
+        "value": [5.0, 2.5, -2],
+        "value2": [1.0, -2.0, 4]
     })
 
 
@@ -73,6 +74,59 @@ class QueryBuilderTest(parameterized.TestCase):
             builder.groupby("group_key",
                             max_groups_contributed=1,
                             max_contributions_per_group=1)
+
+    def test_no_aggregations(self):
+        builder = dataframes.QueryBuilder(get_pandas_df(), "privacy_key")
+        builder.groupby("group_key",
+                        max_groups_contributed=1,
+                        max_contributions_per_group=1)
+        with self.assertRaisesRegex(ValueError, "No aggregations in the query"):
+            builder.build_query()
+
+    def test_only_one_column_is_supported(self):
+        builder = dataframes.QueryBuilder(get_pandas_df(), "privacy_key")
+        builder.groupby("group_key",
+                        max_groups_contributed=1,
+                        max_contributions_per_group=1)
+        builder.sum("value").sum("value2")
+        with self.assertRaisesRegex(
+                NotImplementedError,
+                "Aggregation of only one column is supported"):
+            builder.build_query()
+
+    def test_same_metrics_added_twice(self):
+        builder = dataframes.QueryBuilder(get_pandas_df(), "privacy_key")
+        builder.groupby("group_key",
+                        max_groups_contributed=1,
+                        max_contributions_per_group=1)
+        builder.sum("value").sum("value")
+        with self.assertRaisesRegex(ValueError,
+                                    "Each aggregation can be added only once"):
+            builder.build_query()
+
+    def test_caps_not_given(self):
+        builder = dataframes.QueryBuilder(get_pandas_df(), "privacy_key")
+        builder.groupby("group_key",
+                        max_groups_contributed=1,
+                        max_contributions_per_group=1)
+        builder.sum("value")
+        with self.assertRaisesRegex(ValueError,
+                                    "min_value and max_value must be given"):
+            builder.build_query()
+
+    def test_caps_are_different(self):
+        builder = dataframes.QueryBuilder(get_pandas_df(), "privacy_key")
+        builder.groupby("group_key",
+                        max_groups_contributed=1,
+                        max_contributions_per_group=1)
+        builder.sum("value", min_value=0, max_value=1).mean("value",
+                                                            min_value=0,
+                                                            max_value=2)
+        with self.assertRaisesRegex(
+                ValueError,
+                "If min_value and max_value provided multiple times they must be the same"
+        ):
+            builder.build_query()
 
     def test_count_query(self):
         df = get_pandas_df()
@@ -137,6 +191,30 @@ class QueryBuilderTest(parameterized.TestCase):
                                           min_value=1,
                                           max_value=2.5))
 
+    def test_count_and_mean_query(self):
+        query = dataframes.QueryBuilder(get_pandas_df(), "privacy_key").groupby(
+            "group_key",
+            max_groups_contributed=8,
+            max_contributions_per_group=11).count().sum(
+                "value", name="SUM1").mean("value", min_value=0,
+                                           max_value=3).build_query()
+
+        self.assertEqual(
+            query._columns,
+            dataframes.Columns("privacy_key", "group_key", "value"))
+        self.assertEqual(
+            query._metrics_output_columns, {
+                pipeline_dp.Metrics.COUNT: None,
+                pipeline_dp.Metrics.SUM: "SUM1",
+                pipeline_dp.Metrics.MEAN: None
+            })
+        self.assertEqual(
+            query._contribution_bounds,
+            dataframes.ContributionBounds(max_partitions_contributed=8,
+                                          max_contributions_per_partition=11,
+                                          min_value=0,
+                                          max_value=3))
+
     def test_public_keys(self):
         query = dataframes.QueryBuilder(get_pandas_df(), "privacy_key").groupby(
             "group_key",
@@ -181,6 +259,9 @@ class QueryTest(parameterized.TestCase):
              public_keys=["key1"]),
         dict(testcase_name='sum, count, private partitions',
              metrics=[pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.SUM],
+             public_keys=None),
+        dict(testcase_name='mean, count, private partitions',
+             metrics=[pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.MEAN],
              public_keys=None))
     @patch('pipeline_dp.dp_engine.DPEngine.aggregate')
     def test_run_query(self, mock_aggregate, metrics, public_keys):


### PR DESCRIPTION
This PR intorduces `QueryBuilder.mean`, to allow DP mean computation. Along the way small refactoring done: allmost all validations are performed in `QueryBuilderbuild_query` instead of individual aggregation function (`count`, `sum` etc). That's more convenient, since the conditions on the correct state can be complicated, provided that in future the will be more aggregations and it will be allowed to compute aggregates of multiple columns.