### PR TITLE
Support count of operations for PLD

### DIFF
--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -491,15 +491,15 @@ class PLDBudgetAccountant(BudgetAccountant):
                 "Please ensure that compute_budgets() is called after DP "
                 "aggregations.")
 
-        if count != 1 or noise_standard_deviation is not None:
+        if noise_standard_deviation is not None:
             raise NotImplementedError(
-                "Count and noise standard deviation have not been implemented yet."
-            )
+                "Noise standard deviation have not been implemented yet.")
         if mechanism_type == agg_params.MechanismType.GAUSSIAN and self._total_delta == 0:
             raise AssertionError(
                 "The Gaussian mechanism requires that the pipeline delta is greater than 0"
             )
-        mechanism_spec = MechanismSpec(mechanism_type=mechanism_type)
+        mechanism_spec = MechanismSpec(mechanism_type=mechanism_type,
+                                       _count=count)
         mechanism_spec_internal = MechanismSpecInternal(
             mechanism_spec=mechanism_spec,
             sensitivity=sensitivity,
@@ -614,6 +614,9 @@ class PLDBudgetAccountant(BudgetAccountant):
                         epsilon_0_interim, delta_0_interim),
                     value_discretization_interval=self._pld_discretization)
 
+            count = mechanism_spec_internal.mechanism_spec.count
+            if count > 1:
+                pld = pld.self_compose(count)
             composed = pld if composed is None else composed.compose(pld)
 
         return composed

--- a/tests/budget_accounting_test.py
+++ b/tests/budget_accounting_test.py
@@ -474,7 +474,7 @@ class PLDBudgetAccountantTest(unittest.TestCase):
             accountant = PLDBudgetAccountant(case.epsilon, case.delta, 1e-2)
             actual_mechanisms = []
             for mechanism in case.mechanisms:
-                for _ in range(0, mechanism.count):
+                for _ in range(mechanism.count):
                     actual_mechanisms.append(
                         (mechanism.expected_noise_std,
                          mechanism.expected_mechanism_epsilon,
@@ -529,6 +529,20 @@ class PLDBudgetAccountantTest(unittest.TestCase):
                         msg=f"failed test {case.name} expected mechanism delta "
                         f"{expected_mechanism_delta} "
                         f"got {actual_mechanism._delta}")
+
+    def test_compute_budets_with_count_greater_1(self):
+        accountant = PLDBudgetAccountant(1.0, 1e-12, 1e-2)
+        budget = accountant.request_budget(MechanismType.LAPLACE,
+                                           weight=1.0,
+                                           count=100)
+        accountant.compute_budgets()
+        self.assertEqual(budget.count, 100)
+        # W/o PLD, with Naive composition, the standard deviation for the noise
+        # would be count/eps*sqrt(2) ~= 100/1.0*1.41421 ~= 141, with PLD it's
+        # clearly better.
+        self.assertAlmostEqual(budget.noise_standard_deviation,
+                               94.656,
+                               delta=1e-3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds support for the count argument to the `PLDBudgetAccoun.request_budget`. It's convenient when we need to apply some mechanism 10 times, we can write

```
budget = accountant.request_budget(..., count=10)
```

instead of

```
budgets = []
for _ in range(10):
  budgets.append(accountant.request_budget(...))
```