### PR TITLE
Introduce Exponential mechanism to Budget Accounting

### DIFF
--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -94,6 +94,7 @@ class MechanismType(Enum):
     GAUSSIAN = 'Gaussian'
     LAPLACE_THRESHOLDING = 'Laplace Thresholding'
     GAUSSIAN_THRESHOLDING = 'Gaussian Thresholding'
+    EXPONENTIAL = 'Exponential'
     GENERIC = 'Generic'
 
     def to_noise_kind(self):

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -104,7 +104,10 @@ class MechanismSpec:
         self._noise_standard_deviation = stddev
 
     def use_delta(self) -> bool:
-        return self.mechanism_type != agg_params.MechanismType.LAPLACE
+        return self.mechanism_type not in [
+            agg_params.MechanismType.LAPLACE,
+            agg_params.MechanismType.EXPONENTIAL
+        ]
 
     @property
     def standard_deviation_is_set(self) -> bool:
@@ -117,6 +120,15 @@ class MechanismSpecInternal:
     sensitivity: float
     weight: float
     mechanism_spec: MechanismSpec
+
+    def __post_init__(self):
+        mechanism_type = self.mechanism_spec.mechanism_type
+        if self.sensitivity != 1 and mechanism_type in [
+                agg_params.MechanismType.EXPONENTIAL,
+                agg_params.MechanismType.GENERIC
+        ]:
+            raise ValueError(
+                f"Mechanism {mechanism_type} does not support sensitivity.")
 
 
 Budget = collections.namedtuple("Budget", ["epsilon", "delta"])

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -110,21 +110,25 @@ class NaiveBudgetAccountantTest(parameterized.TestCase):
         self.assertEqual(budget1.eps, 1.0 / (1.0 + 0.5))
         self.assertEqual(budget2.eps, 0.5 / (1.0 + 0.5))
 
-    def test_count(self):
+    def test_weights_count(self):
         budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
                                                   total_delta=1e-6)
         budget1 = budget_accountant.request_budget(
             mechanism_type=MechanismType.LAPLACE, weight=4)
         budget2 = budget_accountant.request_budget(
             mechanism_type=MechanismType.GAUSSIAN, weight=3, count=2)
+        budget3 = budget_accountant.request_budget(
+            mechanism_type=MechanismType.EXPONENTIAL, weight=2, count=5)
         budget_accountant.compute_budgets()
 
-        self.assertEqual(budget1.eps, 0.4)
-        self.assertEqual(budget1.delta,
-                         0)  # Delta should be 0 if mechanism is Laplace.
+        self.assertEqual(budget1.eps, 0.2)
+        self.assertEqual(budget1.delta, 0)  # delta=0 for Laplace.
 
-        self.assertEqual(budget2.eps, 0.3)
+        self.assertEqual(budget2.eps, 0.15)
         self.assertEqual(budget2.delta, 5e-7)
+
+        self.assertEqual(budget3.eps, 0.1)
+        self.assertEqual(budget3.delta, 0)  # delta=0 for Exponential.
 
     def test_two_calls_compute_budgets_raise_exception(self):
         budget_accountant = NaiveBudgetAccountant(total_epsilon=1,
@@ -467,7 +471,26 @@ class PLDBudgetAccountantTest(unittest.TestCase):
                         weight=8,
                         sensitivity=3),
                 ],
-                expected_pipeline_noise_std=40.02)
+                expected_pipeline_noise_std=40.02),
+            ComputeBudgetTestCase(
+                name="gaussian_exponential",
+                epsilon=1.0,
+                delta=1e-6,
+                mechanisms=[
+                    ComputeBudgetMechanisms(
+                        count=4,
+                        expected_noise_std=1.295,
+                        mechanism_type=MechanismType.EXPONENTIAL,
+                        weight=4,
+                        sensitivity=1),
+                    ComputeBudgetMechanisms(
+                        count=6,
+                        expected_noise_std=10.356,
+                        mechanism_type=MechanismType.GAUSSIAN,
+                        weight=2,
+                        sensitivity=4),
+                ],
+                expected_pipeline_noise_std=5.178)
         ]
 
         for case in testcases:


### PR DESCRIPTION
Atm dp_accounting doesn't support yet Exponential mechanism natively, so for PLD accounting PLD from eps-DP mechanism (which is actually eps-randomzed response) is used. eps-Randomized response is dominating any eps-DP so it's safe from privacy perspective, but it results in slightly higher noise.