### PR TITLE
Disable Mac/Windows tests run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:


### PR DESCRIPTION
One of the PipelineDP dependencies - PyDP, doesn't have support of Mac and Windows now. As a result actions for Mac/Windows are failing. Let's first disable it.