### PR TITLE
Support PLD for Laplace/Gaussian thresholding

### DIFF
--- a/examples/movie_view_ratings/run_without_frameworks.py
+++ b/examples/movie_view_ratings/run_without_frameworks.py
@@ -77,7 +77,9 @@ def main(unused_argv):
         # .. with minimal rating of "1"
         min_value=1,
         # .. and maximum rating of "5"
-        max_value=5)
+        max_value=5,
+        partition_selection_strategy=pipeline_dp.PartitionSelectionStrategy.
+        GAUSSIAN_THRESHOLDING)
 
     if FLAGS.pre_threshold:
         params.pre_threshold = FLAGS.pre_threshold
@@ -102,7 +104,7 @@ def main(unused_argv):
         movie_views,
         params,
         data_extractors,
-        public_partitions=list(range(1, 100)),
+        # public_partitions=list(range(1, 100)),
         out_explain_computation_report=explain_computation_report)
 
     budget_accountant.compute_budgets()

--- a/examples/movie_view_ratings/run_without_frameworks.py
+++ b/examples/movie_view_ratings/run_without_frameworks.py
@@ -109,7 +109,6 @@ def main(unused_argv):
         movie_views,
         params,
         data_extractors,
-        # public_partitions=list(range(1, 100)),
         out_explain_computation_report=explain_computation_report)
 
     budget_accountant.compute_budgets()

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -116,6 +116,12 @@ class MechanismType(Enum):
         raise ValueError(f"MechanismType {self.value} can not be converted to "
                          f"PartitionSelectionStrategy")
 
+    def is_thresholding_mechanism(self):
+        return self.value in [
+            MechanismType.LAPLACE_THRESHOLDING.value,
+            MechanismType.GAUSSIAN_THRESHOLDING.value
+        ]
+
 
 def noise_to_thresholding(noise_kind: NoiseKind) -> MechanismType:
     if noise_kind == NoiseKind.LAPLACE:

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -90,9 +90,7 @@ class PartitionSelectionStrategy(Enum):
 
     @property
     def is_thresholding(self) -> bool:
-        return self.value in [
-            self.LAPLACE_THRESHOLDING, self.GAUSSIAN_THRESHOLDING
-        ]
+        return self in [self.LAPLACE_THRESHOLDING, self.GAUSSIAN_THRESHOLDING]
 
     @property
     def mechanism_type(self) -> 'MechanismType':

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -88,6 +88,11 @@ class PartitionSelectionStrategy(Enum):
     LAPLACE_THRESHOLDING = 'Laplace Thresholding'
     GAUSSIAN_THRESHOLDING = 'Gaussian Thresholding'
 
+    def is_thresholding(self) -> bool:
+        return self.value in [
+            self.LAPLACE_THRESHOLDING, self.GAUSSIAN_THRESHOLDING
+        ]
+
 
 class MechanismType(Enum):
     LAPLACE = 'Laplace'

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -88,10 +88,19 @@ class PartitionSelectionStrategy(Enum):
     LAPLACE_THRESHOLDING = 'Laplace Thresholding'
     GAUSSIAN_THRESHOLDING = 'Gaussian Thresholding'
 
+    @property
     def is_thresholding(self) -> bool:
         return self.value in [
             self.LAPLACE_THRESHOLDING, self.GAUSSIAN_THRESHOLDING
         ]
+
+    @property
+    def mechanism_type(self) -> 'MechanismType':
+        if self.value == self.GAUSSIAN_THRESHOLDING.value:
+            return MechanismType.GAUSSIAN_THRESHOLDING
+        if self.value == self.LAPLACE_THRESHOLDING.value:
+            return MechanismType.LAPLACE_THRESHOLDING
+        return MechanismType.TRUNCATED_GEOMETRIC
 
 
 class MechanismType(Enum):
@@ -99,6 +108,7 @@ class MechanismType(Enum):
     GAUSSIAN = 'Gaussian'
     LAPLACE_THRESHOLDING = 'Laplace Thresholding'
     GAUSSIAN_THRESHOLDING = 'Gaussian Thresholding'
+    TRUNCATED_GEOMETRIC = 'Truncated Geometric'
     GENERIC = 'Generic'
 
     def to_noise_kind(self):

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -110,29 +110,37 @@ class MechanismType(Enum):
     GENERIC = 'Generic'
 
     def to_noise_kind(self):
-        if self.value == MechanismType.LAPLACE.value:
+        if self == MechanismType.LAPLACE:
             return NoiseKind.LAPLACE
-        if self.value == MechanismType.GAUSSIAN.value:
+        if self == MechanismType.GAUSSIAN:
             return NoiseKind.GAUSSIAN
-        if self.value == MechanismType.LAPLACE_THRESHOLDING.value:
+        if self == MechanismType.LAPLACE_THRESHOLDING:
             return NoiseKind.LAPLACE
-        if self.value == MechanismType.GAUSSIAN_THRESHOLDING.value:
+        if self == MechanismType.GAUSSIAN_THRESHOLDING:
             return NoiseKind.GAUSSIAN
         raise ValueError(f"MechanismType {self.value} can not be converted to "
                          f"NoiseKind")
 
     def to_partition_selection_strategy(self) -> PartitionSelectionStrategy:
-        if self.value == MechanismType.LAPLACE_THRESHOLDING.value:
+        if self == MechanismType.LAPLACE_THRESHOLDING:
             return PartitionSelectionStrategy.LAPLACE_THRESHOLDING
-        if self.value == MechanismType.GAUSSIAN_THRESHOLDING.value:
+        if self == MechanismType.GAUSSIAN_THRESHOLDING:
             return PartitionSelectionStrategy.GAUSSIAN_THRESHOLDING
         raise ValueError(f"MechanismType {self.value} can not be converted to "
                          f"PartitionSelectionStrategy")
 
