### PR TITLE
Deriving Spark DataFrame schema on converting from RDD to DataFrame

### DIFF
--- a/examples/restaurant_visits/run_on_dataframes.py
+++ b/examples/restaurant_visits/run_on_dataframes.py
@@ -61,7 +61,7 @@ def delete_if_exists(filename):
 
 def load_data_in_spark_dataframe(
         spark: SparkSession) -> pyspark.sql.dataframe.DataFrame:
-    df = spark.read.csv(FLAGS.input_file, header=True, inferSchema=True)  #.limit(10)
+    df = spark.read.csv(FLAGS.input_file, header=True, inferSchema=True)
     return df.withColumnRenamed('VisitorId', 'visitor_id').withColumnRenamed(
         'Time entered', 'enter_time').withColumnRenamed(
             'Time spent (minutes)', 'spent_minutes').withColumnRenamed(

--- a/examples/restaurant_visits/run_on_dataframes.py
+++ b/examples/restaurant_visits/run_on_dataframes.py
@@ -61,7 +61,7 @@ def delete_if_exists(filename):
 
 def load_data_in_spark_dataframe(
         spark: SparkSession) -> pyspark.sql.dataframe.DataFrame:
-    df = spark.read.csv(FLAGS.input_file, header=True, inferSchema=True)
+    df = spark.read.csv(FLAGS.input_file, header=True, inferSchema=True)  #.limit(10)
     return df.withColumnRenamed('VisitorId', 'visitor_id').withColumnRenamed(
         'Time entered', 'enter_time').withColumnRenamed(
             'Time spent (minutes)', 'spent_minutes').withColumnRenamed(

--- a/tests/dataframes_test.py
+++ b/tests/dataframes_test.py
@@ -420,7 +420,7 @@ class QueryTest(parameterized.TestCase):
                                  public_partitions=None)
 
         # Act
-        budget = dataframes.Budget(1, 1e-10)  # large budget to get small noise
+        budget = dataframes.Budget(1, 1e-10)
         result_df = query.run_query(budget)
 
         # Assert

--- a/tests/dataframes_test.py
+++ b/tests/dataframes_test.py
@@ -402,6 +402,32 @@ class QueryTest(parameterized.TestCase):
         self.assertAlmostEqual(row1["count"], 1, delta=1e-3)
         self.assertAlmostEqual(row1["sum_column"], 5, delta=1e-3)
 
+    def test_run_query_e2e_run_empty_result(self):
+        # Arrange
+        spark = self._get_spark_session()
+        df = spark.createDataFrame(get_pandas_df())
+        columns = dataframes.Columns("privacy_key", "group_key", "value")
+        metrics = {pipeline_dp.Metrics.COUNT: "count_column"}
+        bounds = dataframes.ContributionBounds(
+            max_partitions_contributed=2,
+            max_contributions_per_partition=2,
+            min_value=-5,
+            max_value=5)
+        query = dataframes.Query(df,
+                                 columns,
+                                 metrics,
+                                 bounds,
+                                 public_partitions=None)
+
+        # Act
+        budget = dataframes.Budget(1, 1e-10)  # large budget to get small noise
+        result_df = query.run_query(budget)
+
+        # Assert
+        # The small input dataset and private partition selection. It almost
+        # sure leads to the empty result.
+        self.assertTrue(result_df.toPandas().empty)
+
 
 if __name__ == '__main__':
     absltest.main()


### PR DESCRIPTION
In case if the output is not empty the schema can be deduced automatically, but if the output is empty (e.g. because all partitions are dropped by partition selection) there was an example "Empty RDD". Setting the schema fixes that.