### PR TITLE
Fix #551: Clipping VectorSum per contribution

### DIFF
--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -14,16 +14,17 @@
 """Combiners for computing DP aggregations."""
 
 import abc
-import copy
-from typing import Callable, Iterable, Sized, Tuple, List, Union, Optional
-
-import pipeline_dp
-from pipeline_dp import dp_computations, NormKind
-from pipeline_dp import budget_accounting
-import numpy as np
 import collections
+import copy
+from typing import Callable, Iterable, Sized, Tuple, List, Union
+
+import numpy as np
 import pydp
 from pydp.algorithms import quantile_tree
+
+import pipeline_dp
+from pipeline_dp import budget_accounting
+from pipeline_dp import dp_computations, NormKind
 
 ArrayLike = Union[np.ndarray, List[float]]
 ExplainComputationReport = Union[Callable, str, List[Union[Callable, str]]]
@@ -55,8 +56,16 @@ class Combiner(abc.ABC):
 
     @abc.abstractmethod
     def create_accumulator(self, values):
-        """Creates accumulator from 'values'. Values should be all the contributions of a given privacy ID for a
-        partition."""
+        """Creates an accumulator from a collection of privacy ID contributions.
+
+            Args:
+                values: A collection of contributions from a single privacy ID within a
+                    specific partition. These contributions will be aggregated into
+                    the accumulator.
+
+            Returns:
+                An accumulator object representing the aggregated contributions.
+        """
 
     @abc.abstractmethod
     def merge_accumulators(self, accumulator1, accumulator2):
@@ -842,8 +851,7 @@ class VectorSumCombiner(Combiner):
 
     def _clip_vector(self, vec: np.ndarray):
         norm_kind: NormKind = self._params.aggregate_params.vector_norm_kind
-        max_norm: Optional[
-            float] = self._params.aggregate_params.vector_max_norm
+        max_norm: float = self._params.aggregate_params.vector_max_norm
         if norm_kind == NormKind.Linf:
             return np.clip(vec, -max_norm, max_norm)
         if norm_kind in {NormKind.L1, NormKind.L2}:

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -857,6 +857,8 @@ class VectorSumCombiner(Combiner):
         if norm_kind in {NormKind.L1, NormKind.L2}:
             norm_ord = 1 if norm_kind == NormKind.L1 else 2
             vec_norm = np.linalg.norm(vec, ord=norm_ord)