-    def is_thresholding_mechanism(self):
-        return self.value in [
-            MechanismType.LAPLACE_THRESHOLDING.value,
-            MechanismType.GAUSSIAN_THRESHOLDING.value
+    @property
+    def is_thresholding_mechanism(self) -> bool:
+        return self in [
+            MechanismType.LAPLACE_THRESHOLDING,
+            MechanismType.GAUSSIAN_THRESHOLDING
+        ]
+
+    @property
+    def is_partition_selection(self) -> bool:
+        return self in [
+            MechanismType.LAPLACE_THRESHOLDING,
+            MechanismType.GAUSSIAN_THRESHOLDING
         ]
 
 

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -77,9 +77,9 @@ class NoiseKind(Enum):
     GAUSSIAN = 'gaussian'
 
     def convert_to_mechanism_type(self):
-        if self.value == NoiseKind.LAPLACE.value:
+        if self == NoiseKind.LAPLACE:
             return MechanismType.LAPLACE
-        if self.value == NoiseKind.GAUSSIAN.value:
+        if self == NoiseKind.GAUSSIAN:
             return MechanismType.GAUSSIAN
 
 
@@ -94,9 +94,9 @@ class PartitionSelectionStrategy(Enum):
 
     @property
     def mechanism_type(self) -> 'MechanismType':
-        if self.value == self.GAUSSIAN_THRESHOLDING.value:
+        if self == self.GAUSSIAN_THRESHOLDING:
             return MechanismType.GAUSSIAN_THRESHOLDING
-        if self.value == self.LAPLACE_THRESHOLDING.value:
+        if self == self.LAPLACE_THRESHOLDING:
             return MechanismType.LAPLACE_THRESHOLDING
         return MechanismType.TRUNCATED_GEOMETRIC
 

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -139,6 +139,7 @@ class MechanismType(Enum):
     @property
     def is_partition_selection(self) -> bool:
         return self in [
+            MechanismType.TRUNCATED_GEOMETRIC,
             MechanismType.LAPLACE_THRESHOLDING,
             MechanismType.GAUSSIAN_THRESHOLDING
         ]

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -52,7 +52,7 @@ class MechanismSpec:
     _noise_standard_deviation: Optional[float] = None
     _eps: Optional[float] = None
     _delta: Optional[float] = None
-    _count: Optional[int] = 1
+    _count: int = 1
     _thresholding_delta: Optional[float] = None
 
     @property

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -542,8 +542,10 @@ class PLDBudgetAccountant(BudgetAccountant):
             minimum_noise_std = self._find_minimum_noise_std()
 
         self.minimum_noise_std = minimum_noise_std
-        thresholding_delta_per_mechanism = self._get_thresholding_delta(
-        ) / self._count_thresholding_mechanisms()
+        thresholding_delta_per_mechanism = 0
+        if self._count_thresholding_mechanisms() > 0:
+            thresholding_delta_per_mechanism = self._get_thresholding_delta(
+            ) / self._count_thresholding_mechanisms()
         for mechanism in self._mechanisms:
             mechanism_noise_std = mechanism.sensitivity * minimum_noise_std / mechanism.weight
             mechanism.mechanism_spec._noise_standard_deviation = mechanism_noise_std

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -603,10 +603,13 @@ class PLDBudgetAccountant(BudgetAccountant):
                     noise_standard_deviation / mechanism_spec_internal.weight,
                     value_discretization_interval=self._pld_discretization)
             elif mechanism_spec_internal.mechanism_spec.mechanism_type == agg_params.MechanismType.GENERIC:
-                # It is required to convert between the noise_standard_deviation of a Laplace or Gaussian mechanism
-                # and the (epsilon, delta) Generic mechanism because the calibration is defined by one parameter.
-                # There are multiple ways to do this; here it is assumed that (epsilon, delta) specifies the Laplace
-                # mechanism and epsilon is computed based on this. The delta is computed to be proportional to epsilon.
+                # It is required to convert between the noise_standard_deviation
+                # of a Laplace or Gaussian mechanism and the (epsilon, delta)
+                # Generic mechanism because the calibration is defined by one
+                # parameter. There are multiple ways to do this; here it is
+                # assumed that (epsilon, delta) specifies the Laplace mechanism
+                # and epsilon is computed based on this. The delta is computed
+                # to be proportional to epsilon.
                 epsilon_0_interim = math.sqrt(2) / noise_standard_deviation
                 delta_0_interim = epsilon_0_interim / self._total_epsilon * self._total_delta
                 pld = pldlib.from_privacy_parameters(
@@ -617,3 +620,17 @@ class PLDBudgetAccountant(BudgetAccountant):
             composed = pld if composed is None else composed.compose(pld)
 
         return composed
+
+    def _count_thresholding_mechanisms(self):
+        return len(self._thresholding_mechanisms())
+
+    def _get_thresholding_delta(self) -> float:
+        has_threshold_mechanisms = bool(self._thresholding_mechanisms())
+        return 0.25 * self._total_delta if has_threshold_mechanisms else 0
+
+    def _thresholding_mechanisms(self):
+        result = []
+        for m in self._mechanisms:
+            if m.mechanism_spec.mechanism_type.is_thresholding_mechanism():
+                result.append(m)
+        return result

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -473,7 +473,7 @@ class PLDBudgetAccountant(BudgetAccountant):
                               "NaiveBudgetAccountant instead of "
                               "PLDBudgetAccountant")
 
