### PR TITLE
Types and other small linter errors

### DIFF
--- a/analysis/contribution_bounders.py
+++ b/analysis/contribution_bounders.py
@@ -14,6 +14,8 @@
 """ContributionBounder for utility analysis."""
 
 import numpy as np
+
+import pipeline_dp
 from pipeline_dp import contribution_bounders
 from pipeline_dp import sampling_utils
 from typing import Iterable, Tuple, Union

--- a/analysis/contribution_bounders.py
+++ b/analysis/contribution_bounders.py
@@ -35,11 +35,11 @@ class L0LinfAnalysisContributionBounder(
         super().__init__()
         self._sampling_probability = partitions_sampling_prob
 
-    def bound_contributions(self, col, params: 'pipeline_dp.AggregateParams',
-                            backend: 'pipeline_dp.PipelineBackend',
-                            report_generator:
-                            'pipeline_dp.report_generator.ReportGenerator',
-                            aggregate_fn):
+    def bound_contributions(
+            self, col, params: 'pipeline_dp.AggregateParams',
+            backend: 'pipeline_dp.PipelineBackend',
+            report_generator: 'pipeline_dp.report_generator.ReportGenerator',
+            aggregate_fn):
         """See docstrings for this class and the base class."""
 
         col = backend.map_tuple(
@@ -86,8 +86,8 @@ class L0LinfAnalysisContributionBounder(
         return backend.map_values(col, aggregate_fn, "Apply aggregate_fn")
 
 
-class LinfAnalysisContributionBounder(
-    contribution_bounders.ContributionBounder):
+class LinfAnalysisContributionBounder(contribution_bounders.ContributionBounder
+                                     ):
     """'Bounds' the contribution by privacy_id per partitions.
 
     Because this is for Utility Analysis, it doesn't actually ensure that

--- a/analysis/contribution_bounders.py
+++ b/analysis/contribution_bounders.py
@@ -23,19 +23,22 @@ class L0LinfAnalysisContributionBounder(
         contribution_bounders.ContributionBounder):
     """'Bounds' the contribution by privacy_id per and cross partitions.
 
-    Because this is for Utility Analysis, it doesn't actually ensure that
-    contribution bounds are enforced. Instead, it keeps track the information
+    Because this is for Utility Analysis, it doesn't ensure that
+    contribution bounds are enforced. Instead, it keeps track of the information
     needed for computing impact of contribution bounding.
 
     If partitions_sampling_prob < 1.0, partitions are subsampled. This sampling
-    is deterministic and depends on partition key.
+    is deterministic and depends on the partition key.
     """
 
     def __init__(self, partitions_sampling_prob: float):
         super().__init__()
         self._sampling_probability = partitions_sampling_prob
 
-    def bound_contributions(self, col, params, backend, report_generator,
+    def bound_contributions(self, col, params: 'pipeline_dp.AggregateParams',
+                            backend: 'pipeline_dp.PipelineBackend',
+                            report_generator:
+                            'pipeline_dp.report_generator.ReportGenerator',
                             aggregate_fn):
         """See docstrings for this class and the base class."""
 
@@ -83,16 +86,16 @@ class L0LinfAnalysisContributionBounder(
         return backend.map_values(col, aggregate_fn, "Apply aggregate_fn")
 
 
-class LinfAnalysisContributionBounder(contribution_bounders.ContributionBounder
-                                     ):
+class LinfAnalysisContributionBounder(
+    contribution_bounders.ContributionBounder):
     """'Bounds' the contribution by privacy_id per partitions.
 
     Because this is for Utility Analysis, it doesn't actually ensure that
-    contribution bounds are enforced. Instead, it keeps track the information
+    contribution bounds are enforced. Instead, it keeps track of the information
     needed for computing impact of contribution bounding.
 
     If partitions_sampling_prob < 1.0, partitions are subsampled. This sampling
-    is deterministic and depends on partition key.
+    is deterministic and depends on the partition key.
     """
 
     def __init__(self, partitions_sampling_prob: float):
@@ -154,10 +157,11 @@ def _sum_values(
     if not values:
         # Empty public partitions
         return 0
-    if len(values) == 1:
+    tolist = list(values)
+    if len(tolist) == 1:
         # No need to sum, return 0th value
-        return values[0]
-    if not isinstance(values[0], Iterable):
+        return tolist[0]
+    if not isinstance(tolist[0], Iterable):
         # 1 column
         return sum(values)
     # multiple value columns, sum each column independently

--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 """Utility Analysis cross partition combiners."""
 import copy
+import dataclasses
+import math
+from typing import List, Tuple, Callable
 
 import pipeline_dp
 from analysis import metrics
-import dataclasses
-from typing import List, Tuple, Callable
-import math
 
 
 def _sum_metrics_to_data_dropped(
@@ -51,7 +51,7 @@ def _create_contribution_bounding_errors(
         sum_metrics: metrics.SumMetrics) -> metrics.ContributionBoundingErrors:
     """Creates ContributionBoundingErrors from per-partition metrics."""
     l0_mean = sum_metrics.expected_l0_bounding_error
-    l0_var = sum_metrics.std_l0_bounding_error ** 2
+    l0_var = sum_metrics.std_l0_bounding_error**2
     l0_mean_var = metrics.MeanVariance(mean=l0_mean, var=l0_var)
     linf_min = sum_metrics.clipping_to_min_error
     linf_max = sum_metrics.clipping_to_max_error
@@ -69,7 +69,7 @@ def _sum_metrics_to_value_error(sum_metrics: metrics.SumMetrics,
     mean = bounding_errors.l0.mean + bounding_errors.linf_min + bounding_errors.linf_max
     variance = sum_metrics.std_l0_bounding_error**2 + sum_metrics.std_noise**2
 
-    rmse = math.sqrt(mean ** 2 + variance)
+    rmse = math.sqrt(mean**2 + variance)
     l1 = 0  # TODO(dvadym) compute it.
     rmse_with_dropped_partitions = keep_prob * rmse + (1 -
                                                        keep_prob) * abs(value)
@@ -170,8 +170,8 @@ def _add_dataclasses_by_fields(dataclass1, dataclass2,
         setattr(dataclass1, field.name, value1 + value2)
 
 
-def _multiply_float_dataclasses_field(dataclass, factor: float,
-                                      fields_to_ignore: List[str] = ()) -> None:
+def _multiply_float_dataclasses_field(
+    dataclass, factor: float, fields_to_ignore: List[str] = ()) -> None:
     """Recursively multiplies all float fields of the dataclass by the given
     number.
 

--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -22,8 +22,8 @@ from analysis import metrics
 
 
 def _sum_metrics_to_data_dropped(
-        sum_metrics: metrics.SumMetrics, partition_keep_probability: float,
-        dp_metric: pipeline_dp.Metric) -> metrics.DataDropInfo:
+        sum_metrics: metrics.SumMetrics,
+        partition_keep_probability: float) -> metrics.DataDropInfo:
     """Finds Data drop information from per-partition metrics."""
 
     # This function attributes the data that is dropped to the various

--- a/analysis/cross_partition_combiners.py
+++ b/analysis/cross_partition_combiners.py
@@ -26,8 +26,8 @@ def _sum_metrics_to_data_dropped(
         dp_metric: pipeline_dp.Metric) -> metrics.DataDropInfo:
     """Finds Data drop information from per-partition metrics."""
 
-    # This function attributed the data that is dropped, to different reasons
-    # how they are dropped.
+    # This function attributes the data that is dropped to the various
+    # reasons why they are dropped.
 
     # 1. linf/l0 contribution bounding
     # Contribution bounding errors are negative, negate to keep data dropped
@@ -35,7 +35,7 @@ def _sum_metrics_to_data_dropped(
     linf_dropped = sum_metrics.clipping_to_min_error - sum_metrics.clipping_to_max_error
     l0_dropped = -sum_metrics.expected_l0_bounding_error
 
-    # 2. Partition selection (in case of private partition selection).
+    # 2. Partition selection (in the case of private partition selection).
     # The data which survived contribution bounding is dropped with probability
     # = 1 - partition_keep_probability.
     expected_after_contribution_bounding = sum_metrics.sum - l0_dropped - linf_dropped
@@ -51,7 +51,7 @@ def _create_contribution_bounding_errors(
         sum_metrics: metrics.SumMetrics) -> metrics.ContributionBoundingErrors:
     """Creates ContributionBoundingErrors from per-partition metrics."""
     l0_mean = sum_metrics.expected_l0_bounding_error
-    l0_var = sum_metrics.std_l0_bounding_error**2
+    l0_var = sum_metrics.std_l0_bounding_error ** 2
     l0_mean_var = metrics.MeanVariance(mean=l0_mean, var=l0_var)
     linf_min = sum_metrics.clipping_to_min_error
     linf_max = sum_metrics.clipping_to_max_error
@@ -69,7 +69,7 @@ def _sum_metrics_to_value_error(sum_metrics: metrics.SumMetrics,
     mean = bounding_errors.l0.mean + bounding_errors.linf_min + bounding_errors.linf_max
     variance = sum_metrics.std_l0_bounding_error**2 + sum_metrics.std_noise**2
 
-    rmse = math.sqrt(mean**2 + variance)
+    rmse = math.sqrt(mean ** 2 + variance)
     l1 = 0  # TODO(dvadym) compute it.
     rmse_with_dropped_partitions = keep_prob * rmse + (1 -
                                                        keep_prob) * abs(value)
@@ -98,12 +98,11 @@ def _sum_metrics_to_metric_utility(
 
     Attributes:
         sum_metrics: per-partition utility metric.
-        dp_metric: metric for which utility is computed (e.g. COUNT)
+        dp_metric: metric for which utility is computed (e.g., COUNT)
         partition_keep_probability: partition selection probability.
     """
     data_dropped = _sum_metrics_to_data_dropped(sum_metrics,
-                                                partition_keep_probability,
-                                                dp_metric)
+                                                partition_keep_probability)
     absolute_error = _sum_metrics_to_value_error(sum_metrics,
                                                  partition_keep_probability,
                                                  partition_weight)
@@ -171,12 +170,12 @@ def _add_dataclasses_by_fields(dataclass1, dataclass2,
         setattr(dataclass1, field.name, value1 + value2)
 
 
-def _multiply_float_dataclasses_field(dataclass,
-                                      factor: float,
-                                      fields_to_ignore: List[str] = []) -> None:
-    """Recursively multiplies all float fields of the dataclass by given number.
+def _multiply_float_dataclasses_field(dataclass, factor: float,
+                                      fields_to_ignore: List[str] = ()) -> None:
+    """Recursively multiplies all float fields of the dataclass by the given
+    number.
 
-    Warning: it modifies 'dataclass' argument.
+    Warning: it modifies the 'dataclass' argument.
     """
     fields = dataclasses.fields(dataclass)
     for field in fields:
@@ -195,7 +194,7 @@ def _per_partition_to_utility_report(
         per_partition_utility: metrics.PerPartitionMetrics,
         dp_metrics: List[pipeline_dp.Metric], public_partitions: bool,
         partition_weight: float) -> metrics.UtilityReport:
-    """Converts per-partition metrics to cross-partition utility report."""
+    """Converts per-partition metrics to a cross-partition utility report."""
     # Fill partition selection metrics.
     if public_partitions:
         prob_to_keep = 1
@@ -227,7 +226,7 @@ def _merge_partition_metrics(metrics1: metrics.PartitionsInfo,
                              metrics2: metrics.PartitionsInfo) -> None:
     """Merges cross-partition utility metrics.
 
-    Warning: it modifies 'metrics1' argument.
+    Warning: it modifies the 'metrics1' argument.
     """
     _add_dataclasses_by_fields(metrics1, metrics2,
                                ["public_partitions", "strategy"])
@@ -237,7 +236,7 @@ def _merge_metric_utility(utility1: metrics.MetricUtility,
                           utility2: metrics.MetricUtility) -> None:
     """Merges cross-partition metric utilities.
 
-    Warning: it modifies 'utility1' argument.
+    Warning: it modifies the 'utility1' argument.
     """
     _add_dataclasses_by_fields(utility1, utility2,
                                ["metric", "noise_std", "noise_kind"])
@@ -247,7 +246,7 @@ def _merge_utility_reports(report1: metrics.UtilityReport,
                            report2: metrics.UtilityReport) -> None:
     """Merges cross-partition utility reports.
 
-    Warning: it modifies 'report1' argument.
+    Warning: it modifies the 'report1' argument.
     """
     _merge_partition_metrics(report1.partitions_info, report2.partitions_info)
     if report1.metric_errors is None:
@@ -276,21 +275,22 @@ def _average_utility_report(report: metrics.UtilityReport, sums_actual: Tuple,
 
 def partition_size_weight_fn(
         per_partition_metrics: metrics.PerPartitionMetrics) -> float:
-    """Weights partitions according to their size."""
+    """Weights the partitions according to their size."""
     # Only one metric is calculated as of now.
     return per_partition_metrics.metric_errors[0].sum
 
 
 def equal_weight_fn(
         per_partition_metrics: metrics.PerPartitionMetrics) -> float:
-    """Weights partitions according to their probability to be kept."""
+    """Weights the partitions according to their probability to be kept."""
     # For the public partitions weights will be 1, and we will do normal
     # averaging because total weight will equal to the total number of
     # partitions. The function assumes that
     # partition_selection_probability_to_keep for public partitions is 1 and all
-    # public partitions including empty are processed in CrossPartitionCombiner.
-    # For private partitions we will do weighted average and
-    # total weight will equal to mean number of kept partitions
+    # public partitions (including empty ones) are processed in
+    # CrossPartitionCombiner.
+    # For private partitions we will do the weighted average, and
+    # the total weight will equal the mean number of kept partitions
     # (`partitions.kept_partitions.mean`).
     return per_partition_metrics.partition_selection_probability_to_keep
 
@@ -298,11 +298,12 @@ def equal_weight_fn(
 class CrossPartitionCombiner(pipeline_dp.combiners.Combiner):
     """A combiner for aggregating error metrics across partitions"""
     # Accumulator is a tuple of
-    # 1. The sum of non dp metrics, which is used for averaging of error
+    # 1. The sum of non dp metrics, which are used for averaging of error
     # metrics.
     # 2. metrics.UtilityReport contains error metrics.
     # 3. Accumulated weight. Used to calculate total weight after accumulation.
-    # During creation of accumulator in `create_accumulator` the initial weight
+    # During creation of the accumulator in `create_accumulator` the initial
+    # weight
     # is applied to metric errors of a partition.
     AccumulatorType = Tuple[Tuple, metrics.UtilityReport, float]
 

--- a/analysis/data_structures.py
+++ b/analysis/data_structures.py
@@ -94,7 +94,7 @@ class MultiParameterConfiguration:
                                      " they must have the same length.")
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self._size
 
     def get_aggregate_params(

--- a/analysis/data_structures.py
+++ b/analysis/data_structures.py
@@ -51,7 +51,7 @@ class MultiParameterConfiguration:
                                  Sequence[Sequence[float]]] = None
     max_sum_per_partition: Union[Sequence[float],
                                  Sequence[Sequence[float]]] = None
-    noise_kind: list[pipeline_dp.NoiseKind] = None
+    noise_kind: List[pipeline_dp.NoiseKind] = None
     partition_selection_strategy: Sequence[
         pipeline_dp.PartitionSelectionStrategy] = None
 

--- a/analysis/data_structures.py
+++ b/analysis/data_structures.py
@@ -75,12 +75,12 @@ class MultiParameterConfiguration:
             # If elements of min_sum_per_partition and max_sum_per_partition are
             # sequences, all of them should have the same size.
             def all_elements_are_lists(
-                    a: list | Sequence[float] | Sequence[Sequence[float]]
-            ) -> bool:
+                a: Union[List, Sequence[float],
+                         Sequence[Sequence[float]]]) -> bool:
                 return all([isinstance(b, Sequence) for b in a])
 
             def common_value_len(
-                a: list | Sequence[float] | Sequence[Sequence[float]]
+                a: Union[List, Sequence[float], Sequence[Sequence[float]]]
             ) -> Optional[int]:
                 sizes = [len(v) for v in a]
                 return min(sizes) if min(sizes) == max(sizes) else None

--- a/analysis/dataset_summary.py
+++ b/analysis/dataset_summary.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """Contains dataset summary and the computation of the summary."""
 
-import pipeline_dp
 import dataclasses
 from typing import Iterable
+
+import pipeline_dp
 
 
 @dataclasses.dataclass

--- a/analysis/dataset_summary.py
+++ b/analysis/dataset_summary.py
@@ -39,7 +39,7 @@ def compute_public_partitions_summary(col, backend: pipeline_dp.PipelineBackend,
         col: the raw dataset. The collection where all elements are of the same
             type.
         backend: pipeline backend which corresponds to the type of 'col'.
-        extractors: functions that extract needed pieces of information
+        extractors: functions that extract the needed pieces of information
             from elements of 'col'.
         public_partitions: a collection of partition keys that will be present
           in the result. If not provided, partitions will be selected in a DP
@@ -72,8 +72,8 @@ def compute_public_partitions_summary(col, backend: pipeline_dp.PipelineBackend,
     # (partition, Iterable)
 
     def process_fn(_, a: Iterable[bool]) -> int:
-        # a contains up to 2 booleans.
-        # True means that the partition is dataset.
+        # 'a' contains up to 2 booleans.
+        # True means that the partition is a dataset.
         # False means that the partition is in public partitions.
         a = list(a)
         if len(a) == 2:
@@ -90,7 +90,7 @@ def compute_public_partitions_summary(col, backend: pipeline_dp.PipelineBackend,
 
     col = backend.to_list(col, "To list")
 
-    # 1 element with list of tuples (partition_type, count_partition_type)
+    # 1 element with a list of tuples (partition_type, count_partition_type)
 
     def to_summary(partition_types_count: list) -> PublicPartitionsSummary:
         num_dataset_public = num_dataset_non_public = num_empty_public = 0

--- a/analysis/dp_strategy_selector.py
+++ b/analysis/dp_strategy_selector.py
@@ -166,7 +166,8 @@ class DPStrategySelector:
         number is equal to the threshold for thresholding strategies.
  
         Args:
-            epsilon, delta: DP budget for partition selection
+            epsilon: DP budget for partition selection
+            delta: DP budget for partition selection
             l0_sensitivity: l0 sensitivity of the query, i.e., the maximum
               number of partitions, which 1 privacy unit can influence.
 
@@ -176,7 +177,7 @@ class DPStrategySelector:
 
         def create_mechanism(
             strategy: pipeline_dp.PartitionSelectionStrategy
-        ) -> (dp_computations.ThresholdingMechanism):
+        ) -> dp_computations.ThresholdingMechanism:
             return dp_computations.ThresholdingMechanism(epsilon,
                                                          delta,
                                                          strategy,

--- a/analysis/dp_strategy_selector.py
+++ b/analysis/dp_strategy_selector.py
@@ -164,7 +164,7 @@ class DPStrategySelector:
         strategies are compared by the number of privacy units, which is needed
         for achieving the probability of releasing partition to be 50%. That is
         number is equal to the threshold for thresholding strategies.
-
+ 
         Args:
             epsilon, delta: DP budget for partition selection
             l0_sensitivity: l0 sensitivity of the query, i.e., the maximum
@@ -175,8 +175,8 @@ class DPStrategySelector:
         """
 
         def create_mechanism(
-                strategy: pipeline_dp.PartitionSelectionStrategy) -> (
-                dp_computations.ThresholdingMechanism):
+            strategy: pipeline_dp.PartitionSelectionStrategy
+        ) -> (dp_computations.ThresholdingMechanism):
             return dp_computations.ThresholdingMechanism(epsilon,
                                                          delta,
                                                          strategy,
@@ -187,8 +187,8 @@ class DPStrategySelector:
             pipeline_dp.PartitionSelectionStrategy.LAPLACE_THRESHOLDING)
         gaussian_thresholding_mechanism = create_mechanism(
             pipeline_dp.PartitionSelectionStrategy.GAUSSIAN_THRESHOLDING)
-        if (laplace_thresholding_mechanism.threshold() <
-                gaussian_thresholding_mechanism.threshold()):
+        if (laplace_thresholding_mechanism.threshold()
+                < gaussian_thresholding_mechanism.threshold()):
             # Truncated geometric strategy is slightly better than Laplace
             # thresholding, so returns it instead.
             # Truncated geometric does not have a threshold, that is why

--- a/analysis/dp_strategy_selector.py
+++ b/analysis/dp_strategy_selector.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Choosing DP Strategy (i.e. noise_kind, partition selection strategy etc)
+"""Choosing DP Strategy (i.e., noise_kind, partition selection strategy, etc.)
 based on contribution bounding params."""
 from dataclasses import dataclass
 from typing import List, Optional
@@ -32,11 +32,11 @@ class DPStrategy:
 
 
 class DPStrategySelector:
-    """Chooses DPStrategy based on DP budget, computation sensitivites, etc
+    """Chooses DPStrategy based on DP budget, computation sensitivities, etc.
 
     It chooses noise_kind to minimize the noise std deviation.
-    For non-public partitions it chooses partition selection strategy to
-    minimize threshold. For more details see docstring to
+    For non-public partitions it chooses a partition selection strategy to
+    minimize the threshold. For more details see docstring to
     select_partition_selection_strategy().
     """
 
@@ -167,14 +167,16 @@ class DPStrategySelector:
 
         Args:
             epsilon, delta: DP budget for partition selection
-            l0_sensitivity: l0 sensitivity of the query, i.e. the maximum
+            l0_sensitivity: l0 sensitivity of the query, i.e., the maximum
               number of partitions, which 1 privacy unit can influence.
 
         Returns:
             the selected strategy.
         """
 
-        def create_mechanism(strategy: pipeline_dp.PartitionSelectionStrategy):
+        def create_mechanism(
+                strategy: pipeline_dp.PartitionSelectionStrategy) -> (
+                dp_computations.ThresholdingMechanism):
             return dp_computations.ThresholdingMechanism(epsilon,
                                                          delta,
                                                          strategy,
@@ -185,12 +187,11 @@ class DPStrategySelector:
             pipeline_dp.PartitionSelectionStrategy.LAPLACE_THRESHOLDING)
         gaussian_thresholding_mechanism = create_mechanism(
             pipeline_dp.PartitionSelectionStrategy.GAUSSIAN_THRESHOLDING)
-        if laplace_thresholding_mechanism.threshold(
-        ) < gaussian_thresholding_mechanism.threshold():
+        if (laplace_thresholding_mechanism.threshold() <
+                gaussian_thresholding_mechanism.threshold()):
             # Truncated geometric strategy is slightly better than Laplace
             # thresholding, so returns it instead.
-            # Truncated geometric does not have threshold, that is why
-            #
+            # Truncated geometric does not have a threshold, that is why
             return pipeline_dp.PartitionSelectionStrategy.TRUNCATED_GEOMETRIC
         return pipeline_dp.PartitionSelectionStrategy.GAUSSIAN_THRESHOLDING
 
@@ -198,5 +199,6 @@ class DPStrategySelector:
 class DPStrategySelectorFactory:
 
     def create(self, epsilon: float, delta: float,
-               metrics: List[pipeline_dp.Metric], is_public_partitions: bool):
+               metrics: List[pipeline_dp.Metric],
+               is_public_partitions: bool) -> DPStrategySelector:
         return DPStrategySelector(epsilon, delta, metrics, is_public_partitions)

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -30,10 +30,10 @@ class SumMetrics:
         aggregation: DP aggregation for which this analysis was performed. It
           can be COUNT, PRIVACY_ID_COUNT or SUM.
         sum: Non-DP sum of contributions to the aggregated metric being
-          analyzed. In case of SUM, this field stores the sum of all values
-          contributed by privacy IDs, in  case of COUNT, it is the count of
-          contributed values, and in case of PRIVACY_ID_COUNT, the field
-          contains count of privacy IDs that contribute to a partition.
+          analyzed. In the case of SUM, this field stores the sum of all values
+          contributed by privacy IDs, in the case of COUNT, it is the count of
+          contributed values, and in the case of PRIVACY_ID_COUNT, the field
+          contains the count of privacy IDs that contribute to a partition.
         clipping_to_min_error: the amount of error due to contribution min
           clipping.
         clipping_to_max_error: the amount of error due to contribution max
@@ -85,8 +85,9 @@ class ContributionBoundingErrors:
     Attributes:
         l0: max_partition_contributed (aka l0) bounding error. The output of l0
           bounding is a random variable for each partition. Its distribution is
-          close to normal when number of contribution per partition is large.
-        linf_min & linf_max: represents error due to min & max contribution
+          close to normal when the number of contributions per partition is
+          large.
+        linf_min & linf_max: represents error due to min and max contribution
           bounding, respectively (only populated for Sum metrics). It is
           deterministic for each partition.
     """
@@ -95,9 +96,10 @@ class ContributionBoundingErrors:
     linf_max: float
 
     def to_relative(self, value: float) -> 'ContributionBoundingErrors':
-        """Converts from the absolute to the relative error dividing by actual value."""
+        """Converts from the absolute to the relative error dividing by
+        actual value."""
         l0_rel_mean_var = MeanVariance(self.l0.mean / value,
-                                       self.l0.var / value**2)
+                                       self.l0.var / value ** 2)
         return ContributionBoundingErrors(l0=l0_rel_mean_var,
                                           linf_min=self.linf_min / value,
                                           linf_max=self.linf_max / value)
@@ -107,13 +109,14 @@ class ContributionBoundingErrors:
 class ValueErrors:
     """Errors between actual and dp metric.
 
-    This class describes breakdown of errors for (dp_value - actual_value),
-    where value can be a metric like count, sum etc. The value error is a random
-    variable and it comes from different sources - contribution bounding error
+    This class describes the breakdown of errors for (dp_value - actual_value),
+    where value can be a metric like count, sum, etc. The value error is a
+    random
+    variable, and it comes from different sources - contribution bounding error
     and DP noise. This class contains different error metrics.
 
     All attributes correspond to the errors computed per partition and then
-    averaged across partitions, e.g.
+    averaged across partitions, e.g.,
       rmse_per_partition = sqrt(E(dp_value - actual_value)^2)
       self.rmse = mean(rmse_per_partition)
 
@@ -137,12 +140,12 @@ class ValueErrors:
     # The following error metrics include error from dropped partitions for
     # private partition selection. For example:
     #    rmse = sqrt(E(actual_value-dp_output)^2) = f(actual_value-dp_output).
-    # For the partition with probability to keep = p.
+    # For the partition with the probability to keep = p.
     #    rmse_with_dropped_partitions = p*rmse + (1-p)*f(actual_value-0).
     rmse_with_dropped_partitions: float
     l1_with_dropped_partitions: float
 
-    def to_relative(self, value: float):
+    def to_relative(self, value: float) -> 'ValueErrors':
         """Converts from absolute to relative error dividing by actual_value."""
         if value == 0:
             # When the actual value is 0, the relative error can't be computed.
@@ -161,7 +164,7 @@ class ValueErrors:
         return ValueErrors(
             self.bounding_errors.to_relative(value),
             mean=self.mean / value,
-            variance=self.variance / value**2,
+            variance=self.variance / value ** 2,
             rmse=self.rmse / value,
             l1=self.l1 / value,
             rmse_with_dropped_partitions=self.rmse_with_dropped_partitions /
@@ -221,8 +224,8 @@ class PartitionsInfo:
     """Stores aggregate metrics about partitions and partition selection.
 
     Attributes:
-        public_partitions: true if public partitinos are used.
-        num_dataset_partitions: the number of partitions in dataset.
+        public_partitions: true if public partitions are used.
+        num_dataset_partitions: the number of partitions in the dataset.
         num_non_public_partitions: the number of partitions dropped because
           of public partitions.
         num_empty_partitions: the number of empty partitions added because of
@@ -252,9 +255,9 @@ class UtilityReport:
     Attributes:
         configuration_index: the index of the input parameter configuration for
           which this report was computed.
-        partitions_info: utility analysis of selected partition.
-        metric_errors: utility analysis of metrics (e.g. COUNT, SUM,
-          PRIVACY_ID_COUNT).
+        partitions_info: utility analysis of the selected partition.
+        metric_errors: utility analysis of metrics (e.g., COUNT, SUM,
+        PRIVACY_ID_COUNT).
         utility_report_histogram:
     """
     configuration_index: int

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -126,8 +126,10 @@ class ValueErrors:
         variance: averaged across partitions Var(dp_value - actual_value).
         rmse: averaged across partitions sqrt(E(dp_value - actual_value)^2).
         l1: averaged across partitions E|dp_value - actual_value|.
-        with_dropped_partitions: error which takes into consideration partitions
-          dropped due to partition selection. See example below.
+        rmse_with_dropped_partitions: error which takes into consideration
+        partitions dropped due to partition selection. See example below.
+        l1_with_dropped_partitions: error which takes into consideration
+        partitions dropped due to partition selection. See example below.
     """
     bounding_errors: ContributionBoundingErrors
     mean: float
@@ -186,7 +188,7 @@ class DataDropInfo:
 
     # This cannot be computed at PartitionSelectionUtility and needs to be
     # computed for each aggregation separately, since it takes into account data
-    # drop from contribution bounding and that is aggregation-specific.
+    # drops from contribution bounding and that is aggregation-specific.
     partition_selection: float
 
 
@@ -194,7 +196,7 @@ class DataDropInfo:
 class MetricUtility:
     """Stores aggregate cross-partition metrics for utility analysis.
 
-    It contains utility analysis for 1 DP metric (COUNT, SUM etc).
+    It contains utility analysis for 1 DP metric (COUNT, SUM, etc.).
 
     Attributes:
         metric: DP metric for which this analysis was performed.

--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Dataclasses with Utility Analysis result metrics."""
-from enum import Enum
 
-import pipeline_dp
 from dataclasses import dataclass
 from typing import List, Optional
-import math
+
+import pipeline_dp
 
 
 @dataclass
@@ -99,7 +98,7 @@ class ContributionBoundingErrors:
         """Converts from the absolute to the relative error dividing by
         actual value."""
         l0_rel_mean_var = MeanVariance(self.l0.mean / value,
-                                       self.l0.var / value ** 2)
+                                       self.l0.var / value**2)
         return ContributionBoundingErrors(l0=l0_rel_mean_var,
                                           linf_min=self.linf_min / value,
                                           linf_max=self.linf_max / value)
@@ -119,7 +118,7 @@ class ValueErrors:
     averaged across partitions, e.g.,
       rmse_per_partition = sqrt(E(dp_value - actual_value)^2)
       self.rmse = mean(rmse_per_partition)
-
+ 
     Attributes:
         bounding_errors: contribution bounding errors.
         mean: averaged across partitions E(dp_value - actual_value), aka
@@ -164,7 +163,7 @@ class ValueErrors:
         return ValueErrors(
             self.bounding_errors.to_relative(value),
             mean=self.mean / value,
-            variance=self.variance / value ** 2,
+            variance=self.variance / value**2,
             rmse=self.rmse / value,
             l1=self.l1 / value,
             rmse_with_dropped_partitions=self.rmse_with_dropped_partitions /

--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -58,7 +58,8 @@ class ParametersToTune:
 class TuneOptions:
     """Options for the tuning process.
 
-    Note that parameters that are not tuned (e.g. metrics, noise kind) are taken
+    Note that parameters that are not tuned (e.g., metrics, noise kind) are
+    taken
     from aggregate_params.
 
     Attributes:
@@ -104,7 +105,7 @@ class TuneResult:
         utility_analysis_parameters: contains tune parameter values for which
         utility analysis ran.
         index_best: index of the recommended according to minimizing function
-         (best) configuration in utility_analysis_parameters. Note, that those
+         (best) configuration in utility_analysis_parameters. Note that those
           parameters might not necessarily be optimal, since finding the optimal
           parameters is not always feasible.
         utility_reports: the results of all utility analysis runs that
@@ -122,14 +123,16 @@ def _find_candidate_parameters(
         parameters_to_tune: ParametersToTune,
         aggregate_params: pipeline_dp.AggregateParams,
         max_candidates: int) -> analysis.MultiParameterConfiguration:
-    """Finds candidates for l0, l_inf and max_sum_per_partition_bounds parameters.
+    """Finds candidates for l0, l_inf and max_sum_per_partition_bounds
+    parameters.
 
     Args:
         aggregate_params: parameters of aggregation.
         hist: dataset contribution histogram.
         parameters_to_tune: which parameters to tune.
         max_candidates: how many candidates ((l0, linf) pairs) can be in the
-          output. Note that output can contain fewer candidates. 100 is default
+          output. Note that output can contain fewer candidates. 100 is the
+          default
           heuristically chosen value, better to adjust it for your use-case.
     """
     # L0 bounds
@@ -221,7 +224,7 @@ def _find_candidate_parameters(
     )
 
 
-def _pad_list(a: Optional[List], size: int):
+def _pad_list(a: Optional[List], size: int) -> Optional[List]:
     if a is not None and len(a) < size:
         a.extend([a[0]] * (size - len(a)))
 
@@ -305,7 +308,8 @@ def _find_candidates_constant_relative_step(histogram: histograms.Histogram,
 
 def _find_candidates_bins_max_values_subsample(
         histogram: histograms.Histogram, max_candidates: int) -> List[float]:
-    """Takes max values of histogram bins with constant step between each other."""
+    """Takes max values of histogram bins with constant step between each
+    other."""
     # In order to ensure that max_sum_per_partition > 0, let us skip 0-th
     # bin if max = 0.
     # TODO(dvadym): better algorithm for finding candidates.
@@ -420,19 +424,21 @@ def _convert_utility_analysis_to_tune_result(
         tune_options: TuneOptions,
         run_configurations: analysis.MultiParameterConfiguration,
         use_public_partitions: bool,
-        contribution_histograms: histograms.DatasetHistograms):
+        contribution_histograms: histograms.DatasetHistograms) -> TuneResult:
     assert len(utility_reports) == run_configurations.size
     # TODO(dvadym): implement relative error.
     # TODO(dvadym): take into consideration partition selection from private
     # partition selection.
-    assert tune_options.function_to_minimize == MinimizingFunction.ABSOLUTE_ERROR
+    assert (tune_options.function_to_minimize ==
+            MinimizingFunction.ABSOLUTE_ERROR)
 
     # Sort utility reports by configuration index.
     sorted_utility_reports = sorted(utility_reports,
                                     key=lambda e: e.configuration_index)
 
     index_best = -1  # not found
-    # Find best index if there are metrics to compute. Absence of metrics to
+    # Find the best index if there are metrics to compute. The absence of
+    # metrics to
     # compute means that this is SelectPartition analysis.
     if tune_options.aggregate_params.metrics:
         rmse = [

--- a/analysis/parameter_tuning.py
+++ b/analysis/parameter_tuning.py
@@ -11,25 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
+import dataclasses
 import math
-from numbers import Number
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, List, Optional, Tuple, Union
 
-import pipeline_dp
-from pipeline_dp import dp_computations
-from pipeline_dp import pipeline_backend
-from pipeline_dp import input_validators
-from pipeline_dp.dataset_histograms import histograms
+import numpy as np
+
 import analysis
+import pipeline_dp
+from analysis import dp_strategy_selector
 from analysis import metrics
 from analysis import utility_analysis
-from analysis import dp_strategy_selector
-
-import dataclasses
-from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple, Union, Sequence
-from enum import Enum
-import numpy as np
+from pipeline_dp import dp_computations
+from pipeline_dp import input_validators
+from pipeline_dp import pipeline_backend
+from pipeline_dp.dataset_histograms import histograms
 
 
 class MinimizingFunction(Enum):
@@ -429,8 +427,8 @@ def _convert_utility_analysis_to_tune_result(
     # TODO(dvadym): implement relative error.
     # TODO(dvadym): take into consideration partition selection from private
     # partition selection.
-    assert (tune_options.function_to_minimize ==
-            MinimizingFunction.ABSOLUTE_ERROR)
+    assert (
+        tune_options.function_to_minimize == MinimizingFunction.ABSOLUTE_ERROR)
 
     # Sort utility reports by configuration index.
     sorted_utility_reports = sorted(utility_reports,

--- a/analysis/per_partition_combiners.py
+++ b/analysis/per_partition_combiners.py
@@ -248,8 +248,8 @@ class SumCombiner(UtilityAnalysisCombiner):
         self._i_column = i_column
 
     def create_accumulator(
-        self, data: Tuple[np.ndarray | None, np.ndarray,
-                          np.ndarray]) -> AccumulatorType:
+        self, data: Tuple[Optional[np.ndarray], np.ndarray, np.ndarray]
+    ) -> AccumulatorType:
         count, partition_sum, n_partitions = data
         if self._i_column is not None:
             # When i_column is set, it means that this is a multi-column

--- a/analysis/per_partition_combiners.py
+++ b/analysis/per_partition_combiners.py
@@ -180,9 +180,6 @@ def _merge_partition_selection_accumulators(
     probs1, moments1 = acc1
     probs2, moments2 = acc2
 
-    assert probs1 is not None
-    assert probs2 is not None
-
     if ((probs1 is not None) and (probs2 is not None) and
             len(probs1) + len(probs2) <= MAX_PROBABILITIES_IN_ACCUMULATOR):
         merged: List[float] = _merge_list(list(probs1), list(probs2))

--- a/analysis/per_partition_combiners.py
+++ b/analysis/per_partition_combiners.py
@@ -14,17 +14,17 @@
 """Utility Analysis per-partition Combiners."""
 
 import abc
-import copy
+import math
 from dataclasses import dataclass
 from typing import Any, Iterable, List, Optional, Sequence, Tuple, Union
+
 import numpy as np
-import math
 
 import pipeline_dp
-from pipeline_dp import budget_accounting
-from pipeline_dp import dp_computations
 from analysis import metrics
 from analysis import poisson_binomial
+from pipeline_dp import budget_accounting
+from pipeline_dp import dp_computations
 from pipeline_dp import partition_selection
 
 MAX_PROBABILITIES_IN_ACCUMULATOR = 100
@@ -157,8 +157,8 @@ class PartitionSelectionCalculator:
 # If len(probabilities) <= MAX_PROBABILITIES_IN_ACCUMULATOR then 'probabilities'
 # are used otherwise 'moments'. For more details see docstring to
 # PartitionSelectionCalculator.
-PartitionSelectionAccumulator = Tuple[
-    Optional[List[float]], Optional[SumOfRandomVariablesMoments]]
+PartitionSelectionAccumulator = Tuple[Optional[List[float]],
+                                      Optional[SumOfRandomVariablesMoments]]
 
 
 def _merge_list(a: List, b: List) -> List:
@@ -204,10 +204,9 @@ class PartitionSelectionCombiner(UtilityAnalysisCombiner):
         self._spec = spec
         self._params = params
 
-    def create_accumulator(self,
-                           sparse_acc: Tuple[
-                               np.ndarray, np.ndarray, np.ndarray]) -> (
-            PartitionSelectionAccumulator):
+    def create_accumulator(
+        self, sparse_acc: Tuple[np.ndarray, np.ndarray, np.ndarray]
+    ) -> (PartitionSelectionAccumulator):
         count, sum_, n_partitions = sparse_acc
         max_partitions = self._params.max_partitions_contributed
         prob_keep_partition = np.where(
@@ -251,8 +250,9 @@ class SumCombiner(UtilityAnalysisCombiner):
         self._metric = metric
         self._i_column = i_column
 
-    def create_accumulator(self, data: Tuple[
-        np.ndarray | None, np.ndarray, np.ndarray]) -> AccumulatorType:
+    def create_accumulator(
+        self, data: Tuple[np.ndarray | None, np.ndarray,
+                          np.ndarray]) -> AccumulatorType:
         count, partition_sum, n_partitions = data
         if self._i_column is not None:
             # When i_column is set, it means that this is a multi-column
@@ -317,8 +317,8 @@ class CountCombiner(SumCombiner):
         super().__init__(mechanism_spec, params, pipeline_dp.Metrics.COUNT)
 
     def create_accumulator(
-            self, sparse_acc: Tuple[np.ndarray, np.ndarray,
-            np.ndarray]) -> AccumulatorType:
+        self, sparse_acc: Tuple[np.ndarray, np.ndarray,
+                                np.ndarray]) -> AccumulatorType:
         count, _sum, n_partitions = sparse_acc
         data = None, count, n_partitions
         self._params.min_sum_per_partition = 0.0

--- a/analysis/poisson_binomial.py
+++ b/analysis/poisson_binomial.py
@@ -16,10 +16,11 @@
 More details on Poisson binomial distribution https://en.wikipedia.org/wiki/Poisson_binomial_distribution
 """
 
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
 import numpy as np
 from scipy.stats import norm
-from typing import Sequence, Tuple
-from dataclasses import dataclass
 
 
 @dataclass
@@ -36,7 +37,7 @@ class PMF:
     probabilities: np.ndarray
 
 
-def compute_pmf(probabilities: Sequence[float]) -> np.ndarray:
+def compute_pmf(probabilities: Sequence[float]) -> PMF:
     """Computes probability mass function of Poisson binomial distribution."""
     # Compute coefficients of Probability Generating Function (PGF), which
     # equals to

--- a/analysis/poisson_binomial.py
+++ b/analysis/poisson_binomial.py
@@ -55,7 +55,7 @@ def compute_exp_std_skewness(
     exp = np.sum(probabilities)
     std = np.sqrt(np.sum([p * (1 - p) for p in probabilities]))
     skewness = np.sum([p * (1 - p) * (1 - 2 * p) for p in probabilities
-                       ]) / std ** 3
+                      ]) / std**3
     return exp, std, skewness
 
 

--- a/analysis/poisson_binomial.py
+++ b/analysis/poisson_binomial.py
@@ -55,7 +55,7 @@ def compute_exp_std_skewness(
     exp = np.sum(probabilities)
     std = np.sqrt(np.sum([p * (1 - p) for p in probabilities]))
     skewness = np.sum([p * (1 - p) * (1 - 2 * p) for p in probabilities
-                      ]) / std**3
+                       ]) / std ** 3
     return exp, std, skewness
 
 

--- a/analysis/pre_aggregation.py
+++ b/analysis/pre_aggregation.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pipeline_dp
 import analysis.contribution_bounders as utility_contribution_bounders
+import pipeline_dp
 
 
 def preaggregate(col,

--- a/analysis/probability_computations.py
+++ b/analysis/probability_computations.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """Computations related to probabilistic distributions."""
 
-import numpy as np
 from typing import List, Sequence
+
+import numpy as np
 
 
 def compute_sum_laplace_gaussian_quantiles(laplace_b: float,

--- a/analysis/probability_computations.py
+++ b/analysis/probability_computations.py
@@ -33,4 +33,4 @@ def compute_sum_laplace_gaussian_quantiles(laplace_b: float,
     samples = np.random.laplace(
         scale=laplace_b, size=num_samples) + np.random.normal(
             loc=0, scale=gaussian_sigma, size=num_samples)
-    return np.quantile(samples, quantiles)
+    return list(np.quantile(samples, quantiles))

--- a/analysis/tests/cross_partition_combiners_test.py
+++ b/analysis/tests/cross_partition_combiners_test.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for cross-partition utility analysis combiners."""
-from absl.testing import absltest
-from absl.testing import parameterized
 import dataclasses
 import math
 from unittest import mock
 from unittest.mock import patch
 
-from analysis import metrics
-from analysis import cross_partition_combiners
+from absl.testing import absltest
+from absl.testing import parameterized
+
 import pipeline_dp
+from analysis import cross_partition_combiners
+from analysis import metrics
 
 
 def _get_default_sum_metrics(metric=pipeline_dp.Metrics.COUNT, sum=10.0):
@@ -180,9 +181,7 @@ class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
                                    std_noise=4.0,
                                    noise_kind=pipeline_dp.NoiseKind.LAPLACE)
         output = cross_partition_combiners._sum_metrics_to_data_dropped(
-            input,
-            partition_keep_probability=0.5,
-            dp_metric=pipeline_dp.Metrics.COUNT)
+            input, partition_keep_probability=0.5)
         self.assertEqual(
             output,
             metrics.DataDropInfo(l0=2.0, linf=5.0, partition_selection=1.5))
@@ -198,9 +197,7 @@ class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
                                    noise_kind=pipeline_dp.NoiseKind.LAPLACE)
 
         output = cross_partition_combiners._sum_metrics_to_data_dropped(
-            input,
-            partition_keep_probability=0.5,
-            dp_metric=pipeline_dp.Metrics.SUM)
+            input, partition_keep_probability=0.5)
 
         self.assertEqual(
             output,
@@ -209,9 +206,7 @@ class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
     def test_sum_metrics_to_data_dropped_public_partition(self):
         input = _get_default_sum_metrics(metric=pipeline_dp.Metrics.COUNT)
         output = cross_partition_combiners._sum_metrics_to_data_dropped(
-            input,
-            partition_keep_probability=1.0,
-            dp_metric=pipeline_dp.Metrics.COUNT)
+            input, partition_keep_probability=1.0)
         self.assertEqual(
             output,
             metrics.DataDropInfo(l0=2.0, linf=5.0, partition_selection=0.0))
@@ -226,9 +221,7 @@ class PerPartitionToCrossPartitionMetrics(parameterized.TestCase):
                                    std_noise=1.0,
                                    noise_kind=pipeline_dp.NoiseKind.LAPLACE)
         output = cross_partition_combiners._sum_metrics_to_data_dropped(
-            input,
-            partition_keep_probability=1.0,
-            dp_metric=pipeline_dp.Metrics.COUNT)
+            input, partition_keep_probability=1.0)
         self.assertEqual(
             output,
             metrics.DataDropInfo(l0=0.0, linf=0.0, partition_selection=0.0))

--- a/analysis/tests/per_partition_combiners_test.py
+++ b/analysis/tests/per_partition_combiners_test.py
@@ -566,8 +566,8 @@ class CompoundCombinerTest(parameterized.TestCase):
         sparse, dense = combiner.merge_accumulators(acc1, acc2)
         self.assertIsNone(sparse)
         self.assertEqual(
-            (3, ((15, 0, -10, -4.973333333333334, 0.04308888888888889),)),
-            dense)
+            [3,
+             ((15, 0, -10, -4.973333333333334, 0.04308888888888889),)], dense)
 
     def test_merge_dense(self):
         combiner = self._create_combiner()

--- a/analysis/utility_analysis.py
+++ b/analysis/utility_analysis.py
@@ -12,25 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Public API for performing utility analysis."""
+import bisect
+import copy
 from typing import Any, Iterable, List, Tuple, Union
 
-import pipeline_dp
-from pipeline_dp import pipeline_backend
 import analysis
+import pipeline_dp
+from analysis import cross_partition_combiners
 from analysis import data_structures
 from analysis import metrics
 from analysis import utility_analysis_engine
-from analysis import cross_partition_combiners
-import copy
-import bisect
+from pipeline_dp import pipeline_backend
 
 
 def _generate_bucket_bounds():
     result = [0, 1]
     for i in range(1, 13):
-        result.append(10 ** i)
-        result.append(2 * 10 ** i)
-        result.append(5 * 10 ** i)
+        result.append(10**i)
+        result.append(2 * 10**i)
+        result.append(5 * 10**i)
     return tuple(result)
 
 
@@ -198,7 +198,7 @@ def _get_upper_bound(n: int) -> int:
 
 
 def _unnest_metrics(
-        metrics: List[metrics.PerPartitionMetrics]
+    metrics: List[metrics.PerPartitionMetrics]
 ) -> Iterable[Tuple[Any, metrics.PerPartitionMetrics]]:
     """Unnests metrics from different configurations."""
     for i, metric in enumerate(metrics):

--- a/analysis/utility_analysis.py
+++ b/analysis/utility_analysis.py
@@ -14,7 +14,7 @@
 """Public API for performing utility analysis."""
 import bisect
 import copy
-from typing import Any, Iterable, List, Tuple, Union
+from typing import Any, Iterable, List, Tuple, Union, Optional
 
 import analysis
 import pipeline_dp
@@ -212,8 +212,8 @@ def _unnest_metrics(
 
 
 def _group_utility_reports(
-        configuration_index: int,
-        reports: List[metrics.UtilityReport]) -> metrics.UtilityReport | None:
+        configuration_index: int, reports: List[metrics.UtilityReport]
+) -> Optional[metrics.UtilityReport]:
     """Groups utility reports for one configuration.
 
     'reports' contains the global report, i.e., which corresponds to all

--- a/analysis/utility_analysis.py
+++ b/analysis/utility_analysis.py
@@ -28,9 +28,9 @@ import bisect
 def _generate_bucket_bounds():
     result = [0, 1]
     for i in range(1, 13):
-        result.append(10**i)
-        result.append(2 * 10**i)
-        result.append(5 * 10**i)
+        result.append(10 ** i)
+        result.append(2 * 10 ** i)
+        result.append(5 * 10 ** i)
     return tuple(result)
 
 
@@ -126,11 +126,12 @@ def perform_utility_analysis(
     result = backend.map_tuple(cross_partition_metrics, _group_utility_reports,
                                "Group utility reports")
     if public_partitions is None:
-        # Add partition selection strategy for private partitions.
+        # Add the partition selection strategy for private partitions.
         strategies = data_structures.get_partition_selection_strategy(options)
 
         def add_partition_selection_strategy(report: metrics.UtilityReport):
-            # Beam does not allow to change input arguments in map, so copy it.
+            # Beam does not allow changing input arguments in the map,
+            # so copy it.
             report = copy.deepcopy(report)
             strategy = strategies[report.configuration_index]
             report.partitions_info.strategy = strategy
@@ -147,17 +148,17 @@ def perform_utility_analysis(
 
 def _pack_per_partition_metrics(
         utility_result: List[Any],
-        n_configurations: int) -> Tuple[metrics.PerPartitionMetrics]:
+        n_configurations: int) -> List[metrics.PerPartitionMetrics]:
     """Packs per-partition metrics.
 
     Arguments:
         utility_result: a list with per-partition results, which contains
           results for all configurations.
-        n_configurations: the number of configuration of parameters for which
+        n_configurations: the number of configurations of parameters for which
           the utility analysis is computed.
 
-    Returns: a list of element (i_configuration, PerPartitionMetrics),
-    where each element corresponds to one of the configuration of the input
+    Returns: a list of elements (i_configuration, PerPartitionMetrics),
+    where each element corresponds to one of the configurations of the input
     parameters.
     """
     assert (len(utility_result) - 1) % n_configurations == 0
@@ -168,7 +169,7 @@ def _pack_per_partition_metrics(
     # Create 'result' with empty elements.
     empty_partition_metric = lambda: metrics.PerPartitionMetrics(
         1, raw_statistics, [])
-    result = tuple(empty_partition_metric() for _ in range(n_configurations))
+    result = list(empty_partition_metric() for _ in range(n_configurations))
 
     # Fill 'result' from 'utility_metrics'.
     for i, metric in enumerate(utility_result[1:]):
@@ -197,27 +198,28 @@ def _get_upper_bound(n: int) -> int:
 
 
 def _unnest_metrics(
-    metrics: List[metrics.PerPartitionMetrics]
+        metrics: List[metrics.PerPartitionMetrics]
 ) -> Iterable[Tuple[Any, metrics.PerPartitionMetrics]]:
     """Unnests metrics from different configurations."""
     for i, metric in enumerate(metrics):
-        yield ((i, None), metric)
-        # Choose bucket based on the number of privacy id count.
+        yield (i, None), metric
+        # Choose a bucket based on the number of privacy id count.
         partition_size = metrics[0].raw_statistics.privacy_id_count
         bucket = _get_lower_bound(partition_size)
 
         # Emits metrics for computing histogram by partition size.
-        yield ((i, bucket), metric)
+        yield (i, bucket), metric
 
 
 def _group_utility_reports(
         configuration_index: int,
-        reports: List[metrics.UtilityReport]) -> metrics.UtilityReport:
+        reports: List[metrics.UtilityReport]) -> metrics.UtilityReport | None:
     """Groups utility reports for one configuration.
 
-    'reports' contains the global report, i.e. which corresponds to all
-    partitions and reports that corresponds to partitions of some size range.
-    This function creates UtilityReport histogram from reports by size range and
+    'reports' contains the global report, i.e., which corresponds to all
+    partitions and reports that correspond to partitions of some size range.
+    This function creates a UtilityReport histogram from reports by size
+    range and
     sets it to the global report.
     """
     global_report = None
@@ -234,7 +236,7 @@ def _group_utility_reports(
         else:
             histogram_reports.append((lower_bucket_bound, report))
     if global_report is None:
-        # it should not happen, but it better to process gracefully in case
+        # it should not happen, but it is better to process gracefully in case
         # if it happens and return None.
         return None
 

--- a/analysis/utility_analysis_engine.py
+++ b/analysis/utility_analysis_engine.py
@@ -15,15 +15,15 @@
 import copy
 from typing import Optional, Union
 
+import analysis
+import analysis.contribution_bounders as utility_contribution_bounders
 import pipeline_dp
+from analysis import data_structures
+from analysis import per_partition_combiners
 from pipeline_dp import budget_accounting
 from pipeline_dp import combiners
 from pipeline_dp import contribution_bounders
 from pipeline_dp import pipeline_backend
-import analysis
-import analysis.contribution_bounders as utility_contribution_bounders
-from analysis import per_partition_combiners
-from analysis import data_structures
 
 
 class UtilityAnalysisEngine(pipeline_dp.DPEngine):

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -744,6 +744,7 @@ class AddDPNoiseParams:
     output_noise_stddev: bool = False
 
     def __post_init__(self):
+
         def check_is_positive(num: Any, name: str):
             if num is not None and num <= 0:
                 raise ValueError(f"{name} must be positive, but {num} given.")

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -31,7 +31,7 @@ class Metric:
 
     Attributes:
         name: the name of the metric, like 'COUNT', 'PERCENTILE'.
-        parameter: an optional parameter of the metric, e.g. for 90th
+        parameter: an optional parameter of the metric, e.g., for 90th
         percentile, parameter = 90.
     """
     name: str
@@ -81,6 +81,7 @@ class NoiseKind(Enum):
             return MechanismType.LAPLACE
         if self == NoiseKind.GAUSSIAN:
             return MechanismType.GAUSSIAN
+        return None
 
 
 class PartitionSelectionStrategy(Enum):
@@ -232,10 +233,10 @@ class AggregateParams:
         min_value: Lower bound on each value.
         max_value: Upper bound on each value.
         min_sum_per_partition: Lower bound on sum per partition. Used only for
-        SUM metric calculations. It can not be set when min_value/max_value is
+        SUM metric calculations. It cannot be set when min_value/max_value is
          set.
         max_sum_per_partition: Upper bound on sum per partition. Used only for
-        SUM metric calculations. It can not be set when min_value/max_value is
+        SUM metric calculations. It cannot be set when min_value/max_value is
          set.
         custom_combiners: Warning: experimental@ Combiners for computing custom
           metrics.
@@ -261,15 +262,17 @@ class AggregateParams:
          partition with at least pre_threshold privacy units isn't necessarily
          kept. It is ignored when public partitions are used.
          More details on pre-thresholding are in
-         https://github.com/google/differential-privacy/blob/main/common_docs/pre_thresholding.md
+         https://github.com/google/differential-privacy/blob/main/common_docs
+         /pre_thresholding.md
         perform_cross_partition_contribution_bounding: whether to perform cross
-         partition contribution bounding.  
-         Warning: turn off cross partition contribution bounding only when the 
+         partition contribution bounding.
+         Warning: turn off cross partition contribution bounding only when the
          number of contributed partitions per privacy unit is already bounded
          by max_partitions_contributed.
         output_noise_stddev: if True, the output will contain the applied noise
-         standard deviation, in form <lower_case_metric_name>_noise_stddev, e.g.
-         count_noise_stddev. Currently COUNT, PRIVACY_ID_COUNT, SUM are
+         standard deviation, in form <lower_case_metric_name>_noise_stddev,
+         e.g.,
+         count_noise_stddev. Currently, COUNT, PRIVACY_ID_COUNT, SUM are
          supported.
     """
     metrics: List[Metric]
@@ -282,7 +285,7 @@ class AggregateParams:
     max_value: Optional[float] = None
     min_sum_per_partition: Optional[float] = None
     max_sum_per_partition: Optional[float] = None
-    custom_combiners: Sequence['CustomCombiner'] = None
+    custom_combiners: Optional[Sequence['CustomCombiner']] = None
     vector_norm_kind: Optional[NormKind] = None
     vector_max_norm: Optional[float] = None
     vector_size: Optional[int] = None
@@ -741,8 +744,7 @@ class AddDPNoiseParams:
     output_noise_stddev: bool = False
 
     def __post_init__(self):
-
-        def check_is_positive(num: Any, name: str) -> bool:
+        def check_is_positive(num: Any, name: str):
             if num is not None and num <= 0:
                 raise ValueError(f"{name} must be positive, but {num} given.")
 
@@ -754,7 +756,7 @@ class AddDPNoiseParams:
 
 
 def _not_a_proper_number(num: Any) -> bool:
-    """Returns true if num is inf or NaN, false otherwise."""
+    """Returns true if 'num' is inf or NaN, false otherwise."""
     return math.isnan(num) or math.isinf(num)
 
 
@@ -764,7 +766,7 @@ def _check_is_positive_int(num: Any, field_name: str) -> None:
             f"{field_name} has to be positive integer, but {num} given.")
 
 
-def _count_not_none(*args):
+def _count_not_none(*args: Sequence[int]):
     return sum([1 for arg in args if arg is not None])
 
 

--- a/pipeline_dp/aggregate_params.py
+++ b/pipeline_dp/aggregate_params.py
@@ -342,8 +342,9 @@ class AggregateParams:
                         "AggregateParams: vector sum can not be computed "
                         "together with scalar metrics such as sum, mean etc")
             elif partition_bound:
-                all_allowed_metrics = set(
-                    [Metrics.SUM, Metrics.PRIVACY_ID_COUNT, Metrics.COUNT])
+                all_allowed_metrics = {
+                    Metrics.SUM, Metrics.PRIVACY_ID_COUNT, Metrics.COUNT
+                }
                 not_allowed_metrics = set(
                     self.metrics).difference(all_allowed_metrics)
                 if not_allowed_metrics:
@@ -352,8 +353,7 @@ class AggregateParams:
                         f"compatible with metrics {not_allowed_metrics}. Please"
                         f"use min_value/max_value.")
             elif not partition_bound and not value_bound:
-                all_allowed_metrics = set(
-                    [Metrics.PRIVACY_ID_COUNT, Metrics.COUNT])
+                all_allowed_metrics = {Metrics.PRIVACY_ID_COUNT, Metrics.COUNT}
                 not_allowed_metrics = set(
                     self.metrics).difference(all_allowed_metrics)
                 if not_allowed_metrics:

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -17,9 +17,9 @@ import abc
 import collections
 import logging
 import math
+from dataclasses import dataclass
 from typing import Optional
 
-from dataclasses import dataclass
 import pipeline_dp.aggregate_params as agg_params
 from pipeline_dp import input_validators
 
@@ -197,8 +197,8 @@ class BudgetAccountant(abc.ABC):
         """
         return BudgetAccountantScope(self, weight)
 
-    def _compute_budget_for_aggregation(self, weight: float) -> Optional[
-        Budget]:
+    def _compute_budget_for_aggregation(self,
+                                        weight: float) -> Optional[Budget]:
         """Computes budget per aggregation.
 
         It splits the budget using the naive composition.

--- a/pipeline_dp/budget_accounting.py
+++ b/pipeline_dp/budget_accounting.py
@@ -162,7 +162,7 @@ class BudgetAccountant(abc.ABC):
             )
         self._expected_num_aggregations = num_aggregations
         self._expected_aggregation_weights = aggregation_weights
-        self._reqested_aggregations = 0
+        self._requested_aggregations = 0
         self._actual_aggregation_weights = []
 
     @abc.abstractmethod
@@ -197,7 +197,8 @@ class BudgetAccountant(abc.ABC):
         """
         return BudgetAccountantScope(self, weight)
 
-    def _compute_budget_for_aggregation(self, weight: float) -> Budget:
+    def _compute_budget_for_aggregation(self, weight: float) -> Optional[
+        Budget]:
         """Computes budget per aggregation.
 
         It splits the budget using the naive composition.
@@ -323,9 +324,9 @@ class NaiveBudgetAccountant(BudgetAccountant):
             total_epsilon: epsilon for the entire pipeline.
             total_delta: delta for the entire pipeline.
             num_aggregations: number of DP aggregations in the pipeline for
-             which  'self' manages the budget. All aggregations should have
+             which 'self' manages the budget. All aggregations should have
              'budget_weight' = 1. When specified, all aggregations will have
-             equal budget. It is useful to ensure that the pipeline has fixed
+             equal budget. It is useful to ensure that the pipeline has a fixed
              number of DP aggregations.
             aggregation_weights: 'budget_weight' of aggregations for which
              'self' manages the budget. It is useful to ensure that the pipeline
@@ -336,7 +337,8 @@ class NaiveBudgetAccountant(BudgetAccountant):
 
         Raises:
             A ValueError if either argument is out of range.
-            A ValueError if num_aggregations and aggregation_weights are both set.
+            A ValueError if num_aggregations and aggregation_weights are both
+            set.
         """
         super().__init__(total_epsilon, total_delta, num_aggregations,
                          aggregation_weights)

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -482,7 +482,7 @@ class MeanCombiner(Combiner, MechanismContainerMixin):
     def __init__(self, count_spec: budget_accounting.MechanismSpec,
                  sum_spec: budget_accounting.MechanismSpec,
                  params: pipeline_dp.AggregateParams,
-                 metrics_to_compute: list[str]):
+                 metrics_to_compute: List[str]):
         if len(metrics_to_compute) != len(set(metrics_to_compute)):
             raise ValueError(f"{metrics_to_compute} cannot contain duplicates")
         for metric in metrics_to_compute:
@@ -502,7 +502,7 @@ class MeanCombiner(Combiner, MechanismContainerMixin):
         self._sum_sensitivities = dp_computations.compute_sensitivities_for_normalized_sum(
             params)
 
-    def create_accumulator(self, values: list[float]) -> AccumulatorType:
+    def create_accumulator(self, values: List[float]) -> AccumulatorType:
         middle = dp_computations.compute_middle(self._min_value,
                                                 self._max_value)
         normalized_values = np.clip(values, self._min_value,
@@ -562,7 +562,7 @@ class VarianceCombiner(Combiner):
     """
     AccumulatorType = Tuple[int, float, float]
 
-    def __init__(self, params: CombinerParams, metrics_to_compute: list[str]):
+    def __init__(self, params: CombinerParams, metrics_to_compute: List[str]):
         self._params = params
         if len(metrics_to_compute) != len(set(metrics_to_compute)):
             raise ValueError(f"{metrics_to_compute} cannot contain duplicates")
@@ -576,7 +576,7 @@ class VarianceCombiner(Combiner):
                 f"one of the {metrics_to_compute} should be 'variance'")
         self._metrics_to_compute = metrics_to_compute
 
