### PR TITLE
Tuning for multiple columns part 2: Find candidate parameters for multiple aggregation

### DIFF
--- a/analysis/data_structures.py
+++ b/analysis/data_structures.py
@@ -47,8 +47,10 @@ class MultiParameterConfiguration:
     """
     max_partitions_contributed: Sequence[int] = None
     max_contributions_per_partition: Sequence[int] = None
-    min_sum_per_partition: Sequence[float] = None
-    max_sum_per_partition: Sequence[float] = None
+    min_sum_per_partition: Union[Sequence[float],
+                                 Sequence[Sequence[float]]] = None
+    max_sum_per_partition: Union[Sequence[float],
+                                 Sequence[Sequence[float]]] = None
     noise_kind: Sequence[pipeline_dp.NoiseKind] = None
     partition_selection_strategy: Sequence[
         pipeline_dp.PartitionSelectionStrategy] = None

--- a/analysis/dp_strategy_selector.py
+++ b/analysis/dp_strategy_selector.py
@@ -68,7 +68,7 @@ class DPStrategySelector:
             return self._get_strategy_for_select_partition(sensitivities.l0)
 
         n_metrics = len(self._metrics)
-        # Having n metrics is equivalent of multiplying of contributing for
+        # Having n metrics is equivalent to multiplying of contributing for
         # n times more partitions
         scaled_sensitivities = dp_computations.Sensitivities(
             l0=sensitivities.l0 * n_metrics, linf=sensitivities.linf)

--- a/analysis/dp_strategy_selector.py
+++ b/analysis/dp_strategy_selector.py
@@ -14,7 +14,7 @@
 """Choosing DP Strategy (i.e. noise_kind, partition selection strategy etc)
 based on contribution bounding params."""
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 import pipeline_dp
 from pipeline_dp import aggregate_params
@@ -41,8 +41,7 @@ class DPStrategySelector:
     """
 
     def __init__(self, epsilon: float, delta: float,
-                 metric: Optional[pipeline_dp.Metric],
-                 is_public_partitions: bool):
+                 metrics: List[pipeline_dp.Metric], is_public_partitions: bool):
         input_validators.validate_epsilon_delta(epsilon, delta,
                                                 "DPStrategySelector")
         if delta == 0 and not is_public_partitions:
@@ -50,7 +49,7 @@ class DPStrategySelector:
                              "selection is used, delta must be positive")
         self._epsilon = epsilon
         self._delta = delta
-        self._metric = metric
+        self._metrics = metrics
         self._is_public_partitions = is_public_partitions
 
     @property
@@ -59,20 +58,26 @@ class DPStrategySelector:
 
     @property
     def metric(self) -> Optional[pipeline_dp.Metric]:
-        return self._metric
+        return self._metrics
 
     def get_dp_strategy(
             self, sensitivities: dp_computations.Sensitivities) -> DPStrategy:
         """Chooses DPStrategy for given sensitivities."""
-        if self._metric is None:
+        if self._metrics is None or not self._metrics:
             # This is Select partitions case.
             return self._get_strategy_for_select_partition(sensitivities.l0)
+
+        # todo: add comment
+        n_metrics = len(self._metrics)
+        scaled_sensitivities = dp_computations.Sensitivities(
+            l0=sensitivities.l0, linf=n_metrics * sensitivities.linf)
         if self._is_public_partitions:
-            return self._get_dp_strategy_for_public_partitions(sensitivities)
-        if self.use_post_aggregation_thresholding(self._metric):
+            return self._get_dp_strategy_for_public_partitions(
+                scaled_sensitivities)
+        if self.use_post_aggregation_thresholding(self._metrics):
             return self._get_dp_strategy_with_post_aggregation_threshold(
-                sensitivities.l0)
-        return self._get_dp_strategy_private_partition(sensitivities)
+                scaled_sensitivities.l0)
+        return self._get_dp_strategy_private_partition(scaled_sensitivities)
 
     def _get_strategy_for_select_partition(self,
                                            l0_sensitivity: int) -> DPStrategy:
@@ -92,7 +97,7 @@ class DPStrategySelector:
 
     def _get_dp_strategy_with_post_aggregation_threshold(
             self, l0_sensitivity: int) -> DPStrategy:
-        assert self._metric == pipeline_dp.Metrics.PRIVACY_ID_COUNT
+        assert self._metrics == pipeline_dp.Metrics.PRIVACY_ID_COUNT
         # Half delta goes to the noise, the other half for partition selection.
         # For more details see
         # https://github.com/google/differential-privacy/blob/main/common_docs/Delta_For_Thresholding.pdf
@@ -144,9 +149,9 @@ class DPStrategySelector:
             return pipeline_dp.NoiseKind.GAUSSIAN
         return pipeline_dp.NoiseKind.LAPLACE
 
-    def use_post_aggregation_thresholding(self,
-                                          metric: pipeline_dp.Metric) -> bool:
-        return metric == pipeline_dp.Metrics.PRIVACY_ID_COUNT
+    def use_post_aggregation_thresholding(
+            self, metrics: List[pipeline_dp.Metric]) -> bool:
+        return pipeline_dp.Metrics.PRIVACY_ID_COUNT in metrics
 
     def select_partition_selection_strategy(
             self, epsilon: float, delta: float,
@@ -191,6 +196,5 @@ class DPStrategySelector:
 class DPStrategySelectorFactory:
 
     def create(self, epsilon: float, delta: float,
-               metric: Optional[pipeline_dp.Metric],
-               is_public_partitions: bool):
-        return DPStrategySelector(epsilon, delta, metric, is_public_partitions)
+               metrics: List[pipeline_dp.Metric], is_public_partitions: bool):
+        return DPStrategySelector(epsilon, delta, metrics, is_public_partitions)

--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -120,68 +120,114 @@ class TuneResult:
 def _find_candidate_parameters(
         hist: histograms.DatasetHistograms,
         parameters_to_tune: ParametersToTune,
-        metric: Optional[pipeline_dp.Metric],
+        aggregate_params: pipeline_dp.AggregateParams,
         max_candidates: int) -> analysis.MultiParameterConfiguration:
     """Finds candidates for l0, l_inf and max_sum_per_partition_bounds parameters.
 
     Args:
+        aggregate_params: parameters of aggregation.
         hist: dataset contribution histogram.
         parameters_to_tune: which parameters to tune.
-        metric: dp aggregation for which candidates are computed. If metric is
-          None, it means no metrics to compute, i.e. only select partitions.
         max_candidates: how many candidates ((l0, linf) pairs) can be in the
           output. Note that output can contain fewer candidates. 100 is default
           heuristically chosen value, better to adjust it for your use-case.
     """
-    calculate_l0_param = parameters_to_tune.max_partitions_contributed
-    generate_linf_count = metric == pipeline_dp.Metrics.COUNT
-    generate_max_sum_per_partition = metric == pipeline_dp.Metrics.SUM
-    calculate_linf_count = (parameters_to_tune.max_contributions_per_partition
-                            and generate_linf_count)
-    calculate_sum_per_partition_param = (
-        parameters_to_tune.max_sum_per_partition and
-        generate_max_sum_per_partition)
-    l0_bounds = linf_bounds = None
-    max_sum_per_partition_bounds = min_sum_per_partition_bounds = None
+    # L0 bounds
+    tune_l0 = parameters_to_tune.max_partitions_contributed
+    metrics = aggregate_params.metrics
+    tune_count_linf = (parameters_to_tune.max_contributions_per_partition and
+                       pipeline_dp.Metrics.COUNT in metrics)
+    tune_sum_linf = (parameters_to_tune.max_sum_per_partition and
+                     pipeline_dp.Metrics.SUM in metrics)
 