-        self.minimum_noise_std = None
+        self.base_noise_std = None
         self._pld_discretization = pld_discretization
 
     def request_budget(

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -622,12 +622,16 @@ class PLDBudgetAccountant(BudgetAccountant):
             if mechanism_type == MechanismType.LAPLACE:
                 pld = self._create_pld_for_laplace(noise_stddev, mechanism)
             elif mechanism_type == MechanismType.LAPLACE_THRESHOLDING:
-                # todo
+                # Laplace thresholding is emulated with Laplace mechanism
+                # with an additional threshold delta (which is substracted from
+                # total delta)
                 pld = self._create_pld_for_laplace(noise_stddev, mechanism)
             elif mechanism_type == MechanismType.GAUSSIAN:
                 pld = self._create_pld_for_gaussian(noise_stddev, mechanism)
             elif mechanism_type == MechanismType.GAUSSIAN_THRESHOLDING:
-                # todo
+                # Gaussian thresholding is emulated with Gaussian mechanism
+                # with an additional threshold delta (which is substracted from
+                # total delta)
                 pld = self._create_pld_for_gaussian(noise_stddev, mechanism)
             elif mechanism_type == MechanismType.GENERIC:
                 pld = self._create_pld_for_generic(noise_stddev, mechanism)
@@ -640,6 +644,7 @@ class PLDBudgetAccountant(BudgetAccountant):
 
     def _get_thresholding_delta(self) -> float:
         has_threshold_mechanisms = bool(self._thresholding_mechanisms())
+        # 0.25 of total_delta is dedicated for threshold_delta.
         return 0.25 * self._total_delta if has_threshold_mechanisms else 0
 
     def _thresholding_mechanisms(self):

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -565,7 +565,7 @@ class PLDBudgetAccountant(BudgetAccountant):
                 mechanism.mechanism_spec.set_eps_delta(epsilon_0, delta_0)
             else:
                 spec.set_noise_standard_deviation(mechanism_noise_std)
-            if spec.mechanism_type.is_thresholding_mechanism():
+            if spec.mechanism_type.is_thresholding_mechanism:
                 spec.set_thresholding_delta(thresholding_delta_per_mechanism)
 
     def _find_minimum_base_noise_std(self) -> float:
@@ -645,7 +645,7 @@ class PLDBudgetAccountant(BudgetAccountant):
     def _thresholding_mechanisms(self):
         result = []
         for m in self._mechanisms:
-            if m.mechanism_spec.mechanism_type.is_thresholding_mechanism():
+            if m.mechanism_spec.mechanism_type.is_thresholding_mechanism:
                 result.append(m)
         return result
 

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -378,8 +378,10 @@ class NaiveBudgetAccountant(BudgetAccountant):
             raise ValueError(
                 "The Gaussian mechanism requires that the pipeline delta is greater than 0"
             )
-        if mechanism_type.is_thresholding_mechanism():
-            raise
+        if mechanism_type.is_partition_selection and self._total_delta == 0:
+            raise ValueError(
+                "The private partition selections requires that the pipeline delta is greater than 0"
+            )
         mechanism_spec = MechanismSpec(mechanism_type=mechanism_type,
                                        _count=count)
         mechanism_spec_internal = MechanismSpecInternal(

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -626,7 +626,8 @@ class PLDBudgetAccountant(BudgetAccountant):
             self, noise_stddev: float, mechanism: MechanismSpecInternal
     ) -> 'pldlib.PrivacyLossDistribution':
         # The Laplace distribution parameter = std/sqrt(2).
-        laplace_b = noise_stddev / math.sqrt(2) * mechanism.weight
+        laplace_b = mechanism.sensitivity * noise_stddev / math.sqrt(
+            2) / mechanism.weight
         return pldlib.from_laplace_mechanism(
             laplace_b, value_discretization_interval=self._pld_discretization)
 

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -636,7 +636,7 @@ class PLDBudgetAccountant(BudgetAccountant):
             elif mechanism_type == MechanismType.GENERIC:
                 pld = self._create_pld_for_generic(noise_stddev, mechanism)
 
-            count = mechanism_spec_internal.mechanism_spec.count
+            count = mechanism.mechanism_spec.count
             if count > 1:
                 pld = pld.self_compose(count)
             composed = pld if composed is None else composed.compose(pld)

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -141,7 +141,7 @@ def gaussian_epsilon(sigma: float, delta: float) -> float:
     if f(0) >= delta:
         L = 0
         R = 1
-        while f(R) > delta:
+        while f(R) >= delta:
             R *= 2
     else:
         R = 0
@@ -149,6 +149,7 @@ def gaussian_epsilon(sigma: float, delta: float) -> float:
         while f(L) < delta:
             L *= 2
 
+    # TODO: consider using algorithms from scipy.optimize.
     while R - L > 1e-10:
         M = (R + L) / 2
         if f(M) >= delta:

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -116,6 +116,14 @@ def compute_sigma(eps: float, delta: float, l2_sensitivity: float) -> float:
     return dp_mechanisms.GaussianMechanism(eps, delta, l2_sensitivity).std
 
 
+def gaussian_delta(sigma: float, eps: float) -> float:
+    pass
+
+
+def gaussian_eps(sigma: float, delta: float) -> float:
+    pass
+
+
 def apply_laplace_mechanism(value: float, eps: float, l1_sensitivity: float):
     """Applies the Laplace mechanism to the value.
 

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -119,6 +119,9 @@ def compute_sigma(eps: float, delta: float, l2_sensitivity: float) -> float:
 
 
 def gaussian_delta(sigma: float, epsilon: float) -> float:
+    """Computes minimum delta such that the Gaussian(sigma) mechanism is (eps, delta)-dp"""
+    # The optimal delta is found with
+    # https://proceedings.mlr.press/v80/balle18a/balle18a.pdf ALgorithm 1.
     if sigma <= 0:
         raise ValueError(f"sigma must be > 0, but {sigma=}")
     a = 1 / sigma
@@ -127,10 +130,13 @@ def gaussian_delta(sigma: float, epsilon: float) -> float:
 
 
 def gaussian_epsilon(sigma: float, delta: float) -> float:
+    """Computes minimum eps such that the Gaussian(sigma) mechanism is (eps, delta)-dp"""
     if sigma <= 0:
         raise ValueError(f"sigma must be > 0, but {sigma=}")
     if delta < 0 or delta > 1:
         raise ValueError(f"delta must be in [0, 1], but {delta=}")
+    # For a fixed sigma a function delta(epsilon) is decreasing. Solve the
+    # equation gaussian_delta(sigma, epsilon) = delta with binary search.
     f = functools.partial(gaussian_delta, sigma)
     if f(0) >= delta:
         L = 0

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -374,9 +374,13 @@ class DPEngine:
         def generate_partition_selection_text() -> str:
             if budget.standard_deviation_is_set:
                 # PLD case for thresholding.
-                parameters = f"stddev={budget.noise_standard_deviation}, delta={budget.delta}"
+                noise_stddev = budget.noise_standard_deviation
+                thresholding_delta = budget.thresholding_delta
+                parameters = f"{noise_stddev=}, {thresholding_delta=}"
             else:
-                parameters = f"eps={budget.eps}, delta={budget.delta}"
+                epsilon = budget.eps
+                delta = budget.delta
+                parameters = f"{epsilon=}, delta={delta=}"
             text = f"""Private Partition selection: using {strategy.value}
             f"method with ({parameters}, {pre_threshold_str})"""
             return text

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -370,10 +370,10 @@ class DPEngine:
                                       max_rows_per_privacy_id, strategy,
                                       pre_threshold)
         pre_threshold_str = f", pre_threshold={pre_threshold}" if pre_threshold else ""