-    def create_accumulator(self, values: list[float]) -> AccumulatorType:
+    def create_accumulator(self, values: List[float]) -> AccumulatorType:
         min_value = self._params.aggregate_params.min_value
         max_value = self._params.aggregate_params.max_value
         middle = dp_computations.compute_middle(min_value, max_value)
@@ -705,7 +705,7 @@ _named_tuple_cache = {}
 
 
 def _get_or_create_named_tuple(type_name: str,
-                               field_names: list[str]) -> 'MetricsTuple':
+                               field_names: List[str]) -> 'MetricsTuple':
     """Creates namedtuple type with a custom serializer."""
 
     # The custom serializer is required for supporting serialization of
@@ -721,7 +721,7 @@ def _get_or_create_named_tuple(type_name: str,
     return named_tuple
 
 
-def _create_named_tuple_instance(type_name: str, field_names: list[str],
+def _create_named_tuple_instance(type_name: str, field_names: List[str],
                                  values):
     return _get_or_create_named_tuple(type_name, field_names)(*values)
 
@@ -762,8 +762,9 @@ class CompoundCombiner(Combiner):
 
     def __init__(self, combiners: Iterable['Combiner'],
                  return_named_tuple: bool):
+
         self._combiners = list(combiners)
-        self._metrics_to_compute: list[str] = []
+        self._metrics_to_compute: List[str] = []
         self._return_named_tuple = return_named_tuple
         if not self._return_named_tuple:
             return

--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -313,8 +313,7 @@ class PrivacyIdCountCombiner(Combiner, AdditiveMechanismMixin):
                  params: pipeline_dp.AggregateParams):
         self._mechanism_spec = mechanism_spec
         self._sensitivities = (
-            dp_computations.compute_sensitivities_for_privacy_id_count(
-                params))
+            dp_computations.compute_sensitivities_for_privacy_id_count(params))
         self._output_noise_stddev = params.output_noise_stddev
 
     def create_accumulator(self, values: Sized) -> AccumulatorType:
@@ -563,8 +562,7 @@ class VarianceCombiner(Combiner):
     """
     AccumulatorType = Tuple[int, float, float]
 
-    def __init__(self, params: CombinerParams,
-                 metrics_to_compute: list[str]):
+    def __init__(self, params: CombinerParams, metrics_to_compute: list[str]):
         self._params = params
         if len(metrics_to_compute) != len(set(metrics_to_compute)):
             raise ValueError(f"{metrics_to_compute} cannot contain duplicates")
@@ -587,7 +585,7 @@ class VarianceCombiner(Combiner):
         normalized_values = clipped_values - middle
 
         return len(values), normalized_values.sum(), (
-                normalized_values ** 2).sum()
+            normalized_values**2).sum()
 
     def merge_accumulators(self, accum1: AccumulatorType,
                            accum2: AccumulatorType):

--- a/pipeline_dp/contribution_bounders.py
+++ b/pipeline_dp/contribution_bounders.py
@@ -32,9 +32,11 @@ class ContributionBounder(abc.ABC):
     """Interface for objects which perform contribution bounding."""
 
     @abc.abstractmethod
-    def bound_contributions(self, col, params: pipeline_dp.AggregateParams,
-                            backend: pipeline_backend.PipelineBackend,
-                            aggregate_fn: Callable):
+    def bound_contributions(
+            self, col, params: pipeline_dp.AggregateParams,
+            backend: pipeline_backend.PipelineBackend,
+            report_generator: pipeline_dp.report_generator.ReportGenerator,
+            aggregate_fn: Callable):
         """Bound contributions of privacy id.
 
         Contribution bounding is performed to ensure that sensitivity of the
