### PR TITLE
Fix annotations: remove double annotations

### DIFF
--- a/examples/movie_view_ratings/run_on_beam.py
+++ b/examples/movie_view_ratings/run_on_beam.py
@@ -78,8 +78,7 @@ def main(unused_argv):
             pre_threshold=5)
 
         dp_result = private_movie_views | "Private Sum" >> private_beam.Sum(
-            params,
-            out_explain_computaton_report=explain_computation_report)
+            params, out_explain_computaton_report=explain_computation_report)
         budget_accountant.compute_budgets()
 
         # Generate the Explain Computation Report. It must be called after

--- a/examples/movie_view_ratings/run_without_frameworks_dp_parameter_tuning.py
+++ b/examples/movie_view_ratings/run_without_frameworks_dp_parameter_tuning.py
@@ -135,5 +135,3 @@ if __name__ == '__main__':
     flags.mark_flag_as_required("input_file")
     flags.mark_flag_as_required("output_file")
     app.run(main)
-
-

--- a/pipeline_dp/dp_engine.py
+++ b/pipeline_dp/dp_engine.py
@@ -647,11 +647,7 @@ class DPEngine:
             def add_noise(value: Union[int, float]) -> float:
                 return create_mechanism().add_noise(value)
 
-        anonymized_col = self._backend.map_values(col, add_noise, "Add noise")
-
-        budget = self._budget_accountant._compute_budgets_for_aggregation(
-            params.budget_weight)
-        return self._annotate(anonymized_col, params=params, budget=budget)
+        return self._backend.map_values(col, add_noise, "Add noise")
 
     def _annotate(self, col,
                   params: Union[aggregate_params.AggregateParams,


### PR DESCRIPTION
The annotations should be only in add_dp_noise, because of the manual merge from Github, it's added two times in add_dp_noise and _add_dp_noise