### PR TITLE
Minor serialization fix

### DIFF
--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -141,8 +141,8 @@ class DPEngine:
                                           "Drop privacy id")
             # col : (partition_key, accumulator)
         else:
-            col = self._backend.map(col, lambda row: row[1:],
-                                    "Remove privacy_id")
+            col = self._backend.map_tuple(col, lambda pid, pk, v: (pk, v),
+                                          "Drop privacy id")
             # col : (partition_key, value)
 
             col = self._backend.map_values(


### PR DESCRIPTION
The fix is essentially no-op:

`row=(privacy_id, parition, value)`

The goal is to drop `privacy_id`

before this PR: `lambda row: row[1:]`

in this PR:  `lambda pid, pk, v: (pk, v)`

But the first version leads to incorrect type deduction in Python Beam, as a result incorrect coders are chosen.