-    if calculate_sum_per_partition_param:
-        if hist.linf_sum_contributions_histogram.bins[0].lower < 0:
-            logging.warning(
-                "max_sum_per_partition should not contain negative sums because"
-                " min_sum_per_partition tuning is not supported yet and "
-                "therefore tuning for max_sum_per_partition works only when "
-                "linf_sum_contributions_histogram does not negative sums")
-
-    if calculate_l0_param and calculate_linf_count:
-        l0_bounds, linf_bounds = _find_candidates_parameters_in_2d_grid(
-            hist.l0_contributions_histogram, hist.linf_contributions_histogram,
-            _find_candidates_constant_relative_step,
-            _find_candidates_constant_relative_step, max_candidates)
-    elif calculate_l0_param and calculate_sum_per_partition_param:
-        l0_bounds, max_sum_per_partition_bounds = _find_candidates_parameters_in_2d_grid(
-            hist.l0_contributions_histogram,
-            hist.linf_sum_contributions_histogram,
-            _find_candidates_constant_relative_step,
-            _find_candidates_bins_max_values_subsample, max_candidates)
-        min_sum_per_partition_bounds = [0] * len(max_sum_per_partition_bounds)
-    elif calculate_l0_param:
+    # Find L0 candidates (i.e. max_partitions_contributed)
+    if tune_l0:
+        if tune_count_linf or tune_sum_linf:
+            max_l0_candidates = int(np.sqrt(max_candidates))
+        else:
+            max_l0_candidates = max_candidates
         l0_bounds = _find_candidates_constant_relative_step(
-            hist.l0_contributions_histogram, max_candidates)
-    elif calculate_linf_count:
-        linf_bounds = _find_candidates_constant_relative_step(
-            hist.linf_contributions_histogram, max_candidates)
-    elif calculate_sum_per_partition_param:
-        max_sum_per_partition_bounds = _find_candidates_bins_max_values_subsample(
-            hist.linf_sum_contributions_histogram, max_candidates)
-        min_sum_per_partition_bounds = [0] * len(max_sum_per_partition_bounds)
-    else:
-        assert False, "Nothing to tune."
+            hist.l0_contributions_histogram, max_l0_candidates)
+    else:  # no l0 tuning
+        l0 = aggregate_params.max_partitions_contributed
+        l0_bounds = [l0] if l0 else [1]
 