-        self._add_report_stage(
-            lambda: f"Private Partition selection: using {strategy.value} "
-            f"method with (eps={budget.eps}, delta={budget.delta}"
-            f"{pre_threshold_str})")
+        # self._add_report_stage(
+        #     lambda: f"Private Partition selection: using {strategy.value} "
+        #     f"method with (eps={budget.eps}, delta={budget.delta}"
+        #     f"{pre_threshold_str})")
 
         return self._backend.filter(col, filter_fn, "Filter private partitions")
 
@@ -651,7 +651,7 @@ def _create_partition_selector(strategy: pipeline_dp.PartitionSelectionStrategy,
                                budget: budget_accounting.MechanismSpec,
                                max_partitions: int, pre_threshold: int):
     if budget.standard_deviation_is_set:
-        assert strategy.is_thresholding()
+        assert strategy.is_thresholding
         if strategy == pipeline_dp.PartitionSelectionStrategy.LAPLACE_THRESHOLDING:
             return partition_selection.create_laplace_thresholding(
                 budget.noise_standard_deviation, budget.thresholding_delta,

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -336,8 +336,7 @@ class DPEngine:
         Returns:
             collection of elements (partition_key, accumulator).
         """
-        budget = self._budget_accountant.request_budget(
-            mechanism_type=pipeline_dp.MechanismType.GENERIC)
+        budget = self._budget_accountant.request_budget(strategy.mechanism_type)
 
         def filter_fn(
             budget: 'MechanismSpec', max_partitions: int,
@@ -533,9 +532,6 @@ class DPEngine:
                       pipeline_dp.NaiveBudgetAccountant):
             # All aggregations support NaiveBudgetAccountant.
             return
-        if not is_public_partition:
-            raise NotImplementedError("PLD budget accounting does not support "
-                                      "private partition selection")
         supported_metrics = [
             pipeline_dp.Metrics.COUNT, pipeline_dp.Metrics.PRIVACY_ID_COUNT,
             pipeline_dp.Metrics.SUM, pipeline_dp.Metrics.MEAN

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -370,10 +370,18 @@ class DPEngine:
                                       max_rows_per_privacy_id, strategy,
                                       pre_threshold)
         pre_threshold_str = f", pre_threshold={pre_threshold}" if pre_threshold else ""
-        # self._add_report_stage(
-        #     lambda: f"Private Partition selection: using {strategy.value} "
-        #     f"method with (eps={budget.eps}, delta={budget.delta}"
-        #     f"{pre_threshold_str})")
+
+        def generate_partition_selection_text() -> str:
+            if budget.standard_deviation_is_set:
+                # PLD case for thresholding.
+                parameters = f"stddev={budget.noise_standard_deviation}, delta={budget.delta}"
+            else:
+                parameters = f"eps={budget.eps}, delta={budget.delta}"
+            text = f"""Private Partition selection: using {strategy.value}
+            f"method with ({parameters}, {pre_threshold_str})"""
+            return text
+
+        self._add_report_stage(generate_partition_selection_text)
 
         return self._backend.filter(col, filter_fn, "Filter private partitions")
 

--- a/pipeline_dp/partition_selection.py
+++ b/pipeline_dp/partition_selection.py
@@ -14,7 +14,6 @@
 
 import pipeline_dp
 import pydp.algorithms.partition_selection as partition_selection
-from pydp.algorithms import numerical_mechanisms as dp_mechanisms
 from typing import Optional
 import math
 
@@ -51,12 +50,40 @@ def create_gaussian_thresholding(
         thresholding_delta: float,
         max_partitions_contributed: int,
         pre_threshold: Optional[int] = None) -> "PartitionSelectionStrategy":
-    """Creates PyDP partition selection object."""
+    """Creates PyDP Gaussian partition selection object.
+
+    Gaussian thresholding with parameters sigma and thresholding_delta is the
+    partition selection mechanism:
+      if num_privacy_units + N(0, sigma^2) >= threshold:
+        return "release"
+      else:
+        return "not-release"
+    Where `threshold` is chosen, such that the probability of releasing of a
+    partition with 1 privacy unit is less equal to thresholding_delta, i.e.
+      P(1 + N(0, sigma^2) >= threshold) <= thresholding_delta.
+
+    Args:
+       sigma: the standard deviation of Gaussian noise
+       thresholding_delta: upper bound on the probability of releasing of a
+         partition with 1 privacy unit
+       max_partitions_contributed: A bound on the number of partitions to
+          which one unit of privacy (e.g., a user) can contribute.
+       pre_threshold: the minimum amount of privacy units which are required
+         for keeping a partition in private partition selection.
+    """
+    # Now PyDP supports only creating partition selection by epsilon, delta.
+    # So we need to find (epsilon, delta), such that the created object has
+    # the corresponding noise scale:
+    # delta = 2 * threshold_delta (because Gaussian thresholding divides evenly
+    # delta for the noise and threshold)
+    # From sigma and noise_delta we can find epsilon of corresponding Gaussian
+    # mechanism.
     epsilon = pipeline_dp.dp_computations.gaussian_epsilon(
         sigma, thresholding_delta)
+    total_delta = 2 * thresholding_delta
     return create_partition_selection_strategy(
         pipeline_dp.PartitionSelectionStrategy.GAUSSIAN_THRESHOLDING, epsilon,
-        2 * thresholding_delta, max_partitions_contributed, pre_threshold)
+        total_delta, max_partitions_contributed, pre_threshold)
 
 
 def create_laplace_thresholding(
@@ -64,7 +91,33 @@ def create_laplace_thresholding(
         thresholding_delta: float,
         max_partitions_contributed: int,
         pre_threshold: Optional[int] = None) -> "PartitionSelectionStrategy":
-    """Creates PyDP partition selection object."""
+    """Creates PyDP Laplace partition selection object.
+
+    Laplace thresholding with parameters b and thresholding_delta is the
+     partition selection mechanism:
+       if num_privacy_units + Lap(b) >= threshold:
+         return "release"
+       else:
+         return "not-release"
+     Where `threshold` is chosen, such that the probability of releasing of a
+     partition with 1 privacy unit is less equal to thresholding_delta, i.e.
+       P(1 + Lap(b) >= threshold) <= thresholding_delta.
+
+     Args:
+        sigma: the standard deviation of Laplace noise
+        thresholding_delta: upper bound on the probability of releasing of a
+          partition with 1 privacy unit
+        max_partitions_contributed: A bound on the number of partitions to
+           which one unit of privacy (e.g., a user) can contribute.
+        pre_threshold: the minimum amount of privacy units which are required
+          for keeping a partition in private partition selection.
+     """
+    # Now PyDP supports only creating partition selection by epsilon, delta.
+    # So we need to find (epsilon, delta), such that the created object has
+    # the corresponding noise scale:
+    # delta = threshold_delta
+    # epsilon = 1 / laplace_b
+    # laplace_b = sigma/sqrt(2)
     b = sigma / math.sqrt(2)
     epsilon = 1 / b
     return create_partition_selection_strategy(

--- a/pipeline_dp/partition_selection.py
+++ b/pipeline_dp/partition_selection.py
@@ -48,19 +48,20 @@ def create_partition_selection_strategy(
 
 def create_gaussian_thresholding(
         sigma: float,
-        delta: float,
+        thresholding_delta: float,
         max_partitions_contributed: int,
         pre_threshold: Optional[int] = None) -> "PartitionSelectionStrategy":
     """Creates PyDP partition selection object."""
-    epsilon = pipeline_dp.dp_computations.gaussian_eps(sigma, delta)
+    epsilon = pipeline_dp.dp_computations.gaussian_eps(sigma,
+                                                       thresholding_delta)
     return create_partition_selection_strategy(
         pipeline_dp.PartitionSelectionStrategy.GAUSSIAN_THRESHOLDING, epsilon,
-        2 * delta, max_partitions_contributed, pre_threshold)
+        2 * thresholding_delta, max_partitions_contributed, pre_threshold)
 
 
 def create_laplace_thresholding(
         sigma: float,
-        delta: float,
+        thresholding_delta: float,
         max_partitions_contributed: int,
         pre_threshold: Optional[int] = None) -> "PartitionSelectionStrategy":
     """Creates PyDP partition selection object."""
@@ -68,4 +69,4 @@ def create_laplace_thresholding(
     epsilon = 1 / b
     return create_partition_selection_strategy(
         pipeline_dp.PartitionSelectionStrategy.LAPLACE_THRESHOLDING, epsilon,
-        delta, max_partitions_contributed, pre_threshold)
+        thresholding_delta, max_partitions_contributed, pre_threshold)

--- a/pipeline_dp/partition_selection.py
+++ b/pipeline_dp/partition_selection.py
@@ -14,7 +14,9 @@
 
 import pipeline_dp
 import pydp.algorithms.partition_selection as partition_selection
+from pydp.algorithms import numerical_mechanisms as dp_mechanisms
 from typing import Optional
+import math
 
 PARTITION_STRATEGY_ENUM_TO_STR = {
     pipeline_dp.PartitionSelectionStrategy.TRUNCATED_GEOMETRIC:
@@ -42,3 +44,28 @@ def create_partition_selection_strategy(
         return partition_selection.create_partition_strategy(
             strategy_name, epsilon, delta, max_partitions_contributed,
             pre_threshold)
+
+
+def create_gaussian_thresholding(
+        sigma: float,
+        delta: float,
+        max_partitions_contributed: int,
+        pre_threshold: Optional[int] = None) -> "PartitionSelectionStrategy":
+    """Creates PyDP partition selection object."""
+    epsilon = pipeline_dp.dp_computations.gaussian_eps(sigma, delta)
+    return create_partition_selection_strategy(
+        pipeline_dp.PartitionSelectionStrategy.GAUSSIAN_THRESHOLDING, epsilon,
+        2 * delta, max_partitions_contributed, pre_threshold)
+
+
+def create_laplace_thresholding(
+        sigma: float,
+        delta: float,
+        max_partitions_contributed: int,
+        pre_threshold: Optional[int] = None) -> "PartitionSelectionStrategy":
+    """Creates PyDP partition selection object."""
+    b = sigma / math.sqrt(2)
+    epsilon = 1 / b
+    return create_partition_selection_strategy(
+        pipeline_dp.PartitionSelectionStrategy.LAPLACE_THRESHOLDING, epsilon,
+        delta, max_partitions_contributed, pre_threshold)

--- a/pipeline_dp/partition_selection.py
+++ b/pipeline_dp/partition_selection.py
@@ -52,8 +52,8 @@ def create_gaussian_thresholding(
         max_partitions_contributed: int,
         pre_threshold: Optional[int] = None) -> "PartitionSelectionStrategy":
     """Creates PyDP partition selection object."""
-    epsilon = pipeline_dp.dp_computations.gaussian_eps(sigma,
-                                                       thresholding_delta)
+    epsilon = pipeline_dp.dp_computations.gaussian_epsilon(
+        sigma, thresholding_delta)
     return create_partition_selection_strategy(
         pipeline_dp.PartitionSelectionStrategy.GAUSSIAN_THRESHOLDING, epsilon,
         2 * thresholding_delta, max_partitions_contributed, pre_threshold)

--- a/pipeline_dp/partition_selection.py
+++ b/pipeline_dp/partition_selection.py
@@ -59,7 +59,7 @@ def create_gaussian_thresholding(
       else:
         return "not-release"
     Where `threshold` is chosen, such that the probability of releasing of a
-    partition with 1 privacy unit is less equal to thresholding_delta, i.e.
+    partition with 1 privacy unit is less or equal to thresholding_delta, i.e.
       P(1 + N(0, sigma^2) >= threshold) <= thresholding_delta.
 
     Args:

--- a/pipeline_dp/report_generator.py
+++ b/pipeline_dp/report_generator.py
@@ -110,6 +110,6 @@ class ExplainComputationReport:
                              " passed as an argument to DP aggregation method?")
         try:
             return self._report_generator.report()
-        except e:
+        except Exception as e:
             raise ValueError("Explain computation report failed to be generated"
                              ".\nWas BudgetAccountant.compute_budget() called?")

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -485,8 +485,8 @@ class PLDBudgetAccountantTest(unittest.TestCase):
                              sensitivity=mechanism.sensitivity)))
             self.assertEqual(
                 len(actual_mechanisms), len(accountant._mechanisms),
-                f"failed test {case.name} expected len {len(actual_mechanisms)} "
-                f"got len {len(accountant._mechanisms)}")
+                f"failed test {case.name} expected len {len(actual_mechanisms)}"
+                f" got len {len(accountant._mechanisms)}")
             if case.delta > 0:
                 compare_pld = accountant._compose_distributions(
                     case.expected_pipeline_noise_std)

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -221,7 +221,7 @@ class PLDBudgetAccountantTest(unittest.TestCase):
     def test_compute_budgets_none_noise(self):
         accountant = PLDBudgetAccountant(total_epsilon=3, total_delta=1e-5)
         accountant.compute_budgets()