+            if vec_norm == 0.0:
+                return vec
             mul_coef = min(1, max_norm / vec_norm)
             return vec * mul_coef
         raise NotImplementedError(

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -55,7 +55,8 @@ class Combiner(abc.ABC):
 
     @abc.abstractmethod
     def create_accumulator(self, values):
-        """Creates accumulator from 'values'. values are from one privacy ID"""
+        """Creates accumulator from 'values'. Values should be all the contributions of a given privacy ID for a
+        partition."""
 
     @abc.abstractmethod
     def merge_accumulators(self, accumulator1, accumulator2):
@@ -831,9 +832,9 @@ class VectorSumCombiner(Combiner):
         if norm_kind == NormKind.Linf:
             return np.clip(vec, -max_norm, max_norm)
         if norm_kind in {NormKind.L1, NormKind.L2}:
-            norm_digit = int(str(norm_kind.value)[-1])  # 1 or 2
+            norm_digit = int(norm_kind.value[-1])  # 1 or 2
             vec_norm = np.linalg.norm(vec, ord=norm_digit)
-            mul_coef = min(1, int(float(max_norm) / float(vec_norm)))
+            mul_coef = min(1, max_norm / vec_norm)
             return vec * mul_coef
         raise NotImplementedError(
             f"Vector Norm of kind '{norm_kind}' is not supported.")

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -855,8 +855,8 @@ class VectorSumCombiner(Combiner):
         if norm_kind == NormKind.Linf:
             return np.clip(vec, -max_norm, max_norm)
         if norm_kind in {NormKind.L1, NormKind.L2}:
-            norm_digit = int(norm_kind.value[-1])  # 1 or 2
-            vec_norm = np.linalg.norm(vec, ord=norm_digit)
+            norm_ord = 1 if norm_kind == NormKind.L1 else 2
+            vec_norm = np.linalg.norm(vec, ord=norm_ord)
             mul_coef = min(1, max_norm / vec_norm)
             return vec * mul_coef
         raise NotImplementedError(

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -194,20 +194,6 @@ class AdditiveVectorNoiseParams:
     noise_kind: pipeline_dp.NoiseKind
 
 
-def _clip_vector(vec: np.ndarray, max_norm: float,
-                 norm_kind: pipeline_dp.NormKind):
-    norm_kind = norm_kind.value  # type: str
-    if norm_kind == "linf":
-        return np.clip(vec, -max_norm, max_norm)
-    if norm_kind in {"l1", "l2"}:
-        norm_kind = int(norm_kind[-1])
-        vec_norm = np.linalg.norm(vec, ord=norm_kind)
-        mul_coef = min(1, max_norm / vec_norm)
-        return vec * mul_coef
-    raise NotImplementedError(
-        f"Vector Norm of kind '{norm_kind}' is not supported.")
-
-
 def add_noise_vector(vec: np.ndarray, noise_params: AdditiveVectorNoiseParams):
     """Adds noise to vector to make the vector sum computation (eps, delta)-DP.
 
@@ -215,7 +201,6 @@ def add_noise_vector(vec: np.ndarray, noise_params: AdditiveVectorNoiseParams):
         vec: the queried raw vector
         noise_params: parameters of the noise to add to the computation
     """
-    vec = _clip_vector(vec, noise_params.max_norm, noise_params.norm_kind)
     vec = np.array([
         _add_random_noise(
             s,

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -46,9 +46,9 @@ class EmptyCombiner(dp_combiners.Combiner):
 
 
 def _create_mechanism_spec(
-        no_noise: bool,
-        mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
-        GAUSSIAN
+    no_noise: bool,
+    mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
+    GAUSSIAN
 ) -> ba.MechanismSpec:
     if no_noise:
         eps, delta = 1e5, 1.0 - 1e-5
@@ -59,11 +59,11 @@ def _create_mechanism_spec(
 
 
 def _create_aggregate_params(
-        max_value: float = 1,
-        vector_size: int = 1,
-        vector_norm_kind: NormKind = pipeline_dp.NormKind.Linf,
-        vector_max_norm: int = 5,
-        output_noise_stddev: bool = False,
+    max_value: float = 1,
+    vector_size: int = 1,
+    vector_norm_kind: NormKind = pipeline_dp.NormKind.Linf,
+    vector_max_norm: int = 5,
+    output_noise_stddev: bool = False,
 ):
     return pipeline_dp.AggregateParams(
         min_value=0,
@@ -231,11 +231,11 @@ class CreateCompoundCombinersTest(parameterized.TestCase):
 class CountCombinerTest(parameterized.TestCase):
 
     def _create_combiner(
-            self,
-            no_noise: bool,
-            mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
-            GAUSSIAN,
-            output_noise_stddev: bool = False,
+        self,
+        no_noise: bool,
+        mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
+        GAUSSIAN,
+        output_noise_stddev: bool = False,
     ) -> dp_combiners.CountCombiner:
         mechanism_spec = _create_mechanism_spec(no_noise, mechanism_type)
         aggregate_params = _create_aggregate_params(
@@ -322,11 +322,11 @@ class CountCombinerTest(parameterized.TestCase):
 class PrivacyIdCountCombinerTest(parameterized.TestCase):
 
     def _create_combiner(
-            self,
-            no_noise: bool,
-            mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
-            GAUSSIAN,
-            output_noise_stddev: bool = False,
+        self,
+        no_noise: bool,
+        mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
+        GAUSSIAN,
+        output_noise_stddev: bool = False,
     ) -> dp_combiners.PrivacyIdCountCombiner:
         mechanism_spec = _create_mechanism_spec(no_noise, mechanism_type)
         aggregate_params = _create_aggregate_params(
@@ -414,12 +414,12 @@ class PrivacyIdCountCombinerTest(parameterized.TestCase):
 class PostAggregationThresholdingCombinerTest(parameterized.TestCase):
 
     def _create_combiner(
-            self,
-            small_noise: bool = False,
-            noise_kind: pipeline_dp.NoiseKind = pipeline_dp.NoiseKind.GAUSSIAN,
-            pre_threshold: Optional[int] = None
+        self,
+        small_noise: bool = False,
+        noise_kind: pipeline_dp.NoiseKind = pipeline_dp.NoiseKind.GAUSSIAN,
+        pre_threshold: Optional[int] = None
     ) -> dp_combiners.PostAggregationThresholdingCombiner:
-        eps, delta = (10 ** 3, 0.1) if small_noise else (1, 1e-10)
+        eps, delta = (10**3, 0.1) if small_noise else (1, 1e-10)
         budget_accountant = pipeline_dp.NaiveBudgetAccountant(eps, delta)
         aggregate_params = _create_aggregate_params()
         aggregate_params.noise_kind = noise_kind
@@ -539,13 +539,13 @@ class SumCombinerTest(parameterized.TestCase):
             output_noise_stddev=output_noise_stddev)
 
     def _create_combiner(
-            self,
-            no_noise: bool,
-            per_partition_bound: bool,
-            max_value=1.0,
-            mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
-            GAUSSIAN,
-            output_noise_stddev: bool = False,
+        self,
+        no_noise: bool,
+        per_partition_bound: bool,
+        max_value=1.0,
+        mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
+        GAUSSIAN,
+        output_noise_stddev: bool = False,
     ) -> dp_combiners.SumCombiner:
         mechanism_spec = _create_mechanism_spec(no_noise, mechanism_type)
         if per_partition_bound:
@@ -851,7 +851,7 @@ class CompoundCombinerTest(parameterized.TestCase):
             dp_combiners.CountCombiner(mechanism_spec, aggregate_params),
             dp_combiners.SumCombiner(mechanism_spec, aggregate_params)
         ],
-            return_named_tuple=True)
+                                             return_named_tuple=True)
 
     @parameterized.named_parameters(
         dict(testcase_name='no_noise', no_noise=True),
@@ -902,6 +902,7 @@ class CompoundCombinerTest(parameterized.TestCase):
         self.assertTrue(np.var(noised_sum) > 1)  # check that noise is added
 
     def test_expects_per_partition_sampling(self):
+
         class MockCombiner(EmptyCombiner):
 
             def __init__(self, return_value: bool):
@@ -925,25 +926,33 @@ class CompoundCombinerTest(parameterized.TestCase):
 
 class VectorSumCombinerTest(parameterized.TestCase):
 
-    def _create_combiner(self, no_noise: bool, vector_size: int, vector_norm_kind: NormKind = NormKind.Linf,
-                         vector_max_norm: int = 5) -> dp_combiners.VectorSumCombiner:
+    def _create_combiner(
+            self,
+            no_noise: bool,
+            vector_size: int,
+            vector_norm_kind: NormKind = NormKind.Linf,
+            vector_max_norm: int = 5) -> dp_combiners.VectorSumCombiner:
         mechanism_spec = _create_mechanism_spec(no_noise)
-        aggregate_params = _create_aggregate_params(vector_size=vector_size, vector_norm_kind=vector_norm_kind,
-                                                    vector_max_norm=vector_max_norm)
+        aggregate_params = _create_aggregate_params(
+            vector_size=vector_size,
+            vector_norm_kind=vector_norm_kind,
+            vector_max_norm=vector_max_norm)
         params = dp_combiners.CombinerParams(mechanism_spec, aggregate_params)
         return dp_combiners.VectorSumCombiner(params)
 
-    @parameterized.product(
-        testcase=[dict(input_vector=[[]], output_vector=[]),
-                  dict(input_vector=[[0]], output_vector=[0]),
-                  dict(input_vector=[[0, 0]], output_vector=[0, 0]),
-                  dict(input_vector=[[1], [2]], output_vector=[3]),
-                  dict(input_vector=[[1, 2], [3, 4]], output_vector=[4, 6]),
-                  dict(input_vector=[[1, 2, 3], [4, 5, 6]], output_vector=[5, 7, 9])],
-        norm_kind=[NormKind.Linf, NormKind.L1, NormKind.L2]
-    )
+    @parameterized.product(testcase=[
+        dict(input_vector=[[]], output_vector=[]),
+        dict(input_vector=[[0]], output_vector=[0]),
+        dict(input_vector=[[0, 0]], output_vector=[0, 0]),
+        dict(input_vector=[[1], [2]], output_vector=[3]),
+        dict(input_vector=[[1, 2], [3, 4]], output_vector=[4, 6]),
+        dict(input_vector=[[1, 2, 3], [4, 5, 6]], output_vector=[5, 7, 9])
+    ],
+                           norm_kind=[NormKind.Linf, NormKind.L1, NormKind.L2])
     def test_create_accumulator_sums_correctly(self, testcase, norm_kind):
-        combiner = self._create_combiner(no_noise=True, vector_size=len(testcase['input_vector'][0]),
+        combiner = self._create_combiner(no_noise=True,
+                                         vector_size=len(
+                                             testcase['input_vector'][0]),
                                          vector_norm_kind=norm_kind,
                                          vector_max_norm=999)  # no clipping
 
@@ -952,18 +961,48 @@ class VectorSumCombinerTest(parameterized.TestCase):
         np.testing.assert_array_equal(result, testcase['output_vector'])
 
     @parameterized.parameters(
-        dict(norm_kind=NormKind.Linf, norm=5, input_vector=[[6]], output_vector=[5]),
-        dict(norm_kind=NormKind.Linf, norm=5, input_vector=[[6], [7]], output_vector=[5]),
-        dict(norm_kind=NormKind.Linf, norm=5, input_vector=[[5, 6]], output_vector=[5, 5]),
-        dict(norm_kind=NormKind.L1, norm=10, input_vector=[[11]], output_vector=[10]),
-        dict(norm_kind=NormKind.L1, norm=10, input_vector=[[5], [6]], output_vector=[10]),
-        dict(norm_kind=NormKind.L1, norm=5, input_vector=[[6, 6]], output_vector=[2.5, 2.5]),
-        dict(norm_kind=NormKind.L2, norm=5, input_vector=[[6]], output_vector=[5]),
-        dict(norm_kind=NormKind.L2, norm=5, input_vector=[[4], [4]], output_vector=[5]),
-        dict(norm_kind=NormKind.L2, norm=4, input_vector=[[3, 4]], output_vector=[2.4, 3.2]),
+        dict(norm_kind=NormKind.Linf,
+             norm=5,
+             input_vector=[[6]],
+             output_vector=[5]),
+        dict(norm_kind=NormKind.Linf,
+             norm=5,
+             input_vector=[[6], [7]],
+             output_vector=[5]),
+        dict(norm_kind=NormKind.Linf,
+             norm=5,
+             input_vector=[[5, 6]],
+             output_vector=[5, 5]),
+        dict(norm_kind=NormKind.L1,
+             norm=10,
+             input_vector=[[11]],
+             output_vector=[10]),
+        dict(norm_kind=NormKind.L1,
+             norm=10,
+             input_vector=[[5], [6]],
+             output_vector=[10]),
+        dict(norm_kind=NormKind.L1,
+             norm=5,
+             input_vector=[[6, 6]],
+             output_vector=[2.5, 2.5]),
+        dict(norm_kind=NormKind.L2,
+             norm=5,
+             input_vector=[[6]],
+             output_vector=[5]),
+        dict(norm_kind=NormKind.L2,
+             norm=5,
+             input_vector=[[4], [4]],
+             output_vector=[5]),
+        dict(norm_kind=NormKind.L2,
+             norm=4,
+             input_vector=[[3, 4]],
+             output_vector=[2.4, 3.2]),
     )
-    def test_create_accumulator_clips_correctly(self, norm_kind, norm, input_vector, output_vector):
-        combiner = self._create_combiner(no_noise=True, vector_size=len(input_vector[0]), vector_norm_kind=norm_kind,
+    def test_create_accumulator_clips_correctly(self, norm_kind, norm,
+                                                input_vector, output_vector):
+        combiner = self._create_combiner(no_noise=True,
+                                         vector_size=len(input_vector[0]),
+                                         vector_norm_kind=norm_kind,
                                          vector_max_norm=norm)  # clips by norm
 
         result = combiner.create_accumulator(input_vector)

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -46,9 +46,9 @@ class EmptyCombiner(dp_combiners.Combiner):
 
 
 def _create_mechanism_spec(
-        no_noise: bool,
-        mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
-        GAUSSIAN
+    no_noise: bool,
+    mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
+    GAUSSIAN
 ) -> ba.MechanismSpec:
     if no_noise:
         eps, delta = 1e5, 1.0 - 1e-5
@@ -59,11 +59,11 @@ def _create_mechanism_spec(
 
 
 def _create_aggregate_params(
-        max_value: float = 1,
-        vector_size: int = 1,
-        vector_norm_kind: NormKind = pipeline_dp.NormKind.Linf,
-        vector_max_norm: int = 5,
-        output_noise_stddev: bool = False,
+    max_value: float = 1,
+    vector_size: int = 1,
+    vector_norm_kind: NormKind = pipeline_dp.NormKind.Linf,
+    vector_max_norm: int = 5,
+    output_noise_stddev: bool = False,
 ):
     return pipeline_dp.AggregateParams(
         min_value=0,
@@ -454,10 +454,10 @@ class PostAggregationThresholdingCombinerTest(parameterized.TestCase):
         # Arrange/act
         budget_accountant = pipeline_dp.NaiveBudgetAccountant(total_epsilon=1,
                                                               total_delta=1e-10)
-        params = _create_aggregate_params()
-        params.noise_kind = noise_kind
+        aggregate_params = _create_aggregate_params()
+        aggregate_params.noise_kind = noise_kind
         combiner = dp_combiners.PostAggregationThresholdingCombiner(
-            budget_accountant, params)
+            budget_accountant, aggregate_params)
         budget_accountant.compute_budgets()
 
         # Assert
@@ -851,7 +851,7 @@ class CompoundCombinerTest(parameterized.TestCase):
             dp_combiners.CountCombiner(mechanism_spec, aggregate_params),
             dp_combiners.SumCombiner(mechanism_spec, aggregate_params)
         ],
-            return_named_tuple=True)
+                                             return_named_tuple=True)
 
     @parameterized.named_parameters(
         dict(testcase_name='no_noise', no_noise=True),
@@ -902,6 +902,7 @@ class CompoundCombinerTest(parameterized.TestCase):
         self.assertTrue(np.var(noised_sum) > 1)  # check that noise is added
 
     def test_expects_per_partition_sampling(self):
+
         class MockCombiner(EmptyCombiner):
 
             def __init__(self, return_value: bool):

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -880,6 +880,18 @@ class VectorSumCombinerTest(parameterized.TestCase):
         dict(testcase_name='no_noise', no_noise=True),
         dict(testcase_name='noise', no_noise=False),
     )
+    def test_create_accumulator_clips_individual_contributions(self, no_noise):
+        combiner = self._create_combiner(no_noise, vector_size=1)
+        self.assertEqual(np.array([5]), combiner.create_accumulator([[6]]))
+        self.assertEqual(
+            np.array([5]),
+            combiner.create_accumulator([np.array([7]),
+                                         np.array([8])]))
+
+    @parameterized.named_parameters(
+        dict(testcase_name='no_noise', no_noise=True),
+        dict(testcase_name='noise', no_noise=False),
+    )
     def test_merge_accumulators(self, no_noise):
         combiner = self._create_combiner(no_noise, vector_size=1)
         self.assertEqual(

--- a/tests/combiners_test.py
+++ b/tests/combiners_test.py
@@ -46,9 +46,9 @@ class EmptyCombiner(dp_combiners.Combiner):
 
 
 def _create_mechanism_spec(
-    no_noise: bool,
-    mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
-    GAUSSIAN
+        no_noise: bool,
+        mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
+        GAUSSIAN
 ) -> ba.MechanismSpec:
     if no_noise:
         eps, delta = 1e5, 1.0 - 1e-5
@@ -59,11 +59,11 @@ def _create_mechanism_spec(
 
 
 def _create_aggregate_params(
-    max_value: float = 1,
-    vector_size: int = 1,
-    vector_norm_kind: NormKind = pipeline_dp.NormKind.Linf,
-    vector_max_norm: int = 5,
-    output_noise_stddev: bool = False,
+        max_value: float = 1,
+        vector_size: int = 1,
+        vector_norm_kind: NormKind = pipeline_dp.NormKind.Linf,
+        vector_max_norm: int = 5,
+        output_noise_stddev: bool = False,
 ):
     return pipeline_dp.AggregateParams(
         min_value=0,
@@ -231,11 +231,11 @@ class CreateCompoundCombinersTest(parameterized.TestCase):
 class CountCombinerTest(parameterized.TestCase):
 
     def _create_combiner(
-        self,
-        no_noise: bool,
-        mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
-        GAUSSIAN,
-        output_noise_stddev: bool = False,
+            self,
+            no_noise: bool,
+            mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
+            GAUSSIAN,
+            output_noise_stddev: bool = False,
     ) -> dp_combiners.CountCombiner:
         mechanism_spec = _create_mechanism_spec(no_noise, mechanism_type)
         aggregate_params = _create_aggregate_params(
@@ -322,11 +322,11 @@ class CountCombinerTest(parameterized.TestCase):
 class PrivacyIdCountCombinerTest(parameterized.TestCase):
 
     def _create_combiner(
-        self,
-        no_noise: bool,
-        mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
-        GAUSSIAN,
-        output_noise_stddev: bool = False,
+            self,
+            no_noise: bool,
+            mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
+            GAUSSIAN,
+            output_noise_stddev: bool = False,
     ) -> dp_combiners.PrivacyIdCountCombiner:
         mechanism_spec = _create_mechanism_spec(no_noise, mechanism_type)
         aggregate_params = _create_aggregate_params(
@@ -539,13 +539,13 @@ class SumCombinerTest(parameterized.TestCase):
             output_noise_stddev=output_noise_stddev)
 
     def _create_combiner(
-        self,
-        no_noise: bool,
-        per_partition_bound: bool,
-        max_value=1.0,
-        mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
-        GAUSSIAN,
-        output_noise_stddev: bool = False,
+            self,
+            no_noise: bool,
+            per_partition_bound: bool,
+            max_value=1.0,
+            mechanism_type: pipeline_dp.MechanismType = pipeline_dp.MechanismType.
+            GAUSSIAN,
+            output_noise_stddev: bool = False,
     ) -> dp_combiners.SumCombiner:
         mechanism_spec = _create_mechanism_spec(no_noise, mechanism_type)
         if per_partition_bound:
@@ -851,7 +851,7 @@ class CompoundCombinerTest(parameterized.TestCase):
             dp_combiners.CountCombiner(mechanism_spec, aggregate_params),
             dp_combiners.SumCombiner(mechanism_spec, aggregate_params)
         ],
-                                             return_named_tuple=True)
+            return_named_tuple=True)
 
     @parameterized.named_parameters(
         dict(testcase_name='no_noise', no_noise=True),
@@ -902,7 +902,6 @@ class CompoundCombinerTest(parameterized.TestCase):
         self.assertTrue(np.var(noised_sum) > 1)  # check that noise is added
 
     def test_expects_per_partition_sampling(self):
-
         class MockCombiner(EmptyCombiner):
 
             def __init__(self, return_value: bool):
@@ -947,14 +946,15 @@ class VectorSumCombinerTest(parameterized.TestCase):
         combiner = self._create_combiner(no_noise=True, vector_size=len(testcase['input_vector'][0]),
                                          vector_norm_kind=norm_kind,
                                          vector_max_norm=999)  # no clipping
-        self.assertIsNone(np.testing.assert_array_equal(
-            combiner.create_accumulator(testcase['input_vector']), testcase['output_vector']))
+
+        result = combiner.create_accumulator(testcase['input_vector'])
+
+        np.testing.assert_array_equal(result, testcase['output_vector'])
 
     @parameterized.parameters(
         dict(norm_kind=NormKind.Linf, norm=5, input_vector=[[6]], output_vector=[5]),
         dict(norm_kind=NormKind.Linf, norm=5, input_vector=[[6], [7]], output_vector=[5]),
         dict(norm_kind=NormKind.Linf, norm=5, input_vector=[[5, 6]], output_vector=[5, 5]),
-        # L0 noise not implemented at the moment
         dict(norm_kind=NormKind.L1, norm=10, input_vector=[[11]], output_vector=[10]),
         dict(norm_kind=NormKind.L1, norm=10, input_vector=[[5], [6]], output_vector=[10]),
         dict(norm_kind=NormKind.L1, norm=5, input_vector=[[6, 6]], output_vector=[2.5, 2.5]),
@@ -965,8 +965,10 @@ class VectorSumCombinerTest(parameterized.TestCase):
     def test_create_accumulator_clips_correctly(self, norm_kind, norm, input_vector, output_vector):
         combiner = self._create_combiner(no_noise=True, vector_size=len(input_vector[0]), vector_norm_kind=norm_kind,
                                          vector_max_norm=norm)  # clips by norm
-        self.assertIsNone(
-            np.testing.assert_almost_equal(combiner.create_accumulator(input_vector), output_vector, decimal=3))
+
+        result = combiner.create_accumulator(input_vector)
+
+        np.testing.assert_almost_equal(result, output_vector, decimal=3)
 
     def test_merge_accumulators(self):
         combiner = self._create_combiner(no_noise=True, vector_size=1)


### PR DESCRIPTION
## Description

Fixes https://github.com/OpenMined/PipelineDP/issues/551

## Affected Dependencies

None

## How has this been tested?
- Added a failing test `test_create_accumulator_clips_individual_contributions` in which `VectorSum` combiners are not clipped as they should
- Modified `combiners.py` to do the clipping as was done in `dp_computations.py`. Test now passes.
- Removed the clipping in `dp_computations.py`. I considered adding a test that there was /no/ clipping here, but this would contradict the normal behavior where the vectors received at this stage are already clipped, so I did not.
- All existing tests now pass.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