+    max_linf_candidates = max_candidates // len(l0_bounds)
+
+    # Find Linf count candidates (i.e. max_contributions_per_partition)
+    linf_count_bounds = None
+    if tune_count_linf:
+        linf_count_bounds = _find_candidates_constant_relative_step(
+            hist.linf_contributions_histogram, max_linf_candidates)
+
+    linf_sum_bounds = None
+    if tune_sum_linf:
+        n_sum_columns = hist.num_sum_histograms()
+        linf_sum_bounds = []
+        if n_sum_columns == 1:
+            linf_sum_bounds.append(
+                _find_candidates_bins_max_values_subsample(
+                    hist.linf_sum_contributions_histogram, max_linf_candidates))
+            # min_sum_per_partition_bounds = [0] * len(max_sum_per_partition_bounds)
+        else:  # n_sums > 1
+            for i in range(n_sum_columns):
+                linf_sum_bounds.append(
+                    _find_candidates_bins_max_values_subsample(
+                        hist.linf_sum_contributions_histogram[i],
+                        max_linf_candidates))
+
+    # Linf COUNT and SUM bounds can have different number of elements, for
+    # running Utility Analysis it is required have same amount of them.
+    # Let us do padding with 0-th element.
+    max_linf_size = None
+    if linf_count_bounds is not None and linf_sum_bounds is not None:
+        max_linf_size = max(len(linf_count_bounds),
+                            max(map(len, linf_sum_bounds)))
+
+        def pad_list(a: list | None, size: int):
+            if a is not None and len(a) < size:
+                a.extend([a[0]] * (size - len(a)))
+
+        pad_list(linf_count_bounds, max_linf_size)
+        for a in linf_sum_bounds:
+            pad_list(a, max_linf_size)
+
+    min_sum_per_partition = max_sum_per_partition = None
+    if tune_sum_linf:
+        n_sum_columns = hist.num_sum_histograms()
+        if n_sum_columns == 1:
+            max_sum_per_partition = linf_sum_bounds[0]
+            min_sum_per_partition = [0] * len(max_sum_per_partition)
+        else:  # > 1
+            max_sum_per_partition = list(zip(*linf_sum_bounds))
+            min_sum_per_partition = [
+                (0,) * n_sum_columns for _ in range(len(max_sum_per_partition))
+            ]
+
+    l0_duplication = 1 if max_linf_size is None else max_linf_size
+    linf_duplication = 1 if l0_bounds is None else len(l0_bounds)
     return analysis.MultiParameterConfiguration(
-        max_partitions_contributed=l0_bounds,
-        max_contributions_per_partition=linf_bounds,
-        min_sum_per_partition=min_sum_per_partition_bounds,
-        max_sum_per_partition=max_sum_per_partition_bounds)
+        max_partitions_contributed=_duplicate_each_element(
+            l0_bounds, l0_duplication),
+        max_contributions_per_partition=_duplicate_list(linf_count_bounds,
+                                                        linf_duplication),
+        min_sum_per_partition=_duplicate_list(min_sum_per_partition,
+                                              linf_duplication),
+        max_sum_per_partition=_duplicate_list(max_sum_per_partition,
+                                              linf_duplication),
+    )
+
+
+def _duplicate_each_element(a: list | None, n: int) -> list | None:
+    if a is None:
+        return None
+    return [x for x in a for _ in range(n)]
+
+
+def _duplicate_list(a: list | None, n: int) -> list | None:
+    if a is None:
+        return None
+    return a * n
 
 
 def _add_dp_strategy_to_multi_parameter_configuration(
@@ -205,7 +251,10 @@ def _add_dp_strategy_to_multi_parameter_configuration(
             sensitivities = dp_computations.Sensitivities(
                 param.max_partitions_contributed, 1)
         else:
-            sensitivities = dp_computations.compute_sensitivities(metric, param)
+            # sensitivities = dp_computations.compute_sensitivities(metric, param)
+            # todo: add comment
+            sensitivities = dp_computations.Sensitivities(
+                param.max_partitions_contributed, 1)
         dp_strategy = strategy_selector.get_dp_strategy(sensitivities)
         if noise_kind is None:
             configuration.noise_kind.append(dp_strategy.noise_kind)
@@ -214,60 +263,6 @@ def _add_dp_strategy_to_multi_parameter_configuration(
         if find_partition_selection:
             configuration.partition_selection_strategy.append(
                 dp_strategy.partition_selection_strategy)
-
-
-def _find_candidates_parameters_in_2d_grid(
-        hist1: histograms.Histogram, hist2: histograms.Histogram,
-        find_candidates_func1: Callable[[histograms.Histogram, int],
-                                        Sequence[Number]],
-        find_candidates_func2: Callable[[histograms.Histogram, int],
-                                        Sequence[Number]],
-        max_candidates: int) -> Tuple[Sequence[Number], Sequence[Number]]:
-    """Finds candidates for 2 parameters.
-
-    If we have 2 parameters to tune, then candidates for them form a 2
-    dimensional grid. If for one parameter there is less than
-    sqrt(max_candidates) candidates, we can add more candidates for the other
-    parameter. This function implements this logic.
-
-    Args:
-        hist1: histogram of the distribution of the first parameter.
-        hist2: histogram of the distribution of the second parameter.
-        find_candidates_func1: function that given hist1 and maximum of
-          candidates finds the candidates.
-        find_candidates_func2: function that given hist2 and maximum of
-          candidates finds the candidates.
-        max_candidates: maximum number of the candidates to produce.
-    Returns:
-        Two sequences which represent pairs of candidates for parameters 1 and
-          2. Sequences are of the same length and their lengths do not exceed
-          max_candidates.
-    """
-
-    max_candidates_per_parameter = int(math.sqrt(max_candidates))
-    param1_candidates = find_candidates_func1(hist1,
-                                              max_candidates_per_parameter)
-    param2_candidates = find_candidates_func2(hist2,
-                                              max_candidates_per_parameter)
-    param1_bounds, param2_bounds = [], []
-
-    # if param1 or param2 has fewer candidates than requested then we can add
-    # more candidates for the other parameter.
-    if (len(param2_candidates) < max_candidates_per_parameter and
-            len(param1_candidates) == max_candidates_per_parameter):
-        param1_candidates = find_candidates_func1(
-            hist1, int(max_candidates / len(param2_candidates)))
-    elif (len(param1_candidates) < max_candidates_per_parameter and
-          len(param2_candidates) == max_candidates_per_parameter):
-        param2_candidates = find_candidates_func2(
-            hist2, int(max_candidates / len(param1_candidates)))
-
-    for param1 in param1_candidates:
-        for param2 in param2_candidates:
-            param1_bounds.append(param1)
-            param2_bounds.append(param2)
-
-    return param1_bounds, param2_bounds
 
 
 def _find_candidates_constant_relative_step(histogram: histograms.Histogram,
@@ -360,23 +355,24 @@ def tune(col,
         strategy_selector_factory = dp_strategy_selector.DPStrategySelectorFactory(
         )
 
-    metric = None
-    if options.aggregate_params.metrics:
-        metric = options.aggregate_params.metrics[0]
-
-    candidates: analysis.MultiParameterConfiguration = _find_candidate_parameters(
-        contribution_histograms, options.parameters_to_tune, metric,
-        options.number_of_parameter_candidates)
+    candidates: analysis.MultiParameterConfiguration = (
+        _find_candidate_parameters(
+            hist=contribution_histograms,
+            parameters_to_tune=options.parameters_to_tune,
+            aggregate_params=options.aggregate_params,
+            max_candidates=options.number_of_parameter_candidates,
+        ))
 
     # Add DP strategy (noise_kind, partition_selection_strategy) to multi
     # parameter configuration.
     noise_kind = None
     if not options.parameters_to_tune.noise_kind:
         noise_kind = options.aggregate_params.noise_kind
+
     strategy_selector = strategy_selector_factory.create(
         options.epsilon,
         options.delta,
-        metric,
+        metrics=options.aggregate_params.metrics,
         is_public_partitions=public_partitions is not None)
     _add_dp_strategy_to_multi_parameter_configuration(candidates,
                                                       options.aggregate_params,

--- a/analysis/tests/dp_strategy_selector_test.py
+++ b/analysis/tests/dp_strategy_selector_test.py
@@ -28,7 +28,7 @@ class DPStrategySelectorTest(parameterized.TestCase):
         dict(testcase_name="count",
              epsilon=1,
              delta=1e-10,
-             metric=pipeline_dp.Metrics.COUNT,
+             metrics=[pipeline_dp.Metrics.COUNT],
              l0s=[1, 10, 10, 20, 100],
              linfs=[1, 1, 10, 1, 5],
              expected_noise_kinds=[pipeline_dp.NoiseKind.LAPLACE] * 3 +
@@ -36,18 +36,28 @@ class DPStrategySelectorTest(parameterized.TestCase):
         dict(testcase_name="sum",
              epsilon=0.1,
              delta=1e-5,
-             metric=pipeline_dp.Metrics.SUM,
+             metrics=[pipeline_dp.Metrics.SUM],
              l0s=[1, 2, 3, 6],
              linfs=[1, 2, 1, 1],
              expected_noise_kinds=[pipeline_dp.NoiseKind.LAPLACE] * 3 +
              [pipeline_dp.NoiseKind.GAUSSIAN]),
+        dict(testcase_name="count_privacy_id_count",
+             epsilon=0.1,
+             delta=1e-5,
+             metrics=[
+                 pipeline_dp.Metrics.PRIVACY_ID_COUNT, pipeline_dp.Metrics.SUM
+             ],
+             l0s=[1, 2, 3, 6],
+             linfs=[1, 1, 1, 1],
+             expected_noise_kinds=[pipeline_dp.NoiseKind.LAPLACE] * 2 +
+             [pipeline_dp.NoiseKind.GAUSSIAN] * 2),
     )
     def test_selection_for_public_partitions(
-            self, epsilon: float, delta: float, metric: pipeline_dp.Metric,
+            self, epsilon: float, delta: float, metrics: pipeline_dp.Metric,
             l0s: List[int], linfs: List[int],
             expected_noise_kinds: List[pipeline_dp.NoiseKind]):
         selector = dp_strategy_selector.DPStrategySelector(
-            epsilon, delta, metric, is_public_partitions=True)
+            epsilon, delta, metrics, is_public_partitions=True)
         for i in range(len(l0s)):
             sensitivities = dp_computations.Sensitivities(l0s[i], linfs[i])
             output = selector.get_dp_strategy(sensitivities)
@@ -60,7 +70,7 @@ class DPStrategySelectorTest(parameterized.TestCase):
             testcase_name="count",
             epsilon=1,
             delta=1e-8,
-            metric=pipeline_dp.Metrics.COUNT,
+            metrics=[pipeline_dp.Metrics.COUNT],
             l0s=[1, 2, 3, 20, 100],
             linfs=[1, 1, 10, 1, 5],
             expected_noise_kinds=[pipeline_dp.NoiseKind.LAPLACE] * 3 +
@@ -72,7 +82,7 @@ class DPStrategySelectorTest(parameterized.TestCase):
         dict(testcase_name="sum",
              epsilon=0.1,
              delta=1e-3,
-             metric=pipeline_dp.Metrics.COUNT,
+             metrics=[pipeline_dp.Metrics.COUNT],
              l0s=[1, 2, 5],
              linfs=[1, 1, 10],
              expected_noise_kinds=[pipeline_dp.NoiseKind.LAPLACE] +
@@ -82,13 +92,13 @@ class DPStrategySelectorTest(parameterized.TestCase):
              ] * 3),
     )
     def test_selection_for_private_partitions_wo_post_aggregation_thresholding(
-        self, epsilon: float, delta: float, metric: pipeline_dp.Metric,
+        self, epsilon: float, delta: float, metrics: pipeline_dp.Metric,
         l0s: List[int], linfs: List[int],
         expected_noise_kinds: List[pipeline_dp.NoiseKind],
         expected_partition_selection_strategies: List[
             pipeline_dp.PartitionSelectionStrategy]):
         selector = dp_strategy_selector.DPStrategySelector(
-            epsilon, delta, metric, is_public_partitions=False)
+            epsilon, delta, metrics, is_public_partitions=False)
         for i in range(len(l0s)):
             sensitivities = dp_computations.Sensitivities(l0s[i], linfs[i])
             output = selector.get_dp_strategy(sensitivities)
@@ -120,7 +130,7 @@ class DPStrategySelectorTest(parameterized.TestCase):
         selector = dp_strategy_selector.DPStrategySelector(
             epsilon=2,
             delta=1e-12,
-            metric=pipeline_dp.Metrics.PRIVACY_ID_COUNT,
+            metrics=[pipeline_dp.Metrics.PRIVACY_ID_COUNT],
             is_public_partitions=False)
         sensitivities = dp_computations.Sensitivities(l0, 1)
         output = selector.get_dp_strategy(sensitivities)

--- a/analysis/tests/parameter_tuning_test.py
+++ b/analysis/tests/parameter_tuning_test.py
@@ -82,7 +82,7 @@ class ParameterTuning(parameterized.TestCase):
         candidates = parameter_tuning._find_candidate_parameters(
             mock_histograms,
             parameters_to_tune,
-            pipeline_dp.Metrics.COUNT,
+            _get_aggregate_params([pipeline_dp.Metrics.COUNT]),
             max_candidates=5)
         self.assertEqual([1, 1, 6, 6], candidates.max_partitions_contributed)
         self.assertEqual([1, 3, 1, 3],
@@ -107,14 +107,14 @@ class ParameterTuning(parameterized.TestCase):
         candidates = parameter_tuning._find_candidate_parameters(
             mock_histograms,
             parameters_to_tune,
-            pipeline_dp.Metrics.COUNT,
+            _get_aggregate_params([pipeline_dp.Metrics.COUNT]),
             max_candidates=9)
         # sqrt(9) = 3, but l_inf has only 2 possible values,
         # therefore for l_0 we can take 9 / 2 = 4 values,
         # we take all 4 possible values (1, 2, 3, 4).
-        self.assertEqual([1, 1, 2, 2, 3, 3, 4, 4],
+        self.assertEqual([1, 1, 2, 2, 4, 4],
                          candidates.max_partitions_contributed)
-        self.assertEqual([1, 2, 1, 2, 1, 2, 1, 2],
+        self.assertEqual([1, 2, 1, 2, 1, 2],
                          candidates.max_contributions_per_partition)
 
     def test_find_candidate_parameters_more_candidates_for_l_inf_when_not_so_many_l_0_candidates(
@@ -136,7 +136,7 @@ class ParameterTuning(parameterized.TestCase):
         candidates = parameter_tuning._find_candidate_parameters(
             mock_histograms,
             parameters_to_tune,
-            pipeline_dp.Metrics.COUNT,
+            _get_aggregate_params([pipeline_dp.Metrics.COUNT]),
             max_candidates=9)
         # sqrt(9) = 3, but l_0 has only 2 possible values,
         # therefore for l_inf we can take 9 / 2 = 4 values,
@@ -194,7 +194,7 @@ class ParameterTuning(parameterized.TestCase):
         candidates = parameter_tuning._find_candidate_parameters(
             mock_histograms,
             parameters_to_tune,
-            pipeline_dp.Metrics.COUNT,
+            _get_aggregate_params([pipeline_dp.Metrics.COUNT]),
             max_candidates=max_candidates)
 
         self.assertEqual(expected_candidates,
@@ -247,11 +247,9 @@ class ParameterTuning(parameterized.TestCase):
             ' max values',
             bins=[_frequency_bin(max_value=i) for i in range(10)],
             max_candidates=5,
-            # Takes each bin with step ((10 - 1) / (5 - 1) = 1.8), i.e.
-            # [0, 2.25, 4.5, 6.75, 9], then rounds it, i.e. we get
-            # [0, 2, 4, 7, 9] indices of bins to take, they equal to max
-            # values of these bins
-            expected_candidates=[0, 2, 4, 7, 9]),
+            # 0 bin is skipped. Takes each bin with step ((9 - 1) / (5 - 1) =
+            # 2.0), i.e. [1, 3, 5, 7, 9]
+            expected_candidates=[1.0, 3.0, 5.0, 7.0, 9.0]),
     )
     def test_find_candidate_parameters_sum(self, bins, max_candidates,
                                            expected_candidates):
@@ -268,7 +266,7 @@ class ParameterTuning(parameterized.TestCase):
         candidates = parameter_tuning._find_candidate_parameters(
             mock_histograms,
             parameters_to_tune,
-            pipeline_dp.Metrics.SUM,
+            _get_aggregate_params([pipeline_dp.Metrics.SUM]),
             max_candidates=max_candidates)
 
         self.assertEqual(expected_candidates, candidates.max_sum_per_partition)
@@ -297,7 +295,7 @@ class ParameterTuning(parameterized.TestCase):
         candidates = parameter_tuning._find_candidate_parameters(
             mock_histograms,
             parameters_to_tune,
-            pipeline_dp.Metrics.SUM,
+            _get_aggregate_params([pipeline_dp.Metrics.SUM]),
             max_candidates=5)
         self.assertEqual([1, 1, 6, 6], candidates.max_partitions_contributed)
         self.assertEqual([1, 3, 1, 3], candidates.max_sum_per_partition)
@@ -343,7 +341,10 @@ class ParameterTuning(parameterized.TestCase):
             max_contributions_per_partition=True)
 
         candidates = parameter_tuning._find_candidate_parameters(
-            mock_histograms, parameters_to_tune, metric, max_candidates=100)
+            mock_histograms,
+            parameters_to_tune,
+            _get_aggregate_params([metric]),
+            max_candidates=100)
 
         mock_find_candidate_from_histogram.assert_any_call(
             mock_l0_histogram, mock.ANY)
@@ -429,7 +430,7 @@ class ParameterTuning(parameterized.TestCase):
         # Assert.
         tune_result, per_partition_utility_analysis = result
         per_partition_utility_analysis = list(per_partition_utility_analysis)
-        self.assertLen(per_partition_utility_analysis, 10)
+        self.assertLen(per_partition_utility_analysis, 30)
 
         tune_result = list(tune_result)[0]
 
@@ -437,7 +438,7 @@ class ParameterTuning(parameterized.TestCase):
         self.assertEqual(contribution_histograms,
                          tune_result.contribution_histograms)
         utility_reports = tune_result.utility_reports
-        self.assertLen(utility_reports, 1)
+        self.assertLen(utility_reports, 3)
         self.assertIsInstance(utility_reports[0], metrics.UtilityReport)
         self.assertLen(utility_reports[0].metric_errors, 1)
         self.assertEqual(utility_reports[0].metric_errors[0].metric,
@@ -610,7 +611,7 @@ class ParameterTuning(parameterized.TestCase):
         strategy_selector = analysis.dp_strategy_selector.DPStrategySelector(
             epsilon=1,
             delta=1e-7,
-            metric=metric,
+            metrics=[metric],
             is_public_partitions=is_public_partitions)
         parameter_tuning._add_dp_strategy_to_multi_parameter_configuration(
             multi_parameter_configuration,

--- a/pipeline_dp/dataset_histograms/histograms.py
+++ b/pipeline_dp/dataset_histograms/histograms.py
@@ -15,7 +15,7 @@
 
 from dataclasses import dataclass, field
 import enum
-from typing import List, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 
 @dataclass
@@ -210,7 +210,13 @@ class DatasetHistograms:
     l0_contributions_histogram: Histogram
     l1_contributions_histogram: Histogram
     linf_contributions_histogram: Histogram
-    linf_sum_contributions_histogram: Histogram
+    linf_sum_contributions_histogram: Optional[Union[Histogram,
+                                                     List[Histogram]]]
     count_per_partition_histogram: Histogram
     count_privacy_id_per_partition: Histogram
-    sum_per_partition_histogram: Histogram
+    sum_per_partition_histogram: Optional[Union[Histogram, List[Histogram]]]
+
+    def num_sum_histograms(self) -> int:
+        if isinstance(self.linf_sum_contributions_histogram, Histogram):
+            return 1
+        return len(self.linf_sum_contributions_histogram)


### PR DESCRIPTION
This PR introduces finding candidates during tuning for computing utility analysis for case when utility analysis for multiple metrics is computed and SUM can be computed for multiple columns . This covers cases when DP aggregations can be presented in the pseudo-SQL terms as

```
SELECT partition_key, DP_COUNT(), DP_SUM(column1), DP_SUM(columns2)
GROUP BY partition_key
```