@@ -51,6 +53,7 @@ class ContributionBounder(abc.ABC):
             partition_key, value).
           params: contains parameters needed for contribution bounding.
           backend: pipeline backend for performing operations on collections.
+          report_generator: to create a report from the computation
           aggregate_fn: function that takes a list of values and returns an
             aggregator object.
         Returns:

--- a/pipeline_dp/dataframes.py
+++ b/pipeline_dp/dataframes.py
@@ -90,7 +90,7 @@ class SparkConverter(DataFrameConvertor):
             partition_key = row[1] if num_partition_columns == 1 else row[
                 1:1 + num_partition_columns]
             value = row[1 + num_partition_columns] if value_present else 0
-            return (privacy_key, partition_key, value)
+            return privacy_key, partition_key, value
 
         return df.rdd.map(extractor)
 

--- a/pipeline_dp/dataframes.py
+++ b/pipeline_dp/dataframes.py
@@ -18,8 +18,9 @@ from collections import namedtuple
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
-import pipeline_dp
 import pyspark
+
+import pipeline_dp
 
 SparkDataFrame = pyspark.sql.dataframe.DataFrame
 

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -14,17 +14,18 @@
 """Differential privacy computing of count, sum, mean, variance."""
 
 import abc
-from dataclasses import dataclass
 import functools
 import math
