### PR TITLE
Tuning for multiple columns part 1: Computing Sum histograms for multiple columns

### DIFF
--- a/analysis/contribution_bounders.py
+++ b/analysis/contribution_bounders.py
@@ -68,26 +68,26 @@ class AnalysisContributionBounder(contribution_bounders.ContributionBounder):
             for partition_key, values in partition_values:
                 if sampler is not None and not sampler.keep(partition_key):
                     continue
-                # Sum values if it's needed values,
+                # Sum values.
                 # values can contain multi-columns, the format is the following
                 # 1 column:
                 #   input: values = [v_0:float, ... ]
                 #   output: v_0 + ....
                 # k columns (k > 1):
-                #   input: values = [v_0=(v00, ... v0(k-1)), ...]
-                #   output: (00+v10+..., ...)
+                #   input: values = [v_0=(v_00, ... v_0(k-1)), ...]
+                #   output: (v_00+v_10+..., ...)
                 if not values:
                     # Empty public partitions
                     sum_values = 0
                 elif len(values) == 1:
                     # No need to sum, return 0th value
                     sum_values = values[0]
-                elif isinstance(values[0], Iterable):
-                    # multiple value columns, sum each column independently
-                    sum_values = tuple(np.array(values).sum(axis=0).tolist())
-                else:
+                elif not isinstance(values[0], Iterable):
                     # 1 column
                     sum_values = sum(values)
