### PR TITLE
Make LocalBackend methods output reiterable

### DIFF
--- a/examples/movie_view_ratings/run_without_frameworks.py
+++ b/examples/movie_view_ratings/run_without_frameworks.py
@@ -119,7 +119,10 @@ def main(unused_argv):
 
     # Here's where the lazy iterator initiates computations and gets transformed
     # into actual results
+    import time
+    start = time.time()
     dp_result = list(dp_result)
+    print(f"Elapsed time = {time.time()-start}")
 
     # Save the results
     write_to_file(dp_result, FLAGS.output_file)

--- a/examples/movie_view_ratings/run_without_frameworks.py
+++ b/examples/movie_view_ratings/run_without_frameworks.py
@@ -119,10 +119,7 @@ def main(unused_argv):
 
     # Here's where the lazy iterator initiates computations and gets transformed
     # into actual results
-    import time
-    start = time.time()
     dp_result = list(dp_result)
-    print(f"Elapsed time = {time.time()-start}")
 
     # Save the results
     write_to_file(dp_result, FLAGS.output_file)

--- a/tests/pipeline_backend_test.py
+++ b/tests/pipeline_backend_test.py
@@ -21,6 +21,7 @@ import apache_beam.testing.test_pipeline as test_pipeline
 import apache_beam.testing.util as beam_util
 from absl.testing import parameterized
 
+import pipeline_dp
 import pipeline_dp.combiners as dp_combiners
 from pipeline_dp import DataExtractors
 from pipeline_dp.pipeline_backend import BeamBackend
@@ -742,6 +743,18 @@ class LocalBackendTest(unittest.TestCase):
         input = [3, 2, 1, 3, 5, 4, 1, 1, 2]
         output = set(self.backend.distinct(input, "distinct"))
         self.assertSetEqual({1, 2, 3, 4, 5}, output)
+
+    def test_output_reiterable_false(self):
+        backend = pipeline_dp.LocalBackend(output_reiterable=False)
+        output = backend.map([1, 2, 3], lambda x: x, "Map")
+        self.assertEqual(list(output), [1, 2, 3])
+        self.assertEqual(list(output), [])
+
+    def test_output_reiterable_true(self):
+        backend = pipeline_dp.LocalBackend(output_reiterable=True)
+        output = backend.map([1, 2, 3], lambda x: x, "Map")
+        self.assertEqual(list(output), [1, 2, 3])
+        self.assertEqual(list(output), [1, 2, 3])
 
 
 class SumCombiner(dp_combiners.Combiner):


### PR DESCRIPTION
Old behaviour:

```
  backend = pipeline_dp.LocalBackend(output_reiterable=False)
  output = backend.map([1, 2, 3], lambda x: x, "Map")
  print(list(output)) # , [1, 2, 3])
  print(list(output)) # [], only one iteration
```

New (default) behavior
```
  backend = pipeline_dp.LocalBackend(output_reiterable=False)
  output = backend.map([1, 2, 3], lambda x: x, "Map")
  print(list(output)) # , [1, 2, 3])
  print(list(output)) # [1,2,3] any number of iterations
```