-import numpy as np
-from scipy import stats
+from dataclasses import dataclass
 from typing import Any, List, Optional, Tuple, Union
+
+import numpy as np
+from pydp.algorithms import numerical_mechanisms as dp_mechanisms
+from scipy import stats
 
 import pipeline_dp
 from pipeline_dp import budget_accounting
 from pipeline_dp import partition_selection
-from pydp.algorithms import numerical_mechanisms as dp_mechanisms
 
 
 @dataclass
@@ -66,8 +67,8 @@ def compute_squares_interval(min_value: float,
                              max_value: float) -> Tuple[float, float]:
     """Returns the bounds of the interval [min_value^2, max_value^2]."""
     if min_value < 0 < max_value:
-        return 0, max(min_value ** 2, max_value ** 2)
-    return min_value ** 2, max_value ** 2
+        return 0, max(min_value**2, max_value**2)
+    return min_value**2, max_value**2
 
 
 def compute_middle(min_value: float, max_value: float) -> float:
@@ -387,7 +388,7 @@ def compute_dp_var(count: int, normalized_sum: float,
         sum_squares_eps, sum_squares_delta, l0_sensitivity,
         dp_params.max_contributions_per_partition, dp_params.noise_kind)
 
-    dp_var = dp_mean_squares - dp_mean ** 2
+    dp_var = dp_mean_squares - dp_mean**2
     if dp_params.min_value != dp_params.max_value:
         dp_mean += compute_middle(dp_params.min_value, dp_params.max_value)
 

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -614,7 +614,7 @@ class Sensitivities:
 
     def __post_init__(self):
 