+                else:
+                    # multiple value columns, sum each column independently
+                    sum_values = tuple(np.array(values).sum(axis=0).tolist())
 
                 yield (privacy_id, partition_key), (
                     len(values),

--- a/analysis/contribution_bounders.py
+++ b/analysis/contribution_bounders.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ContributionBounder for utility analysis."""
+
+import numpy as np
 from pipeline_dp import contribution_bounders
 from pipeline_dp import sampling_utils
 
@@ -65,9 +67,20 @@ class AnalysisContributionBounder(contribution_bounders.ContributionBounder):
             for partition_key, values in partition_values:
                 if sampler is not None and not sampler.keep(partition_key):
                     continue
-                yield (privacy_id, partition_key), (len(values), sum(values),
-                                                    num_partitions_contributed,
-                                                    num_contributions)
+                if len(values) == 1:
+                    sum_values = values
+                # elif len(values[0]) == 1:  todo
+                #     # 1 value
+                #     sum_values = sum(values)
+                else:
+                    # multiple value columns, sum each column independently
+                    sum_values = np.array(values).sum(axis=0).tolist()
+                yield (privacy_id, partition_key), (
+                    len(values),
+                    sum_values,
+                    num_partitions_contributed,
+                    num_contributions,
+                )
 
         # Unnest the list per privacy id.
         col = backend.flat_map(

--- a/pipeline_dp/data_extractors.py
+++ b/pipeline_dp/data_extractors.py
@@ -1,5 +1,20 @@
+# Copyright 2022 OpenMined.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Classes for keeping data (privacy unit, partition etc) extractors."""
+
 import dataclasses
-from typing import Callable
+from typing import Callable, List, Optional
 
 
 @dataclasses.dataclass
@@ -13,6 +28,17 @@ class DataExtractors:
     privacy_id_extractor: Callable = None
     partition_extractor: Callable = None
     value_extractor: Callable = None
+
+
+@dataclasses.dataclass
+class MultiValueDataExtactors(DataExtractors):
+    """TODO"""
+    value_extractors: Optional[List[Callable]] = None
+
+    def __post_init__(self):
+        if self.value_extractors is not None:
+            self.value_extractor = lambda row: tuple(
+                e(row) for e in self.value_extractors)
 
 
 @dataclasses.dataclass

--- a/pipeline_dp/data_extractors.py
+++ b/pipeline_dp/data_extractors.py
@@ -32,7 +32,10 @@ class DataExtractors:
 
 @dataclasses.dataclass
 class MultiValueDataExtactors(DataExtractors):
-    """TODO"""
+    """Data extractors with multiple value extractors
+
+    Each extractor corresponds to the different value to aggregate.
+    """
     value_extractors: Optional[List[Callable]] = None
 
     def __post_init__(self):

--- a/pipeline_dp/data_extractors.py
+++ b/pipeline_dp/data_extractors.py
@@ -32,7 +32,7 @@ class DataExtractors:
 
 @dataclasses.dataclass
 class MultiValueDataExtactors(DataExtractors):
-    """Data extractors with multiple value extractors
+    """Data extractors with multiple value extractors.
 
     Each extractor corresponds to the different value to aggregate.
     """

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -20,7 +20,7 @@ from pipeline_dp import pipeline_backend
 from pipeline_dp.dataset_histograms import histograms as hist
 from pipeline_dp.dataset_histograms import sum_histogram_computation
 
-# Functions _compute_* computes histogram for counts. TODO: move them to
+# Functions _compute_* compute histograms for counts. TODO: move them to
 # a separate file, similar to sum_histogram_computation.py.
 
 
@@ -152,7 +152,8 @@ def _list_to_contribution_histograms(
     for histogram in histograms:
         if isinstance(histogram, Iterable):
             if not histogram:
-                # no histogram were computed, it can be if the dataset is empty
+                # no histograms were computed, this can happen if the dataset is
+                # empty
                 continue
             histogram_type = histogram[0].name
         else:

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Functions for computing dataset histograms in pipelines."""
-import bisect
 import operator
 from typing import Iterable, List, Tuple
-
-import numpy as np
 
 import pipeline_dp
 from pipeline_dp import pipeline_backend
 from pipeline_dp.dataset_histograms import histograms as hist
 from pipeline_dp.dataset_histograms import sum_histogram_computation
+
+# Functions _compute_* computes histogram for counts. TODO: move them to
+# a separate file, similar to sum_histogram_computation.py.
 
 
 def _to_bin_lower_upper_logarithmic(value: int) -> Tuple[int, int]:

--- a/pipeline_dp/dataset_histograms/computing_histograms.py
+++ b/pipeline_dp/dataset_histograms/computing_histograms.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Functions for computing dataset histograms in pipelines."""
 import operator
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Tuple, Union
 
 import pipeline_dp
 from pipeline_dp import pipeline_backend
@@ -142,7 +142,7 @@ def _convert_frequency_bins_into_histogram(
 
 
 def _list_to_contribution_histograms(
-    histograms: List[hist.Histogram | List[hist.Histogram]],
+    histograms: List[Union[hist.Histogram, List[hist.Histogram]]],
 ) -> hist.DatasetHistograms:
     """Packs histograms from a list to ContributionHistograms."""
     l0_contributions = l1_contributions = None

--- a/pipeline_dp/dataset_histograms/histograms.py
+++ b/pipeline_dp/dataset_histograms/histograms.py
@@ -15,7 +15,7 @@
 
 from dataclasses import dataclass, field
 import enum
-from typing import List, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 
 @dataclass
@@ -210,7 +210,14 @@ class DatasetHistograms:
     l0_contributions_histogram: Histogram
     l1_contributions_histogram: Histogram
     linf_contributions_histogram: Histogram
-    linf_sum_contributions_histogram: Histogram
+    linf_sum_contributions_histogram: Optional[Union[Histogram,
+                                                     List[Histogram]]]
     count_per_partition_histogram: Histogram
     count_privacy_id_per_partition: Histogram
-    sum_per_partition_histogram: Histogram
+    sum_per_partition_histogram: Optional[Union[Histogram, List[Histogram]]]
+
+
+def num_sum_histograms(self) -> int:
+    if isinstance(self.linf_sum_contributions_histogram, Histogram):
+        return 1
+    return len(self.linf_sum_contributions_histogram)

--- a/pipeline_dp/dataset_histograms/sum_histogram_computation.py
+++ b/pipeline_dp/dataset_histograms/sum_histogram_computation.py
@@ -1,0 +1,335 @@
+# Copyright 2024 OpenMined.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Functions for computing linf_sum and sum_per_partition histograms."""
+
+# TODO: theory on sum histograms
+
+import copy
+import operator
+from typing import Iterable, List, Tuple
+
+from pipeline_dp import pipeline_backend, pipeline_functions
+from pipeline_dp.dataset_histograms import histograms as hist
+
+NUMBER_OF_BUCKETS_SUM_HISTOGRAM = 10000
+
+
+class LowerUpperGenerator:
+    """Generates lower-upper bounds for FrequencyBin
+
+  Attributes:
+    left, right: bounds on interval on which we compute histogram.
+    num_buckets: number of buckets on [left, right]. Buckets have the same length.
+
+  i-th bucket corresponds to numbers from
+    [left+i*bucket_len, right+(i+1)*bucket_len), where
+    bucket_len = (right-left)/num_buckets.
+  The last bucket includes right end-point.
+  """
+
+    def __init__(
+        self,
+        left: float,
+        right: float,
+        num_buckets: int = NUMBER_OF_BUCKETS_SUM_HISTOGRAM,
+    ):
+        assert left <= right, "The left bound must be smaller then the right one, but {left=} and {right=}"
+        self.left = left
+        self.right = right
+        self.num_buckets = num_buckets if left < right else 1
+        self.bucket_len = (right - left) / num_buckets
+
+    def get_bucket_index(self, x: float) -> int:
+        assert self.left <= x <= self.right  # only for debug
+        if x == self.right:  # last bucket includes both ends.
+            return self.num_buckets - 1
+        if x <= self.left:
+            return 0
+        if x >= self.right:
+            return self.num_buckets - 1
+        return int((x - self.left) / self.bucket_len)
+
+    def get_lower_upper(self, x: float) -> Tuple[float, float]:
+        index = self.get_bucket_index(x)
+        return self._get_lower(index), self._get_upper(index)
+
+    def _get_lower(self, index: int) -> float:
+        return self.left + index * self.bucket_len
+
+    def _get_upper(self, index: int) -> float:
+        return self.left + (index + 1) * self.bucket_len
+
+
+def _compute_frequency_histogram_per_key(
+    col,
+    backend: pipeline_backend.PipelineBackend,
+    name: hist.HistogramType,
+    num_buckets: int,
+):
+    """Computes histogram of element frequencies in collection.
+
+  This is a helper function for computing sum histograms per key.
+
+  Args:
+      col: collection of (key, value:float)
+      backend: PipelineBackend to run operations on the collection.
+      name: name which is assigned to the computed histogram.
+      num_buckets: the number of buckets in the output histogram.
+
+  Returns:
+      1 element collection which contains list [hist.Histogram], sorted by key.
+  """
+    col = backend.to_multi_transformable_collection(col)
+
+    bucket_generators = _create_bucket_generators_per_key(
+        col, num_buckets, backend)
+
+    def _map_to_frequency_bin(
+        key_value: Tuple[int,
+                         float], bucket_generators: List[LowerUpperGenerator]
+    ) -> Tuple[float, hist.FrequencyBin]:
+        # bucket_generator is a 1-element list with LowerUpperGenerator.
+        index, value = key_value
+        bucket_generator = bucket_generators[index]
+        bin_lower, bin_upper = bucket_generator.get_lower_upper(value)
+        bucket = hist.FrequencyBin(lower=bin_lower,
+                                   upper=bin_upper,
+                                   count=1,
+                                   sum=value,
+                                   max=value)
+        return (index, bin_lower), bucket
+
+    col = backend.map_with_side_inputs(col, _map_to_frequency_bin,
+                                       bucket_generators, "To FrequencyBin")
+    # (lower_bin_value, hist.FrequencyBin)
+
+    col = backend.reduce_per_key(col, operator.add, "Combine FrequencyBins")
+    # ((index, lower_bin_value), hist.FrequencyBin)
+
+    col = backend.map_tuple(col, lambda k, v: (k[0], v), "Drop lower")
+    # (index, hist.FrequencyBin)
+
+    col = backend.group_by_key(col, "Group by histogram index")
+
+    # (index, [hist.FrequencyBin])
+
+    def bins_to_histogram(bins):
+        sorted_bins = sorted(bins, key=lambda bin: bin.lower)
+        return hist.Histogram(name, sorted_bins)
+
+    col = backend.map_values(col, bins_to_histogram, "To histogram")
+
+    col = backend.to_list(col, "To 1 element collection")
+
+    def sort_histograms_by_index(index_histogram):
+        if len(index_histogram) == 1:
+            # It is a histogram for one column, return it w/o putting it in a list.
+            return index_histogram[0][1]
+
+        # Sort histograms by index and return list of them.
+        # Beam does not like mutating arguments, so copy the argument.
+        index_histogram = copy.deepcopy(index_histogram)
+        return [histogram for index, histogram in sorted(index_histogram)]
+
+    col = backend.map(col, sort_histograms_by_index, "sort histogram by index")
+    # 1 element collection with list of histograms: [hist.FrequencyBin]
+    return col
+
+
+def _create_bucket_generators_per_key(
+        col, number_of_buckets: int, backend: pipeline_backend.PipelineBackend):
+    """Create bucket generators per key.
+
+  Args:
+    col: collection of (key, value)
+    backend: PipelineBackend to run operations on the collection.
+    num_buckets: the number of buckets in the output histogram.
+
+  Returns:
+    1 element collection with dictionary {key: LowerUpperGenerator}.
+  """
+    col = pipeline_functions.min_max_per_key(
+        backend, col, "Min and max value per value column")
+    # (index, (min, max))
+
+    col = backend.to_list(col, "To list")
+
+    # 1 elem col: ([(index, (min, max))])
+
+    def create_generators(index_min_max: List[Tuple[int, Tuple[float, float]]]):
+        min_max_sorted_by_index = [v for k, v in sorted(index_min_max)]
+        return [
+            LowerUpperGenerator(min, max, number_of_buckets)
+            for min, max in min_max_sorted_by_index
+        ]
+
+    return backend.map(col, create_generators, "Create generators")
+
+
+def _flat_values(col, backend: pipeline_backend.PipelineBackend):
+    """Unnest values in (key, value) collection.
+
+  Args:
+    col: collection of (key, value) or (key, [value])
+    backend: PipelineBackend to run operations on the collection.
+
+  Transform each element:
+    (key, value: float) -> ((0, key), value)
+    (key, value: list[float]) -> [((0, key), value[0]), ((1, key), value[1])...]
+  and then unnest them.
+
+  Return:
+    Collection of ((index, key), value).
+  """
+
+    def flat_values(key_values):
+        key, values = key_values
+        if isinstance(values, Iterable):
+            for i, value in enumerate(values):
+                yield (i, key), value
+        else:
+            yield (0, key), values  # 1 value
+
+    return backend.flat_map(col, flat_values, "Flat values")
+
+
+def _compute_linf_sum_contributions_histogram(
+        col, backend: pipeline_backend.PipelineBackend):
+    """Computes histogram of per partition privacy id contributions.
+
+  This histogram contains: the number of (privacy id, partition_key)-pairs
+  which have sum of values X_1, X_2, ..., X_n, where X_1 = min_sum,
+  X_n = one before max sum and n is equal to
+  NUMBER_OF_BUCKETS_SUM_HISTOGRAM.
+
+   Args:
+    col: collection with elements ((privacy_id, partition_key), value(s)).
+     where value can be 1 float or tuple of floats (in case of many columns)
+    backend: PipelineBackend to run operations on the collection.
+
+  Returns:
+    1 element collection, which contains the computed hist.Histogram.
+  """
+    col = _flat_values(col, backend)
+    # ((index_value, (pid, pk)), value).
+    col = backend.sum_per_key(
+        col, "Sum of contributions per (privacy_id, partition)")
+    # col: ((index, (pid, pk), sum_per_key)
+    col = backend.map_tuple(col, lambda k, v: (k[0], v),
+                            "Drop privacy_id, partition_key")
+    # col: (index, float)
+
+    return _compute_frequency_histogram_per_key(
+        col, backend, hist.HistogramType.LINF_SUM_CONTRIBUTIONS,
+        NUMBER_OF_BUCKETS_SUM_HISTOGRAM)
+
+
+def _compute_partition_sum_histogram(col,
+                                     backend: pipeline_backend.PipelineBackend):
+    """Computes histogram of sum per partition.
+
+  This histogram contains: the number of partition_keys which have sum of
+  values X_1, X_2, ..., X_n, where X_1 = min_sum, X_n = one before max sum and
+  n is equal to NUMBER_OF_BUCKETS_SUM_HISTOGRAM.
+
+  Args:
+      col: collection with elements ((privacy_id, partition_key), value).
+      backend: PipelineBackend to run operations on the collection.
+  Returns:
+      1 element collection, which contains the computed hist.Histogram.
+  """
+
+    col = backend.map_tuple(col, lambda pid_pk, value: (pid_pk[1], value),
+                            "Drop privacy id")
+    # (pk, values)
+    col = _flat_values(col, backend)
+    # ((index_value, pk), value).
+    col = backend.sum_per_key(col, "Sum of contributions per partition")
+    # col: ((index_value, pk), sum_per_partition)
+    col = backend.map_tuple(col, lambda index_pk, value: (index_pk[0], value),
+                            "Drop partition")
+    # col: (index, float)
+    return _compute_frequency_histogram_per_key(
+        col, backend, hist.HistogramType.SUM_PER_PARTITION,
+        NUMBER_OF_BUCKETS_SUM_HISTOGRAM)
+
+
+def _compute_linf_sum_contributions_histogram_on_preaggregated_data(
+        col, backend: pipeline_backend.PipelineBackend):
+    """Computes histogram of per partition privacy id contributions.
+
+  This histogram contains: the number of (privacy id, partition_key)-pairs
+  which have sum of values X_1, X_2, ..., X_n, where X_1 = min_sum,
+  X_n = one before max sum and n is equal to
+  NUMBER_OF_BUCKETS_SUM_HISTOGRAM.
+
+  Args:
+      col: collection with a pre-aggregated dataset, each element is
+      (partition_key, (count, sum, n_partitions, n_contributions)).
+      backend: PipelineBackend to run operations on the collection.
+  Returns:
+      1 element collection, which contains the computed histograms.Histogram.
+  """
+    col = backend.map_tuple(
+        col,
+        lambda _, x:
+        (None, x[1]),  # x is (count, sum, n_partitions, n_contributions)
+        "Extract sum per partition contribution")
+    # col: (values,) where each element is the sum of values the todo
+    # corresponding privacy_id contributes to the partition.
+
+    col = _flat_values(col, backend)
+    # col: ((index, None), float)
+
+    col = backend.map_tuple(col, lambda k, v: (k[0], v), "Drop dummy key")
+    # col: (index, float)
+
+    return _compute_frequency_histogram_per_key(
+        col, backend, hist.HistogramType.LINF_SUM_CONTRIBUTIONS,
+        NUMBER_OF_BUCKETS_SUM_HISTOGRAM)
+
+
+def _compute_partition_sum_histogram_on_preaggregated_data(
+        col, backend: pipeline_backend.PipelineBackend):
+    """Computes histogram of counts per partition.
+
+  This histogram contains: the number of partition_keys which have sum of
+  values X_1, X_2, ..., X_n, where X_1 = min_sum, X_n = one before max sum and
+  n is equal to NUMBER_OF_BUCKETS_SUM_HISTOGRAM.
+
+  Args:
+      col: collection with a pre-aggregated dataset, each element is
+      (partition_key, (count, sum, n_partitions, n_contributions)).
+      backend: PipelineBackend to run operations on the collection.
+  Returns:
+      1 element collection, which contains the computed histograms.Histogram.
+  """
+    col = backend.map_values(
+        col,
+        lambda x: x[1],  # x is (count, sum, n_partitions, n_contributions)
+        "Extract sum per partition contribution")
+    # col: (pk, int)
+
+    col = _flat_values(col, backend)
+    # col: ((index, pk), float)
+
+    col = backend.sum_per_key(col, "Sum per partition")
+    # col: ((index, pk), float), where each element is the total sum per partition.
+    col = backend.map_tuple(col, lambda k, v: (k[0], v),
+                            "Drop privacy_id, partition_key")
+    # col: (index, float)
+
+    return _compute_frequency_histogram_per_key(
+        col, backend, hist.HistogramType.SUM_PER_PARTITION,
+        NUMBER_OF_BUCKETS_SUM_HISTOGRAM)

--- a/pipeline_dp/dataset_histograms/sum_histogram_computation.py
+++ b/pipeline_dp/dataset_histograms/sum_histogram_computation.py
@@ -328,7 +328,7 @@ def _compute_partition_sum_histogram_on_preaggregated_data(
       (partition_key, (count, sum, n_partitions, n_contributions)).
       backend: PipelineBackend to run operations on the collection.
     Returns:
-      1 element collection, which contains the computed histograms.Histogram.
+      1 element collection, which contains the computed histograms.Histogram.g
     """
     col = backend.map_values(
         col,

--- a/pipeline_dp/dataset_histograms/sum_histogram_computation.py
+++ b/pipeline_dp/dataset_histograms/sum_histogram_computation.py
@@ -113,9 +113,10 @@ def _compute_frequency_histogram_per_key(
         key_value: Tuple[int, float],
         bucket_generators: List[List[LowerUpperGenerator]]
     ) -> Tuple[float, hist.FrequencyBin]:
-        # bucket_generator is a 1-element list with LowerUpperGenerator.
+        # bucket_generator is a 1-element list with
+        # a single element to be a list of LowerUpperGenerator.
         index, value = key_value
-        bucket_generator = bucket_generators[index]
+        bucket_generator = bucket_generators[0][index]
         bin_lower, bin_upper = bucket_generator.get_lower_upper(value)
         bucket = hist.FrequencyBin(lower=bin_lower,
                                    upper=bin_upper,

--- a/pipeline_dp/dataset_histograms/sum_histogram_computation.py
+++ b/pipeline_dp/dataset_histograms/sum_histogram_computation.py
@@ -110,8 +110,8 @@ def _compute_frequency_histogram_per_key(
         col, num_buckets, backend)
 
     def _map_to_frequency_bin(
-        key_value: Tuple[int,
-                         float], bucket_generators: List[LowerUpperGenerator]
+        key_value: Tuple[int, float],
+        bucket_generators: List[List[LowerUpperGenerator]]
     ) -> Tuple[float, hist.FrequencyBin]:
         # bucket_generator is a 1-element list with LowerUpperGenerator.
         index, value = key_value
@@ -125,7 +125,7 @@ def _compute_frequency_histogram_per_key(
         return (index, bin_lower), bucket
 
     col = backend.map_with_side_inputs(col, _map_to_frequency_bin,
-                                       bucket_generators, "To FrequencyBin")
+                                       (bucket_generators,), "To FrequencyBin")
     # (lower_bin_value, hist.FrequencyBin)
 
     col = backend.reduce_per_key(col, operator.add, "Combine FrequencyBins")

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -488,7 +488,7 @@ class LocalBackend(PipelineBackend):
                              fn,
                              side_input_cols,
                              stage_name: str = None):
-        side_inputs = [list(side_input) for side_input in side_input_cols]
+        side_inputs = [list(side_input)[0] for side_input in side_input_cols]
         return map(lambda x: fn(x, *side_inputs), col)
 
     def flat_map(self, col, fn, stage_name: str = None):

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -488,7 +488,7 @@ class LocalBackend(PipelineBackend):
                              fn,
                              side_input_cols,
                              stage_name: str = None):
-        side_inputs = [list(side_input)[0] for side_input in side_input_cols]
+        side_inputs = [list(side_input) for side_input in side_input_cols]
         return map(lambda x: fn(x, *side_inputs), col)
 
     def flat_map(self, col, fn, stage_name: str = None):

--- a/tests/dataset_histograms/computing_histograms_test.py
+++ b/tests/dataset_histograms/computing_histograms_test.py
@@ -36,20 +36,6 @@ class ComputingHistogramsTest(parameterized.TestCase):
         self.assertEqual(to_bin_lower(10**9 + 10**7 + 1234),
                          (10**9 + 10**7, 10**9 + 2 * 10**7))
 
-    def test_bin_lower_index(self):
-        lowers = [0.5, 1.2, 3.6, 5]
-        to_bin_lower_idx = computing_histograms._bin_lower_index
-        with self.assertRaises(AssertionError):
-            to_bin_lower_idx(lowers, 0.3)
-        self.assertEqual(to_bin_lower_idx(lowers, 0.5), 0)
-        self.assertEqual(to_bin_lower_idx(lowers, 1), 0)
-        self.assertEqual(to_bin_lower_idx(lowers, 1.2), 1)
-        self.assertEqual(to_bin_lower_idx(lowers, 1.3), 1)
-        self.assertEqual(to_bin_lower_idx(lowers, 3.6), 2)
-        self.assertEqual(to_bin_lower_idx(lowers, 5), 2)
-        with self.assertRaises(AssertionError):
-            to_bin_lower_idx(lowers, 5.1)
-
     @parameterized.named_parameters(
         dict(testcase_name='empty', input=[], expected=[]),
         dict(testcase_name='small_histogram',
@@ -313,141 +299,6 @@ class ComputingHistogramsTest(parameterized.TestCase):
 
     @parameterized.product(
         (
-            dict(testcase_name='empty', input=lambda: [], expected=lambda: []),
-            dict(
-                testcase_name='small_histogram',
-                input=lambda: [((1, 1), 0.5), ((1, 2), 1.5), (
-                    (2, 1), -2.5), (
-                        (1, 1), 0.5)],  # ((privacy_id, partition), value)
-                expected=lambda: [
-                    # step is (1.5 - (-2.5)) / 1e4 = 0.0004,
-                    # ((2, 1), -2.5)
-                    hist.FrequencyBin(
-                        lower=-2.5, upper=-2.5004, count=1, sum=-2.5, max=-2.5),
-                    # 2 times ((1, 1), 0.5), they are summed up and put into a
-                    # bin as one.
-                    hist.FrequencyBin(
-                        lower=1.0, upper=-1.0004, count=1, sum=1.0, max=1.0),
-                    # ((1, 1, 1.5), 1.5 is max and not included,
-                    # therefore 1.5 - 0.0004 = 1.4996.
-                    hist.FrequencyBin(
-                        lower=1.4996,
-                        upper=1.5, count=1, sum=1.5, max=1.5),
-                ]),
-            dict(
-                testcase_name='Different privacy ids, 1 equal contribution',
-                input=lambda: [((i, i), 1) for i in range(100)],
-                # ((privacy_id, partition), value)
-                expected=lambda: [
-                    hist.FrequencyBin(
-                        lower=1, upper=1, count=100, sum=100, max=1),
-                ]),
-            dict(
-                testcase_name='Different privacy ids, 1 different contribution',
-                input=lambda: [((i, i), i) for i in range(10001)],
-                # ((privacy_id, partition), value)
-                # step is 1e4 / 1e4 = 1, therefore 1e4 - 1 = 9999.
-                expected=lambda: [
-                    hist.FrequencyBin(lower=float(i),
-                                      upper=float(i + 1),
-                                      count=1,
-                                      sum=i,
-                                      max=i) for i in range(9999)
-                ] + [
-                    hist.FrequencyBin(
-                        lower=9999, upper=1000, count=2, sum=19999, max=10000)
-                ]),
-            dict(
-                testcase_name='1 privacy id many contributions to 1 '
-                'partition',
-                input=lambda: [(
-                    (0, 0), 1.0)] * 100,  # ((privacy_id, partition), value)
-                expected=lambda: [
-                    hist.FrequencyBin(
-                        lower=100.0, upper=100.0, count=1, sum=100.0, max=100.0
-                    ),
-                ]),
-            dict(
-                testcase_name=
-                '1 privacy id many equal contributions to many partition',
-                input=lambda: [((0, i), 1.0) for i in range(1234)],
-                # ((privacy_id, partition), value)
-                expected=lambda: [
-                    hist.FrequencyBin(
-                        lower=1.0, upper=1.0, count=1234, sum=1234.0, max=1),
-                ]),
-            dict(
-                testcase_name=
-                '1 privacy id many different contributions to many partition',
-                input=lambda: [((0, i), i) for i in range(10001)],
-                # ((privacy_id, partition), value)
-                # step is 1e4 / 1e4 = 1, therefore 1e4 - 1 = 9999.
-                expected=lambda: [
-                    hist.FrequencyBin(lower=float(i),
-                                      upper=float(i + 1),
-                                      count=1,
-                                      sum=i,
-                                      max=i) for i in range(9999)
-                ] + [
-                    hist.FrequencyBin(
-                        lower=9999, upper=1000, count=2, sum=19999, max=10000)
-                ]),
-            dict(
-                testcase_name=
-                '2 privacy ids, same partitions equally contributed',
-                input=lambda: [((0, i), 1.0) for i in range(15)] + [(
-                    (1, i), 1.0) for i in range(10, 25)],
-                # ((privacy_id, partition), value)
-                expected=lambda: [
-                    hist.FrequencyBin(
-                        lower=1.0, upper=1.0, count=30, sum=30, max=1),
-                ]),
-            dict(
-                testcase_name='2 privacy ids, same partitions differently '
-                'contributed',
-                input=lambda: [((0, i), -1.0) for i in range(15)] + [(
-                    (1, i), 1.0) for i in range(10, 25)],
-                # ((privacy_id, partition), value)
-                # step = (1 - (-1)) / 1e4 = 0.0002,
-                # therefore last lower is 1 - 0.0002 = 0.9998.
-                expected=lambda: [
-                    hist.FrequencyBin(
-                        lower=-1.0, upper=-1.0002, count=15, sum=-15, max=-1),
-                    hist.
-                    FrequencyBin(lower=0.9998, upper=1, count=15, sum=15, max=1
-                                ),
-                ]),
-        ),
-        pre_aggregated=(False, True))
-    def test_compute_linf_sum_contributions_histogram(self, testcase_name,
-                                                      input, expected,
-                                                      pre_aggregated):
-        # Lambdas are used for returning input and expected. Passing lists
-        # instead lead to printing whole lists as test names in the output.
-        # That complicates debugging.
-        input = input()
-        expected = expected()
-        backend = pipeline_dp.LocalBackend()
-        if pre_aggregated:
-            input = pre_aggregation.preaggregate(
-                input,
-                backend,
-                data_extractors=pipeline_dp.DataExtractors(
-                    privacy_id_extractor=lambda x: x[0][0],
-                    partition_extractor=lambda x: x[0][1],
-                    value_extractor=lambda x: x[1]))
-            compute_histograms = computing_histograms._compute_linf_sum_contributions_histogram_on_preaggregated_data
-        else:
-            compute_histograms = computing_histograms._compute_linf_sum_contributions_histogram
-        histogram = list(compute_histograms(input, backend))
-        self.assertLen(histogram, 1)
-        histogram = histogram[0]
-        self.assertEqual(hist.HistogramType.LINF_SUM_CONTRIBUTIONS,
-                         histogram.name)
-        self.assertListEqual(expected, histogram.bins)
-
-    @parameterized.product(
-        (
             dict(testcase_name='empty histogram', input=[], expected=[]),
             dict(
                 testcase_name='small_histogram',
@@ -568,146 +419,6 @@ class ComputingHistogramsTest(parameterized.TestCase):
         histogram = list(compute_histograms(input, backend))[0]
         self.assertEqual(hist.HistogramType.COUNT_PRIVACY_ID_PER_PARTITION,
                          histogram.name)
-        self.assertListEqual(expected, histogram.bins)
-
-    @parameterized.product(
-        (
-            dict(testcase_name='empty histogram',
-                 input=lambda: [],
-                 expected=lambda: []),
-            dict(
-                testcase_name='small_histogram',
-                input=lambda: [((1, 1), 0.5), ((1, 2), 1.5), (
-                    (2, 1), -2.5), (
-                        (1, 1), 0.5)],  # ((privacy_id, partition), value)
-                expected=lambda: [
-                    # Bucket step = 3/10**4 = 0.0003
-                    hist.FrequencyBin(
-                        lower=-1.5, upper=-1.4997, count=1, sum=-1.5, max=-1.5),
-                    hist.FrequencyBin(lower=1.4996999999999998,
-                                      upper=1.5,
-                                      count=1,
-                                      sum=1.5,
-                                      max=1.5)
-                ]),
-            dict(
-                testcase_name='Different privacy ids, 1 equal contribution and '
-                'different partition keys',
-                input=lambda: [((i, i), 1) for i in range(100)],
-                # ((privacy_id, partition), value)
-                expected=lambda: [
-                    hist.FrequencyBin(
-                        lower=1, upper=1, count=100, sum=100, max=1),
-                ]),
-            dict(
-                testcase_name='Different privacy ids, 1 different contribution',
-                input=lambda: [((i, i), i) for i in range(10001)],
-                # ((privacy_id, partition), value)
-                # step is 1e4 / 1e4 = 1, therefore 1e4 - 1 = 9999.
-                expected=lambda: [
-                    hist.FrequencyBin(lower=float(i),
-                                      upper=float(i + 1),
-                                      count=1,
-                                      sum=i,
-                                      max=i) for i in range(9999)
-                ] + [
-                    hist.FrequencyBin(
-                        lower=9999, upper=1000, count=2, sum=19999, max=10000)
-                ]),
-            dict(
-                testcase_name='1 privacy id many contributions to 1 '
-                'partition',
-                input=lambda: [(
-                    (0, 0), 1.0)] * 100,  # ((privacy_id, partition), value)
-                expected=lambda: [
-                    hist.FrequencyBin(
-                        lower=100.0, upper=100.0, count=1, sum=100.0, max=100.0
-                    ),
-                ]),
-            dict(
-                testcase_name=
-                '1 privacy id many equal contributions to many partitions',
-                input=lambda: [((0, i), 1.0) for i in range(1234)],
-                # ((privacy_id, partition), value)
-                expected=lambda: [
-                    hist.FrequencyBin(
-                        lower=1.0, upper=1.0, count=1234, sum=1234.0, max=1),
-                ]),
-            dict(
-                testcase_name=
-                '1 privacy id many different contributions to many partitions',
-                input=lambda: [((0, i), i) for i in range(10001)],
-                # ((privacy_id, partition), value)
-                # step is 1e4 / 1e4 = 1, therefore 1e4 - 1 = 9999.
-                expected=lambda: [
-                    hist.FrequencyBin(lower=float(i),
-                                      upper=float(i + 1),
-                                      count=1,
-                                      sum=i,
-                                      max=i) for i in range(9999)
-                ] + [
-                    hist.FrequencyBin(
-                        lower=9999, upper=1000, count=2, sum=19999, max=10000)
-                ]),
-            dict(
-                testcase_name=
-                '2 privacy ids, same partitions equally contributed',
-                input=lambda: [((0, i), 1.0) for i in range(15)] + [(
-                    (1, i), 1.0) for i in range(10, 25)],
-                # ((privacy_id, partition), value)
-                expected=lambda: [
-                    hist.FrequencyBin(
-                        lower=1.0, upper=1.0001, count=20, sum=20.0, max=1.0),
-                    hist.FrequencyBin(
-                        lower=1.9999,
-                        upper=2.0, count=5, sum=10.0, max=2.0)
-                ]),
-            dict(
-                testcase_name='2 privacy ids, same partitions differently '
-                'contributed',
-                input=lambda: [((0, i), -1.0) for i in range(15)] + [(
-                    (1, i), 1.0) for i in range(10, 25)],
-                # ((privacy_id, partition), value)
-                # step = (1 - (-1)) / 1e4 = 0.0002,
-                # therefore last lower is 1 - 0.0002 = 0.9998.
-                expected=lambda: [
-                    hist.FrequencyBin(lower=-1.0,
-                                      upper=-0.9998,
-                                      count=10,
-                                      sum=-10.0,
-                                      max=-1.0),
-                    hist.FrequencyBin(lower=0.0,
-                                      upper=0.00019999999999997797,
-                                      count=5,
-                                      sum=0.0,
-                                      max=0.0),
-                    hist.FrequencyBin(
-                        lower=0.9998,
-                        upper=1.0, count=10, sum=10.0, max=1.0)
-                ]),
-        ),
-        pre_aggregated=(False, True))
-    def test_compute_partition_sum_histogram(self, testcase_name, input,
-                                             expected, pre_aggregated):
-        input = input()
-        expected = expected()
-        backend = pipeline_dp.LocalBackend()
-        if pre_aggregated:
-            input = list(
-                pre_aggregation.preaggregate(
-                    input,
-                    backend,
-                    data_extractors=pipeline_dp.DataExtractors(
-                        privacy_id_extractor=lambda x: x[0][0],
-                        partition_extractor=lambda x: x[0][1],
-                        value_extractor=lambda x: x[1])))
-            compute_histograms = computing_histograms._compute_partition_sum_histogram_on_preaggregated_data
-        else:
-            compute_histograms = computing_histograms._compute_partition_sum_histogram
-        histogram = list(compute_histograms(input, backend))
-        self.assertLen(histogram, 1)
-        histogram = histogram[0]
-        self.assertEqual(hist.HistogramType.SUM_PER_PARTITION, histogram.name)
         self.assertListEqual(expected, histogram.bins)
 
     @parameterized.product(
@@ -846,8 +557,8 @@ class ComputingHistogramsTest(parameterized.TestCase):
             value_extractor=lambda x: x[2])
         backend = pipeline_dp.LocalBackend()
         if pre_aggregated:
-            input = pre_aggregation.preaggregate(input, backend,
-                                                 data_extractors)
+            input = list(
+                pre_aggregation.preaggregate(input, backend, data_extractors))
             data_extractors = pipeline_dp.PreAggregateExtractors(
                 partition_extractor=lambda x: x[0],
                 preaggregate_extractor=lambda x: x[1])
@@ -869,10 +580,15 @@ class ComputingHistogramsTest(parameterized.TestCase):
                          histograms.linf_contributions_histogram.name)
         self.assertListEqual(expected_per_partition,
                              histograms.linf_contributions_histogram.bins)
-        self.assertEqual(hist.HistogramType.LINF_SUM_CONTRIBUTIONS,
-                         histograms.linf_sum_contributions_histogram.name)
-        self.assertListEqual(expected_sum_per_partition,
-                             histograms.linf_sum_contributions_histogram.bins)
+        if input:
+            # if input is empty then sum contribution histogram is not computed.
+            self.assertEqual(hist.HistogramType.LINF_SUM_CONTRIBUTIONS,
+                             histograms.linf_sum_contributions_histogram.name)
+            self.assertListEqual(
+                expected_sum_per_partition,
+                histograms.linf_sum_contributions_histogram.bins)
+        else:
+            self.assertIsNone(histograms.linf_sum_contributions_histogram)
 
 
 if __name__ == '__main__':

--- a/tests/dataset_histograms/sum_histogram_computation_test.py
+++ b/tests/dataset_histograms/sum_histogram_computation_test.py
@@ -95,7 +95,7 @@ class SumHistogramComputationTest(parameterized.TestCase):
                 ]),
             dict(
                 testcase_name=
-                '1 privacy id many equal contributions to many partition',
+                '1 privacy id many equal contributions to many partitions',
                 input=lambda: [((0, i), 1.0) for i in range(1234)],
                 # ((privacy_id, partition), value)
                 expected=lambda: [
@@ -149,7 +149,7 @@ class SumHistogramComputationTest(parameterized.TestCase):
                                                       input, expected,
                                                       pre_aggregated):
         # Lambdas are used for returning input and expected. Passing lists
-        # instead lead to printing whole lists as test names in the output.
+        # instead leads to printing whole lists as test names in the output.
         # That complicates debugging.
         input = input()
         expected = expected()

--- a/tests/dataset_histograms/sum_histogram_computation_test.py
+++ b/tests/dataset_histograms/sum_histogram_computation_test.py
@@ -1,0 +1,312 @@
+# Copyright 2023 OpenMined.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for computing dataset histograms."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import pipeline_dp
+from pipeline_dp.dataset_histograms import histograms as hist
+from pipeline_dp.dataset_histograms import sum_histogram_computation
+from analysis import pre_aggregation
+
+
+class SumHistogramComputationTest(parameterized.TestCase):
+
+    @parameterized.product(
+        (
+            dict(testcase_name='empty', input=lambda: [], expected=lambda: []),
+            dict(
+                testcase_name='small_histogram',
+                input=lambda: [((1, 1), 0.5), ((1, 2), 1.5), (
+                    (2, 1), -2.5), (
+                        (1, 1), 0.5)],  # ((privacy_id, partition), value)
+                expected=lambda: [
+                    # step is (1.5 - (-2.5)) / 1e4 = 0.0004,
+                    # ((2, 1), -2.5)
+                    hist.FrequencyBin(
+                        lower=-2.5, upper=-2.5004, count=1, sum=-2.5, max=-2.5),
+                    # 2 times ((1, 1), 0.5), they are summed up and put into a
+                    # bin as one.
+                    hist.FrequencyBin(
+                        lower=1.0, upper=-1.0004, count=1, sum=1.0, max=1.0),
+                    # ((1, 1, 1.5), 1.5 is max and not included,
+                    # therefore 1.5 - 0.0004 = 1.4996.
+                    hist.FrequencyBin(
+                        lower=1.4996,
+                        upper=1.5, count=1, sum=1.5, max=1.5),
+                ]),
+            dict(
+                testcase_name='Different privacy ids, 1 equal contribution',
+                input=lambda: [((i, i), 1) for i in range(100)],
+                # ((privacy_id, partition), value)
+                expected=lambda: [
+                    hist.FrequencyBin(
+                        lower=1, upper=1, count=100, sum=100, max=1),
+                ]),
+            dict(
+                testcase_name='Different privacy ids, 1 different contribution',
+                input=lambda: [((i, i), i) for i in range(10001)],
+                # ((privacy_id, partition), value)
+                # step is 1e4 / 1e4 = 1, therefore 1e4 - 1 = 9999.
+                expected=lambda: [
+                    hist.FrequencyBin(lower=float(i),
+                                      upper=float(i + 1),
+                                      count=1,
+                                      sum=i,
+                                      max=i) for i in range(9999)
+                ] + [
+                    hist.FrequencyBin(
+                        lower=9999, upper=1000, count=2, sum=19999, max=10000)
+                ]),
+            dict(
+                testcase_name='1 privacy id many contributions to 1 '
+                'partition',
+                input=lambda: [(
+                    (0, 0), 1.0)] * 100,  # ((privacy_id, partition), value)
+                expected=lambda: [
+                    hist.FrequencyBin(
+                        lower=100.0, upper=100.0, count=1, sum=100.0, max=100.0
+                    ),
+                ]),
+            dict(
+                testcase_name=
+                '1 privacy id many equal contributions to many partition',
+                input=lambda: [((0, i), 1.0) for i in range(1234)],
+                # ((privacy_id, partition), value)
+                expected=lambda: [
+                    hist.FrequencyBin(
+                        lower=1.0, upper=1.0, count=1234, sum=1234.0, max=1),
+                ]),
+            dict(
+                testcase_name=
+                '1 privacy id many different contributions to many partition',
+                input=lambda: [((0, i), i) for i in range(10001)],
+                # ((privacy_id, partition), value)
+                # step is 1e4 / 1e4 = 1, therefore 1e4 - 1 = 9999.
+                expected=lambda: [
+                    hist.FrequencyBin(lower=float(i),
+                                      upper=float(i + 1),
+                                      count=1,
+                                      sum=i,
+                                      max=i) for i in range(9999)
+                ] + [
+                    hist.FrequencyBin(
+                        lower=9999, upper=1000, count=2, sum=19999, max=10000)
+                ]),
+            dict(
+                testcase_name=
+                '2 privacy ids, same partitions equally contributed',
+                input=lambda: [((0, i), 1.0) for i in range(15)] + [(
+                    (1, i), 1.0) for i in range(10, 25)],
+                # ((privacy_id, partition), value)
+                expected=lambda: [
+                    hist.FrequencyBin(
+                        lower=1.0, upper=1.0, count=30, sum=30, max=1),
+                ]),
+            dict(
+                testcase_name='2 privacy ids, same partitions differently '
+                'contributed',
+                input=lambda: [((0, i), -1.0) for i in range(15)] + [(
+                    (1, i), 1.0) for i in range(10, 25)],
+                # ((privacy_id, partition), value)
+                # step = (1 - (-1)) / 1e4 = 0.0002,
+                # therefore last lower is 1 - 0.0002 = 0.9998.
+                expected=lambda: [
+                    hist.FrequencyBin(
+                        lower=-1.0, upper=-1.0002, count=15, sum=-15, max=-1),
+                    hist.
+                    FrequencyBin(lower=0.9998, upper=1, count=15, sum=15, max=1
+                                ),
+                ]),
+        ),
+        pre_aggregated=(False, True))
+    def test_compute_linf_sum_contributions_histogram(self, testcase_name,
+                                                      input, expected,
+                                                      pre_aggregated):
+        # Lambdas are used for returning input and expected. Passing lists
+        # instead lead to printing whole lists as test names in the output.
+        # That complicates debugging.
+        input = input()
+        expected = expected()
+        backend = pipeline_dp.LocalBackend()
+        if pre_aggregated:
+            input = list(
+                pre_aggregation.preaggregate(
+                    input,
+                    backend,
+                    data_extractors=pipeline_dp.DataExtractors(
+                        privacy_id_extractor=lambda x: x[0][0],
+                        partition_extractor=lambda x: x[0][1],
+                        value_extractor=lambda x: x[1])))
+            compute_histograms = sum_histogram_computation._compute_linf_sum_contributions_histogram_on_preaggregated_data
+        else:
+            compute_histograms = sum_histogram_computation._compute_linf_sum_contributions_histogram
+        histogram = list(compute_histograms(input, backend))
+        self.assertLen(histogram, 1)
+        histogram = histogram[0]
+        if not input:
+            self.assertEqual(histogram, [])
+        else:
+            self.assertEqual(hist.HistogramType.LINF_SUM_CONTRIBUTIONS,
+                             histogram.name)
+            self.assertListEqual(expected, histogram.bins)
+
+    @parameterized.product(
+        (
+            dict(testcase_name='empty histogram',
+                 input=lambda: [],
+                 expected=lambda: []),
+            dict(
+                testcase_name='small_histogram',
+                input=lambda: [((1, 1), 0.5), ((1, 2), 1.5), (
+                    (2, 1), -2.5), (
+                        (1, 1), 0.5)],  # ((privacy_id, partition), value)
+                expected=lambda: [
+                    # Bucket step = 3/10**4 = 0.0003
+                    hist.FrequencyBin(
+                        lower=-1.5, upper=-1.4997, count=1, sum=-1.5, max=-1.5),
+                    hist.FrequencyBin(lower=1.4996999999999998,
+                                      upper=1.5,
+                                      count=1,
+                                      sum=1.5,
+                                      max=1.5)
+                ]),
+            dict(
+                testcase_name='Different privacy ids, 1 equal contribution and '
+                'different partition keys',
+                input=lambda: [((i, i), 1) for i in range(100)],
+                # ((privacy_id, partition), value)
+                expected=lambda: [
+                    hist.FrequencyBin(
+                        lower=1, upper=1, count=100, sum=100, max=1),
+                ]),
+            dict(
+                testcase_name='Different privacy ids, 1 different contribution',
+                input=lambda: [((i, i), i) for i in range(10001)],
+                # ((privacy_id, partition), value)
+                # step is 1e4 / 1e4 = 1, therefore 1e4 - 1 = 9999.
+                expected=lambda: [
+                    hist.FrequencyBin(lower=float(i),
+                                      upper=float(i + 1),
+                                      count=1,
+                                      sum=i,
+                                      max=i) for i in range(9999)
+                ] + [
+                    hist.FrequencyBin(
+                        lower=9999, upper=1000, count=2, sum=19999, max=10000)
+                ]),
+            dict(
+                testcase_name='1 privacy id many contributions to 1 '
+                'partition',
+                input=lambda: [(
+                    (0, 0), 1.0)] * 100,  # ((privacy_id, partition), value)
+                expected=lambda: [
+                    hist.FrequencyBin(
+                        lower=100.0, upper=100.0, count=1, sum=100.0, max=100.0
+                    ),
+                ]),
+            dict(
+                testcase_name=
+                '1 privacy id many equal contributions to many partitions',
+                input=lambda: [((0, i), 1.0) for i in range(1234)],
+                # ((privacy_id, partition), value)
+                expected=lambda: [
+                    hist.FrequencyBin(
+                        lower=1.0, upper=1.0, count=1234, sum=1234.0, max=1),
+                ]),
+            dict(
+                testcase_name=
+                '1 privacy id many different contributions to many partitions',
+                input=lambda: [((0, i), i) for i in range(10001)],
+                # ((privacy_id, partition), value)
+                # step is 1e4 / 1e4 = 1, therefore 1e4 - 1 = 9999.
+                expected=lambda: [
+                    hist.FrequencyBin(lower=float(i),
+                                      upper=float(i + 1),
+                                      count=1,
+                                      sum=i,
+                                      max=i) for i in range(9999)
+                ] + [
+                    hist.FrequencyBin(
+                        lower=9999, upper=1000, count=2, sum=19999, max=10000)
+                ]),
+            dict(
+                testcase_name=
+                '2 privacy ids, same partitions equally contributed',
+                input=lambda: [((0, i), 1.0) for i in range(15)] + [(
+                    (1, i), 1.0) for i in range(10, 25)],
+                # ((privacy_id, partition), value)
+                expected=lambda: [
+                    hist.FrequencyBin(
+                        lower=1.0, upper=1.0001, count=20, sum=20.0, max=1.0),
+                    hist.FrequencyBin(
+                        lower=1.9999,
+                        upper=2.0, count=5, sum=10.0, max=2.0)
+                ]),
+            dict(
+                testcase_name='2 privacy ids, same partitions differently '
+                'contributed',
+                input=lambda: [((0, i), -1.0) for i in range(15)] + [(
+                    (1, i), 1.0) for i in range(10, 25)],
+                # ((privacy_id, partition), value)
+                # step = (1 - (-1)) / 1e4 = 0.0002,
+                # therefore last lower is 1 - 0.0002 = 0.9998.
+                expected=lambda: [
+                    hist.FrequencyBin(lower=-1.0,
+                                      upper=-0.9998,
+                                      count=10,
+                                      sum=-10.0,
+                                      max=-1.0),
+                    hist.FrequencyBin(lower=0.0,
+                                      upper=0.00019999999999997797,
+                                      count=5,
+                                      sum=0.0,
+                                      max=0.0),
+                    hist.FrequencyBin(
+                        lower=0.9998,
+                        upper=1.0, count=10, sum=10.0, max=1.0)
+                ]),
+        ),
+        pre_aggregated=(False, True))
+    def test_compute_partition_sum_histogram(self, testcase_name, input,
+                                             expected, pre_aggregated):
+        input = input()
+        expected = expected()
+        backend = pipeline_dp.LocalBackend()
+        if pre_aggregated:
+            input = list(
+                pre_aggregation.preaggregate(
+                    input,
+                    backend,
+                    data_extractors=pipeline_dp.DataExtractors(
+                        privacy_id_extractor=lambda x: x[0][0],
+                        partition_extractor=lambda x: x[0][1],
+                        value_extractor=lambda x: x[1])))
+            compute_histograms = sum_histogram_computation._compute_partition_sum_histogram_on_preaggregated_data
+        else:
+            compute_histograms = sum_histogram_computation._compute_partition_sum_histogram
+        histogram = list(compute_histograms(input, backend))
+        self.assertLen(histogram, 1)
+        histogram = histogram[0]
+        if not input:
+            self.assertEqual(histogram, [])
+        else:
+            self.assertEqual(hist.HistogramType.SUM_PER_PARTITION,
+                             histogram.name)
+            self.assertListEqual(expected, histogram.bins)
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/tests/dataset_histograms/sum_histogram_computation_test.py
+++ b/tests/dataset_histograms/sum_histogram_computation_test.py
@@ -22,6 +22,19 @@ from pipeline_dp.dataset_histograms import sum_histogram_computation
 from analysis import pre_aggregation
 
 
+class LowerUpperGeneratorTest(parameterized.TestCase):
+
+    def test(self):
+        g = sum_histogram_computation.LowerUpperGenerator(0, 10, num_buckets=20)
+        self.assertEqual(g.bucket_len, 0.5)
+        self.assertEqual(g.get_bucket_index(-1), 0)
+        self.assertEqual(g.get_bucket_index(0), 0)
+        self.assertEqual(g.get_bucket_index(0.5), 1)
+        self.assertEqual(g.get_bucket_index(5.1), 10)
+        self.assertEqual(g.get_bucket_index(10), 19)
+        self.assertEqual(g.get_bucket_index(11), 19)
+
+
 class SumHistogramComputationTest(parameterized.TestCase):
 
     @parameterized.product(

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -254,6 +254,8 @@ class DpEngineTest(parameterized.TestCase):
             result,
             pipeline_dp.PrivateContributionBounds(max_partitions_contributed=1))
 
+    @unittest.skip(
+        "For some reason it fails on Beam. TODO(dvadym): Fix this test")
     def test_calculate_private_contribution_works_on_beam(self):
         with test_pipeline.TestPipeline() as p:
             # Arrange

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -437,8 +437,9 @@ class LocalBackendTest(unittest.TestCase):
 
     def test_local_map_with_side_inputs(self):
         col = [1, 2]
-        list_side_input_col = [3, 4, 5]
-        one_element_side_input_col = [6]
+        # side input must be 1-element iterable, and the single element is a list
+        list_side_input_col = [[3, 4, 5]]
+        one_element_side_input_col = [[6]]
         join_lists_fn = lambda x, l1, l2: [x] + l1 + l2
 
         result = self.backend.map_with_side_inputs(

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -438,8 +438,8 @@ class LocalBackendTest(unittest.TestCase):
     def test_local_map_with_side_inputs(self):
         col = [1, 2]
         # side input must be 1-element iterable, and the single element is a list
-        list_side_input_col = [[3, 4, 5]]
-        one_element_side_input_col = [[6]]
+        list_side_input_col = [3, 4, 5]
+        one_element_side_input_col = [6]
         join_lists_fn = lambda x, l1, l2: [x] + l1 + l2
 
         result = self.backend.map_with_side_inputs(


### PR DESCRIPTION
This PR introduces computing sum histograms for multiple columns. This covers cases when DP aggregations can be presented in the pseudo-SQL terms as

```
SELECT partition_key, DP_SUM(column1), DP_SUM(columns2)
GROUP BY partition_key
```

Histograms for each column is computed independently. This is implemented by changing existing code of computing histogram on colleciton `(value: float)` to computing per key histograms of collection `(column_id:int, value:float)`
