### PR TITLE
Export from Google internal repo

### DIFF
--- a/pipeline_dp/combiners.py
+++ b/pipeline_dp/combiners.py
@@ -634,7 +634,7 @@ class QuantileCombiner(Combiner):
     The accumulator is QuantileTree object serialized to string.
     """
 
-    AccumulatorType = bytes | list[float]
+    AccumulatorType = Union[bytes, List[float]]
 
     def __init__(self, params, percentiles_to_compute: List[float]):
         self._params = params

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -647,7 +647,11 @@ class DPEngine:
             def add_noise(value: Union[int, float]) -> float:
                 return create_mechanism().add_noise(value)
 
-        return self._backend.map_values(col, add_noise, "Add noise")
+        anonymized_col = self._backend.map_values(col, add_noise, "Add noise")
+
+        budget = self._budget_accountant._compute_budgets_for_aggregation(
+            params.budget_weight)
+        return self._annotate(anonymized_col, params=params, budget=budget)
 
     def _annotate(self, col,
                   params: Union[aggregate_params.AggregateParams,


### PR DESCRIPTION
It contains
1. DPEngine: import pipeline_dp.aggregate_params instead of pipeline_dp (we shouldn't rely internally on __init__ reimport to avoid circular import)
2. Workaround on serialization in combiners.py