-        def check_is_positive(num: Any, name: str) -> bool:
+        def check_is_positive(num: Any, name: str):
             if num is not None and num <= 0:
                 raise ValueError(f"{name} must be positive, but {num} given.")
 

--- a/pipeline_dp/dp_computations.py
+++ b/pipeline_dp/dp_computations.py
@@ -66,8 +66,8 @@ def compute_squares_interval(min_value: float,
                              max_value: float) -> Tuple[float, float]:
     """Returns the bounds of the interval [min_value^2, max_value^2]."""
     if min_value < 0 < max_value:
-        return 0, max(min_value**2, max_value**2)
-    return min_value**2, max_value**2
+        return 0, max(min_value ** 2, max_value ** 2)
+    return min_value ** 2, max_value ** 2
 
 
 def compute_middle(min_value: float, max_value: float) -> float:
@@ -387,7 +387,7 @@ def compute_dp_var(count: int, normalized_sum: float,
         sum_squares_eps, sum_squares_delta, l0_sensitivity,
         dp_params.max_contributions_per_partition, dp_params.noise_kind)
 
-    dp_var = dp_mean_squares - dp_mean**2
+    dp_var = dp_mean_squares - dp_mean ** 2
     if dp_params.min_value != dp_params.max_value:
         dp_mean += compute_middle(dp_params.min_value, dp_params.max_value)
 

