### PR TITLE
Add an option to add noise standard deviation to the ouput of add_dp_noise

### DIFF
--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -700,6 +700,9 @@ class AddDPNoiseParams:
        l2_sensitivity: the sensitivity in L2 norm.
        budget_weight: Relative weight of the privacy budget allocated to this
          aggregation.
+       output_noise_stddev: if True, the output will contain the applied noise
+         standard deviation, namely the output will be NamedTuple(noisified_value,
+         noise_stddev).
    """
     noise_kind: NoiseKind
     l0_sensitivity: Optional[int] = None
@@ -707,6 +710,7 @@ class AddDPNoiseParams:
     l1_sensitivity: Optional[float] = None
     l2_sensitivity: Optional[float] = None
     budget_weight: float = 1
+    output_noise_stddev: bool = False
 
     def __post_init__(self):
 

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -613,7 +613,7 @@ class DPEngine:
 
         if params.output_noise_stddev:
             Output = collections.namedtuple("Output",
-                                            ["noisified_value", "noise_stddev"])
+                                            ["noised_value", "noise_stddev"])
 
             def add_noise(value: Union[int, float]) -> float:
                 mechanism = create_mechanism()

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """DP aggregations."""
+import collections
 import functools
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
@@ -609,8 +610,20 @@ class DPEngine:
         self._add_report_stage(
             lambda: f"Adding {create_mechanism().noise_kind} noise with "
             f"parameter {create_mechanism().noise_parameter}")
-        anonymized_col = self._backend.map_values(
-            col, lambda value: create_mechanism().add_noise(value), "Add noise")
+
+        if params.output_noise_stddev:
+            Output = collections.namedtuple("Output",
+                                            ["noisified_value", "noise_stddev"])
+
+            def add_noise(value: Union[int, float]) -> float:
+                mechanism = create_mechanism()
+                return Output(mechanism.add_noise(value), mechanism.std)
+        else:
+
+            def add_noise(value: Union[int, float]) -> float:
+                return create_mechanism().add_noise(value)
+
+        anonymized_col = self._backend.map_values(col, add_noise(), "Add noise")
 
         budget = self._budget_accountant._compute_budget_for_aggregation(
             params.budget_weight)

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -623,7 +623,7 @@ class DPEngine:
             def add_noise(value: Union[int, float]) -> float:
                 return create_mechanism().add_noise(value)
 
-        anonymized_col = self._backend.map_values(col, add_noise(), "Add noise")
+        anonymized_col = self._backend.map_values(col, add_noise, "Add noise")
 
         budget = self._budget_accountant._compute_budget_for_aggregation(
             params.budget_weight)

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -1454,6 +1454,8 @@ class DpEngineTest(parameterized.TestCase):
                 (value.noisified_value - index) for index, value in output
             ]
             self.assertAlmostEqual(output[0][1].noise_stddev, 53.03, delta=0.01)
+        else:
+            noise_values = [(value - index) for index, value in output]
         self.assertGreater(np.std(noise_values), 10)
         # Expected Laplace parameter is
         # l0_sensitivity*linf_sensitivity/epsilon = 5*15/2 = 37.5

--- a/tests/dp_engine_test.py
+++ b/tests/dp_engine_test.py
@@ -1451,7 +1451,7 @@ class DpEngineTest(parameterized.TestCase):
         # Assert
         if output_noise_stddev:
             noise_values = [
-                (value.noisified_value - index) for index, value in output
+                (value.noised_value - index) for index, value in output
             ]
             self.assertAlmostEqual(output[0][1].noise_stddev, 53.03, delta=0.01)
         else:


### PR DESCRIPTION
It's similar to [PR](https://github.com/OpenMined/PipelineDP/pull/550), but for another function  `DPEngine.add_dp_noise`.