-        self.assertEqual(None, accountant.minimum_noise_std)
+        self.assertEqual(None, accountant.base_noise_std)
 
     def test_two_calls_compute_budgets_raise_exception(self):
         budget_accountant = PLDBudgetAccountant(total_epsilon=1,
@@ -500,20 +500,13 @@ class PLDBudgetAccountantTest(unittest.TestCase):
             accountant.compute_budgets()
             self.assertAlmostEqual(
                 first=case.expected_pipeline_noise_std,
-                second=accountant.minimum_noise_std,
+                second=accountant.base_noise_std,
                 delta=1e-2,
                 msg=f"failed test {case.name} expected pipeline noise "
                 f"{case.expected_pipeline_noise_std} "
-                f"got {accountant.minimum_noise_std}")
+                f"got {accountant.base_noise_std}")
             for mechanism_expectations in actual_mechanisms:
                 expected_mechanism_noise_std, expected_mechanism_epsilon, expected_mechanism_delta, actual_mechanism = mechanism_expectations
-                self.assertAlmostEqual(
-                    first=expected_mechanism_noise_std,
-                    second=actual_mechanism.noise_standard_deviation,
-                    delta=1e-2,
-                    msg=f"failed test {case.name} expected mechanism noise "
-                    f"{expected_mechanism_noise_std} "
-                    f"got {actual_mechanism.noise_standard_deviation}")
                 if actual_mechanism.mechanism_type == MechanismType.GENERIC:
                     self.assertAlmostEqual(
                         first=expected_mechanism_epsilon,
@@ -529,6 +522,14 @@ class PLDBudgetAccountantTest(unittest.TestCase):
                         msg=f"failed test {case.name} expected mechanism delta "
                         f"{expected_mechanism_delta} "
                         f"got {actual_mechanism._delta}")