--- a/pipeline_dp/partition_selection.py
+++ b/pipeline_dp/partition_selection.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pipeline_dp
-import pydp.algorithms.partition_selection as partition_selection
-from typing import Optional
 import math
+from typing import Optional
+
+import pydp.algorithms.partition_selection as partition_selection
+
+import pipeline_dp
 
 PARTITION_STRATEGY_ENUM_TO_STR = {
     pipeline_dp.PartitionSelectionStrategy.TRUNCATED_GEOMETRIC:

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -588,7 +588,7 @@ class ReiterableLazyIterable(Iterable):
             iterable: Iterable to make reiterable
         """
         self._iterable = iterable
-        self._cache: List = None
+        self._cache: Optional[List] = None
         self._first_run_complete = False
 
     def __iter__(self) -> Iterator:
@@ -706,8 +706,7 @@ class LocalBackend(PipelineBackend):
             d = collections.defaultdict(list)
             for key, value in col:
                 d[key].append(value)
-            for item in d.items():
-                yield item
+            yield from d.items()
 
         return ReiterableLazyIterable(group_by_key_generator())
 
@@ -796,8 +795,7 @@ class LocalBackend(PipelineBackend):
     def distinct(self, col, stage_name: str):
 
         def generator():
-            for v in set(col):
-                yield v
+            yield from set(col)
 
         return ReiterableLazyIterable(generator())
 

--- a/pipeline_dp/pipeline_backend.py
+++ b/pipeline_dp/pipeline_backend.py
@@ -13,19 +13,20 @@
 # limitations under the License.
 """Adapters for working with pipeline frameworks."""
 
+import abc
+import collections
 import functools
+import itertools
+import operator
 import random
-import numpy as np
+import typing
+import warnings
 from collections.abc import Iterable, Iterator
 from typing import Callable, List, Optional, Union
 
-import abc
+import numpy as np
+
 import pipeline_dp.combiners as dp_combiners
-import typing
-import collections
-import itertools
-import operator
-import warnings
 
 try:
     import apache_beam as beam

--- a/pipeline_dp/private_beam.py
+++ b/pipeline_dp/private_beam.py
@@ -14,11 +14,12 @@
 import abc
 import dataclasses
 import typing
-from apache_beam.transforms import ptransform
 from abc import abstractmethod
 from typing import Any, Callable, Optional
-from apache_beam import pvalue
+
 import apache_beam as beam
+from apache_beam import pvalue
+from apache_beam.transforms import ptransform
 
 import pipeline_dp
 from pipeline_dp import aggregate_params, budget_accounting

--- a/pipeline_dp/private_beam.py
+++ b/pipeline_dp/private_beam.py
@@ -33,7 +33,7 @@ _beam_backend = None
 
 def _get_beam_backend() -> pipeline_dp.BeamBackend:
     global _beam_backend
-    if _beam_backend == None:
+    if _beam_backend is None:
         _beam_backend = pipeline_dp.BeamBackend()
     return _beam_backend
 

--- a/pipeline_dp/private_contribution_bounds.py
+++ b/pipeline_dp/private_contribution_bounds.py
@@ -19,9 +19,8 @@ from typing import List
 
 import pipeline_dp
 from pipeline_dp import dp_computations
-
-from pipeline_dp.dataset_histograms.histograms import Histogram
 from pipeline_dp import pipeline_functions
+from pipeline_dp.dataset_histograms.histograms import Histogram
 
 
 class PrivateL0Calculator:

--- a/pipeline_dp/report_generator.py
+++ b/pipeline_dp/report_generator.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Explain DP computation reports.
 
-An Explain Computation report contains a human readable description of a DP
+An Explain Computation report contains a human-readable description of a DP
 aggregation performed by PipelineDP. It includes
-1. The input parameters (i.e. pipeline_dp.AggregateParams)
+1. The input parameters (i.e., pipeline_dp.AggregateParams)
 2. The main stages the computation graphs.
 
 Example of the report
@@ -56,7 +56,7 @@ class ReportGenerator:
                  method_name: str,
                  is_public_partition: Optional[bool] = None):
         """Initialize the ReportGenerator."""
-        self._params_str = None
+        self._params_str: Optional[str] = None
         if params:
             self._params_str = agg.parameters_to_readable_string(
                 params, is_public_partition)
@@ -70,7 +70,7 @@ class ReportGenerator:
             stage_description: description of the stage. Note that it might be
             a Callable that returns str. Support Callable is needed to support
             cases when the description contains information which is not yet
-            available during the pipeline construction, e.g. the budget.
+            available during the pipeline construction, e.g., the budget.
         """
         self._stages.append(stage_description)
 

--- a/pipeline_dp/report_generator.py
+++ b/pipeline_dp/report_generator.py
@@ -78,9 +78,10 @@ class ReportGenerator:
         """Constructs a report based on stages and metrics."""
         if not self._params_str:
             return ""
-        result = [f"DPEngine method: {self._method_name}"]
-        result.append(self._params_str)
-        result.append("Computation graph:")
+        result = [
+            f"DPEngine method: {self._method_name}", self._params_str,
+            "Computation graph:"
+        ]
         for i, stage_str in enumerate(self._stages):
             if hasattr(stage_str, "__call__"):
                 result.append(f" {i+1}. {stage_str()}")

--- a/pipeline_dp/sampling_utils.py
+++ b/pipeline_dp/sampling_utils.py
@@ -14,22 +14,23 @@
 
 import numpy as np
 import hashlib
+from typing import Any
 
 
 def choose_from_list_without_replacement(a: list, size: int) -> list:
     if len(a) <= size:
         return a
-    # np.random.choice makes casting of elements to numpy types
-    # which is undesirable by 2 reasons:
-    # 1. Apache Beam can not serialize numpy types.
-    # 2. It might lead for losing precision (e.g. arbitrary
-    # precision int is converted to int64).
+    # np.random.choice makes casting of elements to numpy types which is
+    # undesirable for 2 reasons:
+    # 1. Apache Beam cannot serialize numpy types.
+    # 2. It might lead to losing precision (e.g., arbitrary precision int is
+    # converted to int64).
     sampled_indices = np.random.choice(np.arange(len(a)), size, replace=False)
 
     return [a[i] for i in sampled_indices]
 
 
-def _compute_64bit_hash(v) -> int:
+def _compute_64bit_hash(v: Any) -> int:
     m = hashlib.sha1()
     m.update(repr(v).encode())
     return int(m.hexdigest()[:16], 16)
@@ -44,8 +45,8 @@ class ValueSampler:
     """
 
     def __init__(self, sampling_rate: float):
-        self._sample_bound = int(round(2**64 * sampling_rate))
+        self._sample_bound = int(round(2 ** 64 * sampling_rate))
 
-    def keep(self, value) -> bool:
+    def keep(self, value: Any) -> bool:
         """Returns true if the value should be kept."""
         return _compute_64bit_hash(value) < self._sample_bound

--- a/pipeline_dp/sampling_utils.py
+++ b/pipeline_dp/sampling_utils.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import hashlib
 from typing import Any
+
+import numpy as np
 
 
 def choose_from_list_without_replacement(a: list, size: int) -> list:
@@ -45,7 +46,7 @@ class ValueSampler:
     """
 
     def __init__(self, sampling_rate: float):
-        self._sample_bound = int(round(2 ** 64 * sampling_rate))
+        self._sample_bound = int(round(2**64 * sampling_rate))
 
     def keep(self, value: Any) -> bool:
         """Returns true if the value should be kept."""

--- a/pylintrc.dms
+++ b/pylintrc.dms
@@ -155,12 +155,6 @@ disable=abstract-method,
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]". This option is deprecated
-# and it will be removed in Pylint 2.0.
-files-output=no
-
 # Tells whether to display a full report or only the messages
 reports=no
 
@@ -283,7 +277,7 @@ single-line-if-stmt=yes
 # separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
 # `trailing-comma` allows a space between comma and closing bracket: (a, ).
 # `empty-line` allows space-only lines.
-no-space-check=
+disable=C0326
 
 # Maximum number of lines in a module
 max-module-lines=99999
@@ -436,6 +430,6 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=StandardError,
-                       Exception,
-                       BaseException
+overgeneral-exceptions=builtins.StandardError,
+                       builtins.Exception,
+                       builtins.BaseException


### PR DESCRIPTION
## Description

Spring-cleanup commit. Initially the goal was to add type annotations. On the way, I also went over small linter errors, including typos. The work is not finished, but this PR is already too big and messy, the follow-ups will be shorter and cleaner.

The goal is to eventually have all types annotated (generics will require python 3.12), and ~no linter error. 

This PR has zero functionality change.

## Affected Dependencies
- none

## How has this been tested?
- make test

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
