### PR TITLE
Fix serialization

### DIFF
--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -28,8 +28,8 @@ from pipeline_dp import sampling_utils
 from pipeline_dp.dataset_histograms import computing_histograms
 from pipeline_dp.private_contribution_bounds import PrivateL0Calculator
 
-AddDPNoiseOutput = collections.namedtuple("AddDPNoiseOutput",
-                                          ["noised_value", "noise_stddev"])
+DpNoiseAdditionResult = collections.namedtuple("DpNoiseAdditionResult",
+                                               ["noised_value", "noise_stddev"])
 
 
 class DPEngine:
@@ -593,7 +593,7 @@ class DPEngine:
             For more details see the docstring to report_generator.py.
         Returns:
             In case of params.output_noise_stddev it returns collection of
-            (partition_key, AddDPNoiseOutput) else
+            (partition_key, DpNoiseAdditionResult) else
             collection of (partition_key, value + noise).
             Output partition keys are the same as in the input collection.
         """
@@ -626,10 +626,10 @@ class DPEngine:
 
         if params.output_noise_stddev:
 
-            def add_noise(value: Union[int, float]) -> AddDPNoiseOutput:
+            def add_noise(value: Union[int, float]) -> DpNoiseAdditionResult:
                 mechanism = create_mechanism()
-                return AddDPNoiseOutput(mechanism.add_noise(value),
-                                        mechanism.std)
+                return DpNoiseAdditionResult(mechanism.add_noise(value),
+                                             mechanism.std)
         else:
 
             def add_noise(value: Union[int, float]) -> float:


### PR DESCRIPTION
This PR moves `AddDPNoiseOutput` out of the function to module level. That's needed to avoid deserialization issues, internal class can't be deserialize. Otherwise this PR is no-op