+                else:  # mechanism != Generic
+                    self.assertAlmostEqual(
+                        first=expected_mechanism_noise_std,
+                        second=actual_mechanism.noise_standard_deviation,
+                        delta=1e-2,
+                        msg=f"failed test {case.name} expected mechanism noise "
+                        f"{expected_mechanism_noise_std} "
+                        f"got {actual_mechanism.noise_standard_deviation}")
 
 
 if __name__ == '__main__':

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -535,7 +535,7 @@ class PLDBudgetAccountantTest(unittest.TestCase):
         accountant = PLDBudgetAccountant(total_epsilon=1.0, total_delta=1e-8)
         thresholding_budget = accountant.request_budget(
             MechanismType.GAUSSIAN_THRESHOLDING)
-        guasisan_budget = accountant.request_budget(MechanismType.GAUSSIAN)
+        gaussian_budget = accountant.request_budget(MechanismType.GAUSSIAN)
         accountant.compute_budgets()
 
         # Gaussian mechanism thresholding and Gaussian mechanism have to have the
@@ -544,16 +544,16 @@ class PLDBudgetAccountantTest(unittest.TestCase):
         self.assertAlmostEqual(thresholding_budget.noise_standard_deviation,
                                7.284667,
                                delta=1e-5)
-        self.assertAlmostEqual(guasisan_budget.noise_standard_deviation,
-                               7.284667,
-                               delta=1e-5)
+        self.assertEqual(gaussian_budget.noise_standard_deviation,
+                         thresholding_budget.noise_standard_deviation)
+        # thresholding gets 25% of total delta
         self.assertEqual(thresholding_budget.thresholding_delta, 1e-8 / 4)
 
     def test_compute_budgets_laplace_thresholding(self):
         accountant = PLDBudgetAccountant(total_epsilon=1.0, total_delta=1e-8)
         thresholding_budget = accountant.request_budget(
             MechanismType.LAPLACE_THRESHOLDING)
