### PR TITLE
(Refactoring) Drop using CombinerParams Class in Utility analysis combiners

### DIFF
--- a/analysis/utility_analysis_engine.py
+++ b/analysis/utility_analysis_engine.py
@@ -120,24 +120,19 @@ class UtilityAnalysisEngine(pipeline_dp.DPEngine):
             if not self._is_public_partitions:
                 internal_combiners.append(
                     per_partition_combiners.PartitionSelectionCombiner(
-                        combiners.CombinerParams(
-                            private_partition_selection_budget, params)))
+                        private_partition_selection_budget, params))
             if pipeline_dp.Metrics.SUM in aggregate_params.metrics:
                 internal_combiners.append(
                     per_partition_combiners.SumCombiner(
-                        combiners.CombinerParams(
-                            budgets[pipeline_dp.Metrics.SUM], params)))
+                        budgets[pipeline_dp.Metrics.SUM], params))
             if pipeline_dp.Metrics.COUNT in aggregate_params.metrics:
                 internal_combiners.append(
                     per_partition_combiners.CountCombiner(
-                        combiners.CombinerParams(
-                            budgets[pipeline_dp.Metrics.COUNT], params)))
+                        budgets[pipeline_dp.Metrics.COUNT], params))
             if pipeline_dp.Metrics.PRIVACY_ID_COUNT in aggregate_params.metrics:
                 internal_combiners.append(
                     per_partition_combiners.PrivacyIdCountCombiner(
-                        combiners.CombinerParams(
-                            budgets[pipeline_dp.Metrics.PRIVACY_ID_COUNT],
-                            params)))
+                        budgets[pipeline_dp.Metrics.PRIVACY_ID_COUNT], params))
 
         return per_partition_combiners.CompoundCombiner(
             internal_combiners, return_named_tuple=False)


### PR DESCRIPTION
`CombinerParams` class is not used anymore in production  combiners. Moreover it doesn't provide any benefits, it just contains 2 fields: `MechanismSpec` and `AggregateParams`. Let's stop using `CombinerParams` in utility analysis and pass `MechanismSpec` and `AggregateParams` directly. That would simplify the code a little bit.