### PR TITLE
Mark numpy version as 1.23.5 to fix import issue on example Codelab

### DIFF
--- a/examples/codelab/codelab_PipelineDP.ipynb
+++ b/examples/codelab/codelab_PipelineDP.ipynb
@@ -35,7 +35,7 @@
       "outputs": [],
       "source": [
         "!pip install numpy==1.23.5\n",
-        "!pip install pipeline-dp apache-beam=2.63\n",
+        "!pip install pipeline-dp apache-beam==2.63\n",
         "from IPython.display import clear_output\n",
         "\n",
         "clear_output()"

--- a/examples/codelab/codelab_PipelineDP.ipynb
+++ b/examples/codelab/codelab_PipelineDP.ipynb
@@ -35,7 +35,7 @@
       "outputs": [],
       "source": [
         "!pip install numpy==1.23.5\n",
-        "!pip install pipeline-dp apache-beam\n",
+        "!pip install pipeline-dp apache-beam=2.63\n",
         "from IPython.display import clear_output\n",
         "\n",
         "clear_output()"

--- a/examples/codelab/codelab_PipelineDP.ipynb
+++ b/examples/codelab/codelab_PipelineDP.ipynb
@@ -35,7 +35,8 @@
       "outputs": [],
       "source": [
         "!pip install numpy==1.23.5\n",
-        "!pip install pipeline-dp apache-beam==2.63\n",
+        "!pip install apache-beam==2.63\n",
+        "!pip install pipeline-dp\n",
         "from IPython.display import clear_output\n",
         "\n",
         "clear_output()"

--- a/examples/codelab/codelab_PipelineDP.ipynb
+++ b/examples/codelab/codelab_PipelineDP.ipynb
@@ -34,6 +34,7 @@
       },
       "outputs": [],
       "source": [
+        "!pip install numpy==1.23.5\n",
         "!pip install pipeline-dp apache-beam\n",
         "from IPython.display import clear_output\n",
         "\n",


### PR DESCRIPTION

## Description
Specify numpy version as 1.23.5 to fix import issue

If I don't specify this version, when trying to run in Google Codelab I get the following error:

ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject

## Affected Dependencies
numpy

## How has this been tested?
- Running the codelab
- instructions to reproduce: trying to run the Codelab without the change

## Checklist
- [ X ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ X ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ X ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ n/a ] My changes are covered by tests