-        guasisan_budget = accountant.request_budget(MechanismType.LAPLACE,
+        gaussian_budget = accountant.request_budget(MechanismType.LAPLACE,
                                                     weight=2)
         accountant.compute_budgets()
 
@@ -563,7 +563,7 @@ class PLDBudgetAccountantTest(unittest.TestCase):
         self.assertAlmostEqual(thresholding_budget.noise_standard_deviation,
                                2 * expected_stddev,
                                delta=1e-5)
-        self.assertAlmostEqual(guasisan_budget.noise_standard_deviation,
+        self.assertAlmostEqual(gaussian_budget.noise_standard_deviation,
                                expected_stddev,
                                delta=1e-5)
         self.assertEqual(thresholding_budget.thresholding_delta, 1e-8 / 4)

--- a/tests/dp_computations_test.py
+++ b/tests/dp_computations_test.py
@@ -404,6 +404,23 @@ class DPComputationsTest(parameterized.TestCase):
 
         self.assertAlmostEqual(scale, expected_std)
 
+    def test_gaussian_delta(self):
+        self.assertAlmostEqual(dp_computations.gaussian_delta(5, 1.0),
+                               1.75463e-8,
+                               delta=1e-12)
+        self.assertAlmostEqual(dp_computations.gaussian_delta(3.42, 1.1),
+                               1.00362244e-5,
+                               delta=1e-10)
+
+    def test_gaussian_epsilon(self):
+        self.assertAlmostEqual(dp_computations.gaussian_epsilon(5, 1.75463e-8),
+                               1.00000007214,
+                               delta=1e-10)
+        self.assertAlmostEqual(dp_computations.gaussian_epsilon(
+            3.42, 1.00362244e-5),
+                               1.1000000002386,
+                               delta=1e-10)
+
 
 def create_aggregate_params(
         max_partitions_contributed: Optional[int] = None,

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -1189,7 +1189,7 @@ class DpEngineTest(parameterized.TestCase):
         sys.version_info.major == 3 and sys.version_info.minor <= 8,
         "dp_accounting library only support python >=3.9")
     @parameterized.parameters(False, True)
-    def test_run_e2e_count_public_partition_local(self, pld_accounting):
+    def test_run_e2e_count_public_partition_local(self, pld_accounting=True):
         Accountant = pipeline_dp.PLDBudgetAccountant if pld_accounting else pipeline_dp.NaiveBudgetAccountant
         accountant = Accountant(total_epsilon=1,
                                 total_delta=1e-3,
@@ -1363,21 +1363,6 @@ class DpEngineTest(parameterized.TestCase):
             aggregate_params.metrics = [pipeline_dp.Metrics.VARIANCE]
             engine.aggregate([1], aggregate_params,
                              self._get_default_extractors(), public_partitions)
-
-    @unittest.skipIf(
-        sys.version_info.major == 3 and sys.version_info.minor <= 8,
-        "dp_accounting library only support python >=3.9")
-    def test_pld_not_support_private_partition_selection(self):
-        with self.assertRaisesRegex(
-                NotImplementedError,
-                "PLD budget accounting does not support private partition"):
-            budget_accountant = pipeline_dp.PLDBudgetAccountant(
-                total_epsilon=1, total_delta=1e-10)
-            engine = pipeline_dp.DPEngine(budget_accountant=budget_accountant,
-                                          backend=pipeline_dp.LocalBackend())
-            aggregate_params, _ = self._create_params_default()
-            engine.aggregate([1], aggregate_params,
-                             self._get_default_extractors())
 
     @parameterized.named_parameters(
         dict(testcase_name='Gaussian',

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -1189,7 +1189,7 @@ class DpEngineTest(parameterized.TestCase):
         sys.version_info.major == 3 and sys.version_info.minor <= 8,
         "dp_accounting library only support python >=3.9")
     @parameterized.parameters(False, True)
-    def test_run_e2e_count_public_partition_local(self, pld_accounting=True):
+    def test_run_e2e_count_public_partition_local(self, pld_accounting):
         Accountant = pipeline_dp.PLDBudgetAccountant if pld_accounting else pipeline_dp.NaiveBudgetAccountant
         accountant = Accountant(total_epsilon=1,
                                 total_delta=1e-3,

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -466,7 +466,7 @@ class DpEngineTest(parameterized.TestCase):
                 "Cross-partition contribution bounding: for each privacy id "
                 "randomly select max(actual_partition_contributed, 3)",
                 "Private Partition selection: using Truncated Geometric "
-                "method with (eps="
+                "method with (epsilon="
             ],
         )
 

--- a/tests/partition_selection_test.py
+++ b/tests/partition_selection_test.py
@@ -16,8 +16,8 @@ from pipeline_dp import partition_selection
 
 from absl.testing import absltest
 from absl.testing import parameterized
-import unittest
 from unittest.mock import patch
+import math
 
 
 class PartitionSelectionTest(parameterized.TestCase):
@@ -66,6 +66,27 @@ class PartitionSelectionTest(parameterized.TestCase):
             delta, max_partitions, pre_threshold)
         mock_method.assert_called_once_with("gaussian", eps, delta,
                                             max_partitions, pre_threshold)
+
+    @patch("pydp.algorithms.partition_selection.create_partition_strategy")
+    def test_truncated_laplace_thresholding_with_sigma(self, mock_method):
+        sigma, delta, max_partitions_contributed, pre_threshold = 1.5, 1e-5, 2, 3
+        partition_selection.create_laplace_thresholding(
+            sigma, delta, max_partitions_contributed, pre_threshold)
+        mock_method.assert_called_once_with("laplace",
+                                            math.sqrt(2) / sigma, delta,
+                                            max_partitions_contributed,
+                                            pre_threshold)
+
+    @patch("pydp.algorithms.partition_selection.create_partition_strategy")
+    def test_truncated_gaussian_thresholding_with_sigma(self, mock_method):
+        sigma, delta, max_partitions_contributed, pre_threshold = 1.5, 1e-5, 5, 10
+        partition_selection.create_gaussian_thresholding(
+            sigma, delta, max_partitions_contributed, pre_threshold)
+        expected_epsilon = 2.7533813795016613
+        mock_method.assert_called_once_with("gaussian", expected_epsilon,
+                                            2 * delta,
+                                            max_partitions_contributed,
+                                            pre_threshold)
 
 
 if __name__ == '__main__':

--- a/tests/partition_selection_test.py
+++ b/tests/partition_selection_test.py
@@ -67,26 +67,25 @@ class PartitionSelectionTest(parameterized.TestCase):
         mock_method.assert_called_once_with("gaussian", eps, delta,
                                             max_partitions, pre_threshold)
 
-    @patch("pydp.algorithms.partition_selection.create_partition_strategy")
-    def test_truncated_laplace_thresholding_with_sigma(self, mock_method):
+    def test_truncated_laplace_thresholding_with_sigma(self):
         sigma, delta, max_partitions_contributed, pre_threshold = 1.5, 1e-5, 2, 3
-        partition_selection.create_laplace_thresholding(
+        thresholding = partition_selection.create_laplace_thresholding(
             sigma, delta, max_partitions_contributed, pre_threshold)
-        mock_method.assert_called_once_with("laplace",
-                                            math.sqrt(2) / sigma, delta,
-                                            max_partitions_contributed,
-                                            pre_threshold)
 
-    @patch("pydp.algorithms.partition_selection.create_partition_strategy")
-    def test_truncated_gaussian_thresholding_with_sigma(self, mock_method):
+        expected_epsilon = math.sqrt(2) / sigma
+        self.assertEqual(thresholding.epsilon, expected_epsilon)
+        self.assertEqual(thresholding.delta, delta)
+        self.assertEqual(thresholding.max_partitions_contributed, 2)
+        self.assertEqual(thresholding.pre_threshold, 3)
+
+    def test_truncated_gaussian_thresholding_with_sigma(self):
         sigma, delta, max_partitions_contributed, pre_threshold = 1.5, 1e-5, 5, 10
-        partition_selection.create_gaussian_thresholding(
+        thresholding = partition_selection.create_gaussian_thresholding(
             sigma, delta, max_partitions_contributed, pre_threshold)
-        expected_epsilon = 2.7533813795016613
-        mock_method.assert_called_once_with("gaussian", expected_epsilon,
-                                            2 * delta,
-                                            max_partitions_contributed,
-                                            pre_threshold)
+        self.assertAlmostEqual(thresholding.epsilon, 2.753381, delta=1e-5)
+        self.assertEqual(thresholding.delta, 2 * delta)
+        self.assertEqual(thresholding.max_partitions_contributed, 5)
+        self.assertEqual(thresholding.pre_threshold, 10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements support of Laplace/Gaussian thresholding in `PLDBudgetAccountant`. It's implemented the following way.

PLD implementation for dp_accounting doesn't directly support thresholding, we need to track indpendently threshold delta (e.g. Gaussian Thresholding = (Gaussian Mechanism, threshold delta). `0.25*total_delta` is taken of  threshold_deltas of thresholding mechanisms (0.25 is rather arbitrary). (this implemented in budget_accountant.py)

Another complication is that the output of PLD computations for Thresholding is stddev of the noise and threshold_delta. PyDP supports only `(epsilon, delta)` for partition selection, so we need to choose  proper `(epsilon, delta)` (implementation in partition_selection.py)